### PR TITLE
Extract enemy tier scaling rules

### DIFF
--- a/src/js/enemy/Enemy.ts
+++ b/src/js/enemy/Enemy.ts
@@ -16,6 +16,7 @@ import {
 	economyGlobals
 } from "../main/globalVariables";
 import positionGenerator from "../utility/positionGenerator";
+import { enemyDiameter } from "../gameplay/enemyScaling";
 
 interface Position2D {
 	x: number;
@@ -26,7 +27,7 @@ class Enemy {
 	constructor(level: number, position: Position2D, scene: Scene) {
 		const name = `enemyLevel${level}Index${enemyGlobals.index}` as string;
 		enemyGlobals.index += 1;
-		const diameter = (level * level + 5) as number;
+		const diameter = enemyDiameter(level);
 		const sphereMesh = MeshBuilder.CreateIcoSphere(
 			name,
 			{

--- a/src/js/enemy/enemyAi.ts
+++ b/src/js/enemy/enemyAi.ts
@@ -2,11 +2,15 @@ import { Vector3 } from "babylonjs";
 import randomNumberRange from "../utility/randomNumberRange";
 import { enemyGlobals } from "../main/globalVariables";
 import { EnemySphere } from "./enemyBorn";
+import {
+	enemyDiameter,
+	enemyMoveImpulse
+} from "../gameplay/enemyScaling";
 
 function vector(enemy: EnemySphere, direction: string = "", level: number) {
 	if (enemy.physicsImpostor !== null) {
-		const speed = enemyGlobals.speed * level * level;
-		const radius = (level * level + 5) / 2;
+		const speed = enemyMoveImpulse(enemyGlobals.speed, level);
+		const radius = enemyDiameter(level) / 2;
 
 		switch (direction) {
 			case "down":

--- a/src/js/enemy/enemyBorn.ts
+++ b/src/js/enemy/enemyBorn.ts
@@ -10,6 +10,11 @@ import { Position2D } from "./Enemy";
 import { decide } from "./decide";
 import { checkHitPoints } from "./checkHitPoints";
 import randomNumberRange from "../utility/randomNumberRange";
+import {
+	enemyHitPoints,
+	enemyMass,
+	enemyRestitution
+} from "../gameplay/enemyScaling";
 
 interface EnemySphere extends Mesh {
 	hitPoints: number;
@@ -22,9 +27,9 @@ function enemyBorn (
 	diameter: number,
 	level: number = 1 | 2 | 3
 ) {
-	const enemyMass = (enemyGlobals.mass * level * level) as number;
+	const mass = enemyMass(enemyGlobals.mass, level);
 
-	sphereMesh.hitPoints = level * level * enemyGlobals.baseHitPoints + level * 440;
+	sphereMesh.hitPoints = enemyHitPoints(enemyGlobals.baseHitPoints, level);
 
 	const hitPointsMeter = MeshBuilder.CreateIcoSphere(
 		name + "hitPointMeter",
@@ -46,8 +51,8 @@ function enemyBorn (
 		sphereMesh,
 		PhysicsImpostor.SphereImpostor,
 		{
-			mass: enemyMass,
-			restitution: enemyGlobals.restitution - (level * level) / 10,
+			mass,
+			restitution: enemyRestitution(enemyGlobals.restitution, level),
 			friction: enemyGlobals.friction
 		},
 		scene

--- a/src/js/gameplay/enemyScaling.ts
+++ b/src/js/gameplay/enemyScaling.ts
@@ -1,0 +1,35 @@
+// Pure enemy tier-scaling rules extracted from the legacy Babylon/Cannon call sites.
+// These intentionally preserve the current arithmetic, including restitution values
+// that can become negative, so physics migration can compare behavior explicitly.
+
+function levelSquared(level: number): number {
+	return level * level;
+}
+
+function enemyDiameter(level: number): number {
+	return levelSquared(level) + 5;
+}
+
+function enemyHitPoints(baseHitPoints: number, level: number): number {
+	return levelSquared(level) * baseHitPoints + level * 440;
+}
+
+function enemyMass(baseMass: number, level: number): number {
+	return baseMass * levelSquared(level);
+}
+
+function enemyMoveImpulse(baseSpeed: number, level: number): number {
+	return baseSpeed * levelSquared(level);
+}
+
+function enemyRestitution(baseRestitution: number, level: number): number {
+	return baseRestitution - levelSquared(level) / 10;
+}
+
+export {
+	enemyDiameter,
+	enemyHitPoints,
+	enemyMass,
+	enemyMoveImpulse,
+	enemyRestitution
+};


### PR DESCRIPTION
Refs #30, #32

## Ownership boundary

Live enemy tier-scaling arithmetic only: diameter, hit points, mass, movement impulse magnitude, and restitution. No wave timing, AI decision ordering, enemy decay, economy damage, fragment behavior, rendering, or physics-engine migration.

## Change

- add `src/js/gameplay/enemyScaling.ts`, a Babylon/Cannon-free module containing the current enemy formulas;
- route live enemy diameter through `enemyDiameter()`;
- route enemy hit points, mass, and restitution through pure functions;
- route movement impulse magnitude and its radius offset through the same diameter/scaling contract.

No validation, clamping, or reinterpretation of `level` is introduced. The current arithmetic is preserved exactly, including negative restitution values.

## Expected numeric contract

Using current globals (`baseHitPoints=15000`, `mass=5400`, `speed=7400`, `restitution=0.08`):

| Tier | diameter | hit points | mass | move impulse | restitution |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | 6 | 15440 | 5400 | 7400 | -0.02 |
| 2 | 9 | 60880 | 21600 | 29600 | -0.32 |
| 3 | 14 | 136320 | 48600 | 66600 | -0.82 |

The negative restitution values are an observed legacy property, not a new design decision. They should be characterized under Cannon before deciding whether a future physics engine should preserve, clamp, or reinterpret them.

## Gameplay impact

- [x] No intended gameplay/balance change.
- [x] Enemy AI still chooses directions exactly as before.
- [x] Physics impulses remain authoritative.
- [x] Enemy decay, waves, and bank collisions are untouched.

## Online verification

- branch starts at current `master` `bef418bfc012f07f2c402ce494342a28f09b0409`;
- diff is one 35-line pure module plus three narrow call-site substitutions;
- independent from #36 economy work, #43 tower metadata, and #45 projectile/turret scaling.

## Local Codex certification before merge

1. Confirm historical TypeScript/build accepts the new module/imports.
2. Verify spawned L1/L2/L3 enemies expose the expected diameter, hit points, and physics mass values above.
3. Verify the impulse magnitude used by movement is unchanged at 7400/29600/66600.
4. Inspect Cannon's effective behavior with the current negative restitution inputs and record whether it accepts, clamps, or otherwise normalizes them.
5. Compare representative rolling/collision behavior before and after this refactor and report exact commands/exit codes.

Keep this draft until that evidence is posted.