### PR TITLE
Extract projectile and turret tier scaling rules

### DIFF
--- a/src/js/gameplay/tierScaling.ts
+++ b/src/js/gameplay/tierScaling.ts
@@ -1,0 +1,34 @@
+// Pure tier-scaling rules extracted from the legacy Babylon/Cannon call sites.
+// Keep these calculations engine-independent so modernization can certify balance
+// without coupling tests to rendering or physics APIs.
+
+function levelSquared(level: number): number {
+	return level * level;
+}
+
+function levelCubed(level: number): number {
+	return level * level * level;
+}
+
+function projectileHitPoints(baseHitPoints: number, level: number): number {
+	return baseHitPoints * levelCubed(level);
+}
+
+function projectileImpulse(baseSpeed: number, level: number): number {
+	return baseSpeed * levelCubed(level);
+}
+
+function projectileMass(baseMass: number, level: number): number {
+	return baseMass * levelSquared(level);
+}
+
+function towerShotInterval(baseRateOfFire: number, level: number): number {
+	return baseRateOfFire * levelCubed(level);
+}
+
+export {
+	projectileHitPoints,
+	projectileImpulse,
+	projectileMass,
+	towerShotInterval
+};

--- a/src/js/projectile/Projectile.ts
+++ b/src/js/projectile/Projectile.ts
@@ -4,6 +4,10 @@ import { Scene, Vector3, PhysicsEngine } from "babylonjs";
 import { projectileGlobals } from "../main/globalVariables";
 import { EnemySphere } from "../enemy/enemyBorn";
 import { TowerTurret } from "../tower/towerBorn";
+import {
+	projectileHitPoints,
+	projectileImpulse
+} from "../gameplay/tierScaling";
 
 class Projectile {
 	constructor(
@@ -34,7 +38,10 @@ class Projectile {
 		}
 		if (projectile !== undefined) {
 
-			projectile.hitPoints = level * level * level * projectileGlobals.baseHitPoints;
+			projectile.hitPoints = projectileHitPoints(
+				projectileGlobals.baseHitPoints,
+				level
+			);
 
 			startLife(
 				scene,
@@ -58,7 +65,7 @@ export function impulsePhys (
 	const forwardLocal = new Vector3(
 		0,
 		0,
-		projectileGlobals.speed * (level * level * level) * -1
+		projectileImpulse(projectileGlobals.speed, level) * -1
 	) as Vector3;
 	const speed = originMesh.getDirection(forwardLocal) as Vector3;
 		if (projectile.physicsImpostor !== null) {

--- a/src/js/projectile/startLife.ts
+++ b/src/js/projectile/startLife.ts
@@ -13,6 +13,7 @@ import { impulsePhys } from "./Projectile";
 import { destroyOnCollide } from "./destroyOnCollide";
 import { EnemySphere } from "../enemy/enemyBorn";
 import { TowerTurret } from "../tower/towerBorn";
+import { projectileMass } from "../gameplay/tierScaling";
 
 interface LiveProjectile extends Mesh {
 	hitPoints: number;
@@ -41,7 +42,7 @@ export function startLife (
 		projectile,
 		PhysicsImpostor.BoxImpostor,
 		{
-			mass: projectileGlobals.mass * (level * level),
+			mass: projectileMass(projectileGlobals.mass, level),
 			restitution: 0.3,
 			friction: 0.4
 		},

--- a/src/js/tower/trackSpheres.ts
+++ b/src/js/tower/trackSpheres.ts
@@ -5,6 +5,7 @@ import { rotateTurret } from "./Tower";
 import { shoot } from "../main/sound";
 import { TowerTurret } from "./towerBorn";
 import { EnemySphere } from "../enemy/enemyBorn";
+import { towerShotInterval } from "../gameplay/tierScaling";
 
 function trackSpheres (
 	scene: Scene,
@@ -47,7 +48,7 @@ function trackSpheres (
 					level
 				) as Vector3; // track the enemy spheres
 				if (
-					now - deltaTime > towerGlobals.rateOfFire * level * level * level &&
+					now - deltaTime > towerShotInterval(towerGlobals.rateOfFire, level) &&
 					towerGlobals.shoot
 					//  &&           shotClearsTower(scene, ray, nearestEnemy)
 				) {


### PR DESCRIPTION
Refs #30, #32

## Ownership boundary

Projectile/turret tier-scaling arithmetic only: projectile damage, projectile impulse magnitude, projectile mass, and turret fire interval. No enemy scaling, economy formulas, tower metadata, targeting policy, physics-engine migration, or balance changes.

## Change

- add `src/js/gameplay/tierScaling.ts`, a Babylon/Cannon-free module containing the existing level²/level³ rules;
- route projectile hit points through `projectileHitPoints()`;
- route projectile impulse magnitude through `projectileImpulse()`;
- route projectile physics mass through `projectileMass()`;
- route turret fire cadence through `towerShotInterval()`.

No validation, clamping, or reinterpretation of `level` is introduced. The pure functions intentionally preserve the legacy arithmetic exactly.

## Gameplay impact

- [x] No intended gameplay/balance change.
- [x] Physical projectile creation/collision remains authoritative.
- [x] The stronger-tower trade-off remains unchanged: level 3 has much heavier/faster/more damaging projectiles but a substantially slower fire cadence.

## Expected numeric contract

Using current globals (`baseHitPoints=220`, `speed=3320`, `mass=30`, `rateOfFire=26`):

| Tier | projectile HP | impulse magnitude | projectile mass | shot interval |
| --- | ---: | ---: | ---: | ---: |
| 2 | 1760 | 26560 | 120 | 208 ms |
| 3 | 5940 | 89640 | 270 | 702 ms |

These are the existing formulas, now represented explicitly for characterization and future engine migration.

## Online verification

- branch starts at current `master` `bef418bfc012f07f2c402ce494342a28f09b0409`;
- diff is one 34-line pure module plus three narrow call-site substitutions;
- no overlap with #36 economy calculations or #43 tower-level metadata;
- no rendering/audio/wave/enemy changes.

## Local Codex certification before merge

1. Confirm historical TypeScript/build accepts the new module/imports.
2. In a deterministic runtime fixture, verify tier-2 values: HP 1760, mass 120, impulse vector magnitude derived from 26560, cadence 208 ms.
3. Verify tier-3 values: HP 5940, mass 270, impulse vector magnitude derived from 89640, cadence 702 ms.
4. Confirm projectile collision/knockback behavior and tower targeting are observationally unchanged from baseline.
5. Post exact commands, exit codes, and any pre-existing failures.

Keep this draft until that evidence is posted.