### PR TITLE
Fix tower occlusion helper return value

### DIFF
--- a/src/js/tower/Tower.ts
+++ b/src/js/tower/Tower.ts
@@ -64,7 +64,7 @@ function shotClearsTower(scene: Scene, ray: Ray, intendedEnemy: Mesh) {
 	) {
 		result = true as boolean;
 	}
-	return true as boolean;
+	return result;
 }
 
 function rotateTurret(


### PR DESCRIPTION
Refs #32

## Ownership boundary

This PR touches only `shotClearsTower()` in `src/js/tower/Tower.ts`.

## Change

Return the raycast-derived `result` instead of unconditional `true`.

The helper already computes whether the ray actually reaches the intended enemy without treating the target as an obstacle, but then discards that calculation. The only known call site remains commented out in `trackSpheres.ts`, so this PR does **not** enable occlusion checks or change current firing behavior.

## Why now

#32 explicitly identifies this as a suspicious simulation seam. Correcting the dormant helper makes its contract internally coherent before any executor re-enables or tests line-of-fire behavior.

## Gameplay impact

- [x] No current gameplay/balance change: the call site is disabled.
- [x] No rendering, physics registration, economy, tower timing, or dependency changes.

## Validation

Online verification:

- branch starts from current `master` (`9aa36551d5cb7b0af125fe970a384815bc88094a`);
- compare is exactly one line added / one line removed in one file;
- repository search confirms the only call site is currently commented out.

Local Codex should still run the normal TypeScript/build gate when convenient and report any pre-existing historical-toolchain failures. No browser behavior certification is required for merge because the helper is dormant.

## Concurrency

Independent from #35 (tooling) and #36 (economy seam). Future work that re-enables `shotClearsTower()` should be a separate PR with browser/physics certification.