### PR TITLE
Use explicit metadata for tower upgrade levels

### DIFF
--- a/src/js/tower/Tower.ts
+++ b/src/js/tower/Tower.ts
@@ -13,6 +13,10 @@ import { towerGlobals, projectileGlobals } from "../main/globalVariables";
 import { Position2D } from "../enemy/Enemy";
 import { EnemySphere } from "../enemy/enemyBorn";
 
+interface TowerMetadata {
+	level: number;
+}
+
 class Tower {
 	constructor(
 		level: number = 1 | 2 | 3,
@@ -25,6 +29,7 @@ class Tower {
 		let tower = towerGlobals.towerBaseMesh.clone(
 			name, undefined, true, false
 		) as Mesh;
+		tower.metadata = { level } as TowerMetadata;
 
 		tower.physicsImpostor = new PhysicsImpostor(
 			tower,
@@ -39,6 +44,10 @@ class Tower {
 		addTower(tower, level);
 		towerGlobals.allPositions = towerBasePositions(scene);
 	}
+}
+
+function towerLevel(tower: Mesh): number {
+	return (tower.metadata as TowerMetadata).level;
 }
 
 function towerBasePositions(scene: Scene) {
@@ -146,6 +155,7 @@ export {
 	Tower,
 	destroyTower,
 	towerBasePositions,
+	towerLevel,
 	shotClearsTower,
 	rotateTurret
 };

--- a/src/js/tower/upgradeTower.ts
+++ b/src/js/tower/upgradeTower.ts
@@ -11,7 +11,7 @@ import {
 	towerGlobals,
 	economyGlobals,
 } from "../main/globalVariables";
-import { towerBasePositions, Tower } from "./Tower";
+import { towerBasePositions, towerLevel, Tower } from "./Tower";
 import { removeTower } from "../main/sound";
 import { currencyMeshColor } from "../enemy/currencyMeshColor";
 import { createBaseInstance } from "./indicatorInstance";
@@ -19,17 +19,14 @@ import { createBaseInstance } from "./indicatorInstance";
 function upgradeTower(scene: Scene, physicsEngine: PhysicsEngine) {
 	//When pointer tap event is raised
 	scene.onPointerObservable.add(function (evt: PointerInfo) {
-		let currentLevel = 0;
 		const pickResult = evt.pickInfo as PickingInfo;
-		if (pickResult.pickedMesh !== null) {
-			currentLevel = parseInt(pickResult.pickedMesh.name[10]);
-		}
 		if (
 			pickResult.hit &&
 			pickResult.pickedMesh !== null &&
 			Tags.MatchesQuery(pickResult.pickedMesh, "towerBase") &&
 			pickResult.pickedMesh.name !== "ground"
 		) {
+			const currentLevel = towerLevel(pickResult.pickedMesh);
 			const samePosition = {
 				x: pickResult.pickedMesh.position.x,
 				z: pickResult.pickedMesh.position.z


### PR DESCRIPTION
Refs #32, #30

## Ownership boundary

Tower-level identity used by the pointer upgrade path only.

## Change

- attach explicit `{ level }` metadata to each tower base mesh at construction;
- expose a small `towerLevel()` accessor;
- read the level only after the pointer target has been verified as a `towerBase`;
- remove the brittle `parseInt(pickedMesh.name[10])` dependency.

Tower names are intentionally left unchanged for diagnostics/backward familiarity. Upgrade costs and the existing level 1→2, 2→3, and current level-3 behavior are not changed in this PR.

## Why

#32 calls out mesh-name character parsing as hidden gameplay state. Tower level is simulation data and should be explicit rather than encoded in a presentation/debug string. This is a narrow prerequisite for later lifecycle and upgrade remediation.

## Gameplay impact

- [x] No intended balance change.
- [x] Existing upgrade branching and economy expressions are preserved.
- [x] No physics, rendering, audio, wave, or dependency changes.

## Online verification

- based on `master` after #40 (`38ff29a560f7453efb8e00b4790a1dbfc32e03a9`);
- two files changed: `Tower.ts` and `upgradeTower.ts`;
- 12 additions / 5 deletions;
- metadata is assigned before the mesh receives the `towerBase` tag;
- the accessor is invoked only after the tag/pick checks, so arbitrary picked meshes no longer have their names parsed.

## Local Codex certification

Please certify this head before merge:

1. TypeScript/build succeeds or report the exact historical-toolchain blocker.
2. Place a level-1 tower and upgrade 1→2 and 2→3; confirm the same costs are charged exactly once.
3. Verify level metadata survives the live Babylon mesh lifecycle through placement and each reconstruction.
4. Record the current behavior of tapping/upgrading an already-level-3 tower without changing it here; #32 tracks whether that behavior is a defect.
5. Confirm non-tower pointer taps remain harmless.

Post commands, exit codes, and observed results to this PR. Do not broaden this PR into the level-3 behavior fix.

## Concurrency

Independent from #35 tooling and #36 economy work. Any intentional change to upgrade caps/level-3 behavior should be a separate PR after baseline evidence.