### PR TITLE
Extract pure gameplay economy calculations

### DIFF
--- a/src/js/enemy/currencyCollide.ts
+++ b/src/js/enemy/currencyCollide.ts
@@ -2,6 +2,7 @@ import { currencyMeshColor } from "./currencyMeshColor";
 
 import { economyGlobals } from "../main/globalVariables";
 import { damageCurrency } from "../main/sound";
+import { applyEnemyBankDamage } from "../gameplay/economy";
 import { EnemySphere } from "./enemyBorn";
 import { Vector3, Scene } from "babylonjs";
 import { fragment } from "./Enemy";
@@ -24,7 +25,10 @@ function currencyCollide(enemy: EnemySphere, scene: Scene, level: number) {
 				) {
 					// color
 					currencyMeshColor();
-					economyGlobals.currentBalance -= enemy.hitPoints / 2;
+					economyGlobals.currentBalance = applyEnemyBankDamage(
+						economyGlobals.currentBalance,
+						enemy.hitPoints
+					);
 
 					if (
 						enemy.physicsImpostor !== null

--- a/src/js/gameplay/economy.ts
+++ b/src/js/gameplay/economy.ts
@@ -1,0 +1,37 @@
+function projectileEnergyRecovery(
+	projectileHitPoints: number,
+	energyRecoveryRatio: number
+): number {
+	return projectileHitPoints * energyRecoveryRatio;
+}
+
+function applyProjectileEnergyRecovery(
+	currentBalance: number,
+	projectileHitPoints: number,
+	energyRecoveryRatio: number,
+	maxBalance: number
+): number {
+	const recoveredBalance =
+		currentBalance +
+		projectileEnergyRecovery(projectileHitPoints, energyRecoveryRatio);
+
+	return recoveredBalance > maxBalance ? maxBalance : recoveredBalance;
+}
+
+function enemyBankDamage(enemyHitPoints: number): number {
+	return enemyHitPoints / 2;
+}
+
+function applyEnemyBankDamage(
+	currentBalance: number,
+	enemyHitPoints: number
+): number {
+	return currentBalance - enemyBankDamage(enemyHitPoints);
+}
+
+export {
+	projectileEnergyRecovery,
+	applyProjectileEnergyRecovery,
+	enemyBankDamage,
+	applyEnemyBankDamage
+};

--- a/src/js/projectile/hitEffect.ts
+++ b/src/js/projectile/hitEffect.ts
@@ -1,6 +1,7 @@
 import { economyGlobals, materialGlobals } from "../main/globalVariables";
 import { damage } from "../main/sound";
 import { EnemySphere } from "../enemy/enemyBorn";
+import { applyProjectileEnergyRecovery } from "../gameplay/economy";
 import { LiveProjectileInstance } from "./startLife";
 
 export function hitEffect(
@@ -28,12 +29,12 @@ export function hitEffect(
 				) {
 					// hitpoints
 					enemy.hitPoints -= projectile.hitPoints;
-					economyGlobals.currentBalance +=
-						projectile.hitPoints * economyGlobals.energyRecoveryRatio;
-
-					if (economyGlobals.currentBalance > economyGlobals.maxBalance) {
-						economyGlobals.currentBalance = economyGlobals.maxBalance;
-					}
+					economyGlobals.currentBalance = applyProjectileEnergyRecovery(
+						economyGlobals.currentBalance,
+						projectile.hitPoints,
+						economyGlobals.energyRecoveryRatio,
+						economyGlobals.maxBalance
+					);
 				}
 				if (enemy.material === materialGlobals.hitMaterial) {
 					// color


### PR DESCRIPTION
## Scope

Linked issues: #30, #32

Ownership boundary: projectile-hit energy recovery and central-bank collision damage calculations only.

## Change

- add `src/js/gameplay/economy.ts`, a Babylon/Cannon-free module for the two core energy formulas;
- route projectile-hit recovery through the pure calculation while preserving the existing `projectileHitPoints * energyRecoveryRatio` behavior and max-balance cap;
- route central-bank collision damage through the pure calculation while preserving `enemyHitPoints / 2` and intentionally allowing the balance to cross below zero for the existing defeat path.

This is the first deterministic seam for the #30 characterization effort. It does not change collision registration, enemy lifecycle, projectile physics, tower behavior, wave timing, rendering, or sound.

## Gameplay impact

- [x] No intended gameplay/balance change
- [ ] Intended gameplay change is documented in the linked issue

Preserved #29 invariants:

- offense still sustains defense at exactly the existing recovery ratio;
- remaining enemy threat/HP still determines damage to the defended energy bank;
- physics collisions remain authoritative for deciding when either transition occurs.

## Validation

Performed online:

- branch is based on current `master` after #34;
- reviewed a 3-file diff: 37-line pure module plus two narrow call-site substitutions;
- formulas and cap/negative-balance semantics were compared directly with the legacy expressions.

Not validated online / requires local Codex:

- [x] build/install
- [x] browser interaction
- [x] physics behavior
- [ ] performance/profile
- [ ] touch/input
- [ ] audio
- [ ] PWA/offline
- [ ] other

Local certification should confirm that a projectile collision changes enemy HP and energy exactly as before, a bank collision damages energy based on remaining HP, and the historical project still compiles with the new module/imports.

## Concurrency

No overlap intended with toolchain work in #31 or presentation work in #33. Simulation refactors under #32 may build on this pure module rather than duplicating the formulas.

This PR is intentionally a draft until the local Codex executor posts build/runtime certification.