### PR TITLE
refactor: stop parsing tower level from mesh names

### DIFF
--- a/src/js/tower/Tower.ts
+++ b/src/js/tower/Tower.ts
@@ -13,6 +13,29 @@ import { towerGlobals, projectileGlobals } from "../main/globalVariables";
 import { Position2D } from "../enemy/Enemy";
 import { EnemySphere } from "../enemy/enemyBorn";
 
+interface TowerMetadata {
+	level: number;
+	index: number;
+}
+
+function setTowerMetadata(tower: Mesh, level: number, index: number): void {
+	const metadata = tower.metadata || {};
+	metadata.defendTower = { level, index } as TowerMetadata;
+	tower.metadata = metadata;
+}
+
+function towerLevel(tower: Mesh): number {
+	const metadata = tower.metadata;
+	if (
+		metadata &&
+		metadata.defendTower &&
+		typeof metadata.defendTower.level === "number"
+	) {
+		return metadata.defendTower.level;
+	}
+	return 0;
+}
+
 class Tower {
 	constructor(
 		level: number = 1 | 2 | 3,
@@ -20,11 +43,14 @@ class Tower {
 		scene: Scene,
 		physicsEngine: PhysicsEngine
 	) {
-		const name = `towerLevel${level}Index${towerGlobals.index}` as string;
+		const towerIndex = towerGlobals.index;
+		const name = `towerLevel${level}Index${towerIndex}` as string;
 		towerGlobals.index += 1;
 		let tower = towerGlobals.towerBaseMesh.clone(
 			name, undefined, true, false
 		) as Mesh;
+
+		setTowerMetadata(tower, level, towerIndex);
 
 		tower.physicsImpostor = new PhysicsImpostor(
 			tower,
@@ -146,6 +172,7 @@ export {
 	Tower,
 	destroyTower,
 	towerBasePositions,
+	towerLevel,
 	shotClearsTower,
 	rotateTurret
 };

--- a/src/js/tower/upgradeTower.ts
+++ b/src/js/tower/upgradeTower.ts
@@ -11,7 +11,7 @@ import {
 	towerGlobals,
 	economyGlobals,
 } from "../main/globalVariables";
-import { towerBasePositions, Tower } from "./Tower";
+import { towerBasePositions, Tower, towerLevel } from "./Tower";
 import { removeTower } from "../main/sound";
 import { currencyMeshColor } from "../enemy/currencyMeshColor";
 import { createBaseInstance } from "./indicatorInstance";
@@ -22,13 +22,14 @@ function upgradeTower(scene: Scene, physicsEngine: PhysicsEngine) {
 		let currentLevel = 0;
 		const pickResult = evt.pickInfo as PickingInfo;
 		if (pickResult.pickedMesh !== null) {
-			currentLevel = parseInt(pickResult.pickedMesh.name[10]);
+			currentLevel = towerLevel(pickResult.pickedMesh);
 		}
 		if (
 			pickResult.hit &&
 			pickResult.pickedMesh !== null &&
 			Tags.MatchesQuery(pickResult.pickedMesh, "towerBase") &&
-			pickResult.pickedMesh.name !== "ground"
+			pickResult.pickedMesh.name !== "ground" &&
+			currentLevel > 0
 		) {
 			const samePosition = {
 				x: pickResult.pickedMesh.position.x,


### PR DESCRIPTION
Refs #32
Related #30
Supersedes #41 after concurrent `master` changes touched `Tower.ts`.

## Ownership boundary

This PR changes only tower identity metadata and the upgrade handler's level lookup. It does not alter tower costs, upgrade tier transitions, lifetimes, firing behavior, physics, or the known level-3 refresh semantics.

## Changes

- attach explicit `defendTower` metadata (`level`, `index`) to each tower base when it is constructed;
- expose a small `towerLevel()` accessor;
- make upgrade handling read the explicit level instead of `pickedMesh.name[10]`;
- refuse the upgrade path when a tagged tower base lacks valid level metadata rather than disposing an object based on malformed name parsing.

## Concurrency handling

The first branch was created just before #40 landed in `Tower.ts`. Rather than force-rebase or risk reverting another executor's fix, this replacement branch was recreated from current `master` and the metadata change was reapplied narrowly. Current comparison is clean: two commits ahead, zero behind.

## Validation

Online review confirms the change is limited to `Tower.ts` and `upgradeTower.ts`; the existing level switch, affordability logic, and the merged `shotClearsTower()` fix are preserved.

Local Codex validation requested:

- [ ] historical TypeScript/BabylonJS stack compiles the `Mesh.metadata` access;
- [ ] placing L1/L2/L3 towers attaches correct metadata;
- [ ] tapping L1 upgrades to L2 with the same charge as baseline;
- [ ] tapping L2 upgrades to L3 with the same charge as baseline;
- [ ] existing level-3 behavior remains unchanged for this PR;
- [ ] degradation/reconstruction produces new tower bases with correct metadata;
- [ ] no change to tower placement, collision, targeting, or occlusion-helper behavior.

Do not fold affordability-boundary or level-3 gameplay decisions into this PR; those remain separate after #30 evidence.