### PR TITLE
Extract enemy finite-lifetime decay calculations

### DIFF
--- a/src/js/enemy/checkHitPoints.ts
+++ b/src/js/enemy/checkHitPoints.ts
@@ -3,6 +3,10 @@ import { enemyGlobals } from "../main/globalVariables";
 import { fragment } from "./Enemy";
 import { destroyEnemy } from "./destroyEnemy";
 import { EnemySphere } from "./enemyBorn";
+import {
+	decayEnemyHitPoints,
+	enemyHealthMeterScale
+} from "../gameplay/enemyLifecycle";
 
 function checkHitPoints(
 	scene: Scene,
@@ -30,9 +34,15 @@ function checkHitPoints(
 
 		destroyEnemy(sphereMesh, scene, level);
 	} else {
-		sphereMesh.hitPoints -= enemyGlobals.decayRate;
-		const scaleRate =
-      1 / ((level * level * enemyGlobals.baseHitPoints) / (sphereMesh.hitPoints));
+		sphereMesh.hitPoints = decayEnemyHitPoints(
+			sphereMesh.hitPoints,
+			enemyGlobals.decayRate
+		);
+		const scaleRate = enemyHealthMeterScale(
+			sphereMesh.hitPoints,
+			enemyGlobals.baseHitPoints,
+			level
+		);
 
 		hitPointsMeter.scaling = new BABYLON.Vector3(
 			scaleRate,

--- a/src/js/gameplay/enemyLifecycle.ts
+++ b/src/js/gameplay/enemyLifecycle.ts
@@ -1,0 +1,17 @@
+// Pure finite-lifetime calculations extracted from the legacy enemy loop.
+// Preserve the current arithmetic exactly so runtime modernization can compare
+// behavior without depending on Babylon meshes or render callbacks.
+
+function decayEnemyHitPoints(hitPoints: number, decayRate: number): number {
+	return hitPoints - decayRate;
+}
+
+function enemyHealthMeterScale(
+	hitPoints: number,
+	baseHitPoints: number,
+	level: number
+): number {
+	return 1 / ((level * level * baseHitPoints) / hitPoints);
+}
+
+export { decayEnemyHitPoints, enemyHealthMeterScale };


### PR DESCRIPTION
Refs #30, #32, #50

## Ownership boundary

Enemy finite-lifetime arithmetic and health-meter scaling only. No enemy spawn/tier scaling (#46), wave scheduling (#37), spawn occupancy (#47), projectile economy (#36), AI decisions, death/ejection predicates, physics behavior, or balance changes.

## Change

- add `src/js/gameplay/enemyLifecycle.ts`, a Babylon-free module containing the current decay and health-meter arithmetic;
- route the live 20-HP-per-decision decay through `decayEnemyHitPoints()`;
- route the live health-meter scale expression through `enemyHealthMeterScale()`.

The health-meter helper intentionally preserves the legacy expression order:

```ts
1 / ((level * level * baseHitPoints) / hitPoints)
```

It does not clamp the result to 1.0. Because spawned enemy HP includes the existing `level * 440` bonus while this denominator does not, the live meter may exceed 100% shortly after spawn. #50 records that as an observed property requiring characterization rather than an implicit fix.

## Gameplay impact

- [x] No intended gameplay/balance change.
- [x] Decay amount remains exactly `enemyGlobals.decayRate` per eligible decision check.
- [x] Death is still checked before decay; reaching zero via decay is not changed to immediate destruction.
- [x] The render-loop/strict-`>` cadence remains unchanged.
- [x] Ejection, fragments, disposal, AI, collisions, and physics are untouched.

## Online verification

- branch starts at current `master` `f2174940c6dfdd2e7a895523f67a5a85d555e87e`;
- branch is 2 commits ahead / 0 behind at PR preparation time;
- two files changed: one 17-line pure helper plus a narrow call-site substitution;
- no overlap with #46's modified files except the broader enemy domain; #46 explicitly excludes enemy decay and does not touch `checkHitPoints.ts`;
- no overlap with #47 occupancy, #37 wave scheduling, or #36 economy call sites.

## Local Codex certification before merge

1. Confirm the historical TypeScript/build accepts the new module/import.
2. Isolate an enemy from projectile damage/ejection and verify consecutive eligible checks subtract exactly 20 HP with current globals.
3. Measure actual decay intervals at representative frame rates; the nominal setting is 110 ms but the live loop uses strict `now - deltaTime > decisionRate` inside `registerBeforeRender`.
4. Record first post-decay meter scaling for L1/L2/L3 and whether Babylon visibly represents values above 1.0.
5. Verify natural death still occurs on the decision check after HP first reaches `deadHitPoints`.
6. Post exact commands, exit codes, and observed values to this PR and #50.

Keep this PR draft until that runtime/build evidence is posted.