### PR TITLE
Define backend-neutral acoustic contact model

### DIFF
--- a/src/js/audio/acoustics.ts
+++ b/src/js/audio/acoustics.ts
@@ -1,0 +1,206 @@
+export type AcousticMaterialId =
+	| "tower"
+	| "projectile"
+	| "enemy"
+	| "ground"
+	| "energy"
+	| "fragment";
+
+export interface AcousticMaterial {
+	id: AcousticMaterialId;
+	density: number;
+	stiffness: number;
+	damping: number;
+	roughness: number;
+	brightness: number;
+	noise: number;
+	saturation: number;
+	modeRatios: number[];
+}
+
+export interface AcousticVector3 {
+	x: number;
+	y: number;
+	z: number;
+}
+
+export interface AcousticContact {
+	position: AcousticVector3;
+	normal: AcousticVector3;
+	normalSpeed: number;
+	tangentialSpeed: number;
+	angularSpeed: number;
+	effectiveMass: number;
+	bodyScale: number;
+	materialA: AcousticMaterialId;
+	materialB: AcousticMaterialId;
+	damageEnergy: number;
+	seed: number;
+}
+
+export interface AcousticCalibration {
+	referenceImpactEnergy: number;
+	referenceSpeed: number;
+	referenceBodyScale: number;
+	referenceFrequencyHz: number;
+	referenceDecaySeconds: number;
+}
+
+export interface AcousticExcitation {
+	position: AcousticVector3;
+	impactEnergy: number;
+	normalizedEnergy: number;
+	fundamentalHz: number;
+	decaySeconds: number;
+	brightness: number;
+	noiseMix: number;
+	scrapeMix: number;
+	saturation: number;
+	modeRatios: number[];
+	seed: number;
+}
+
+export const acousticMaterials: { [key: string]: AcousticMaterial } = {
+	tower: {
+		id: "tower",
+		density: 0.9,
+		stiffness: 0.85,
+		damping: 0.35,
+		roughness: 0.35,
+		brightness: 0.65,
+		noise: 0.2,
+		saturation: 0.25,
+		modeRatios: [1, 1.61, 2.37, 3.91]
+	},
+	projectile: {
+		id: "projectile",
+		density: 1,
+		stiffness: 1,
+		damping: 0.2,
+		roughness: 0.15,
+		brightness: 0.95,
+		noise: 0.15,
+		saturation: 0.45,
+		modeRatios: [1, 2.08, 3.23, 5.17]
+	},
+	enemy: {
+		id: "enemy",
+		density: 0.75,
+		stiffness: 0.62,
+		damping: 0.25,
+		roughness: 0.2,
+		brightness: 0.6,
+		noise: 0.3,
+		saturation: 0.35,
+		modeRatios: [1, 1.42, 2.09, 3.16]
+	},
+	ground: {
+		id: "ground",
+		density: 1,
+		stiffness: 0.95,
+		damping: 0.55,
+		roughness: 0.7,
+		brightness: 0.45,
+		noise: 0.45,
+		saturation: 0.15,
+		modeRatios: [1, 1.3, 1.92, 2.84]
+	},
+	energy: {
+		id: "energy",
+		density: 0.55,
+		stiffness: 0.78,
+		damping: 0.18,
+		roughness: 0.05,
+		brightness: 1,
+		noise: 0.08,
+		saturation: 0.55,
+		modeRatios: [1, 1.5, 2.5, 4]
+	},
+	fragment: {
+		id: "fragment",
+		density: 0.7,
+		stiffness: 0.7,
+		damping: 0.45,
+		roughness: 0.55,
+		brightness: 0.75,
+		noise: 0.55,
+		saturation: 0.25,
+		modeRatios: [1, 1.73, 2.68, 4.11]
+	}
+};
+
+function clamp01(value: number): number {
+	return Math.max(0, Math.min(1, value));
+}
+
+function average(a: number, b: number): number {
+	return (a + b) / 2;
+}
+
+function materialPair(
+	materialA: AcousticMaterialId,
+	materialB: AcousticMaterialId
+): AcousticMaterial {
+	const a = acousticMaterials[materialA];
+	const b = acousticMaterials[materialB];
+	return {
+		id: a.id,
+		density: average(a.density, b.density),
+		stiffness: average(a.stiffness, b.stiffness),
+		damping: average(a.damping, b.damping),
+		roughness: average(a.roughness, b.roughness),
+		brightness: average(a.brightness, b.brightness),
+		noise: average(a.noise, b.noise),
+		saturation: average(a.saturation, b.saturation),
+		modeRatios: a.modeRatios.concat(b.modeRatios)
+	};
+}
+
+export function impactEnergy(contact: AcousticContact): number {
+	return 0.5 * Math.max(0, contact.effectiveMass) *
+		Math.pow(Math.max(0, contact.normalSpeed), 2);
+}
+
+export function deriveAcousticExcitation(
+	contact: AcousticContact,
+	calibration: AcousticCalibration
+): AcousticExcitation {
+	const pair = materialPair(contact.materialA, contact.materialB);
+	const energy = impactEnergy(contact);
+	const normalizedEnergy = clamp01(
+		energy / Math.max(calibration.referenceImpactEnergy, 0.000001)
+	);
+	const speedRatio = clamp01(
+		contact.normalSpeed / Math.max(calibration.referenceSpeed, 0.000001)
+	);
+	const scaleRatio = Math.max(
+		contact.bodyScale / Math.max(calibration.referenceBodyScale, 0.000001),
+		0.1
+	);
+	const materialPitch = Math.sqrt(
+		Math.max(pair.stiffness, 0.000001) / Math.max(pair.density, 0.000001)
+	);
+	const tangentialRatio = clamp01(
+		contact.tangentialSpeed / Math.max(calibration.referenceSpeed, 0.000001)
+	);
+	const angularRatio = clamp01(
+		contact.angularSpeed * contact.bodyScale /
+		Math.max(calibration.referenceSpeed, 0.000001)
+	);
+
+	return {
+		position: contact.position,
+		impactEnergy: energy,
+		normalizedEnergy,
+		fundamentalHz:
+			calibration.referenceFrequencyHz * materialPitch / scaleRatio,
+		decaySeconds:
+			calibration.referenceDecaySeconds * (0.15 + 1 - pair.damping),
+		brightness: clamp01(pair.brightness * (0.5 + speedRatio * 0.5)),
+		noiseMix: clamp01(pair.noise * normalizedEnergy + pair.roughness * tangentialRatio),
+		scrapeMix: clamp01(pair.roughness * Math.max(tangentialRatio, angularRatio)),
+		saturation: clamp01(pair.saturation * normalizedEnergy),
+		modeRatios: pair.modeRatios,
+		seed: contact.seed
+	};
+}

--- a/src/js/audio/acoustics.ts
+++ b/src/js/audio/acoustics.ts
@@ -18,6 +18,17 @@ export interface AcousticMaterial {
 	modeRatios: number[];
 }
 
+interface AcousticMaterialBlend {
+	density: number;
+	stiffness: number;
+	damping: number;
+	roughness: number;
+	brightness: number;
+	noise: number;
+	saturation: number;
+	modeRatios: number[];
+}
+
 export interface AcousticVector3 {
 	x: number;
 	y: number;
@@ -27,6 +38,7 @@ export interface AcousticVector3 {
 export interface AcousticContact {
 	position: AcousticVector3;
 	normal: AcousticVector3;
+	/** Signed or absolute relative speed along the contact normal. */
 	normalSpeed: number;
 	tangentialSpeed: number;
 	angularSpeed: number;
@@ -50,6 +62,8 @@ export interface AcousticExcitation {
 	position: AcousticVector3;
 	impactEnergy: number;
 	normalizedEnergy: number;
+	damageEnergy: number;
+	normalizedDamageEnergy: number;
 	fundamentalHz: number;
 	decaySeconds: number;
 	brightness: number;
@@ -129,36 +143,83 @@ export const acousticMaterials: { [key: string]: AcousticMaterial } = {
 	}
 };
 
+const MAX_ACOUSTIC_SCALAR = 1e100;
+
+function finiteScalar(value: number, fallback = 0): number {
+	if (value !== value) {
+		return fallback;
+	}
+	if (value > MAX_ACOUSTIC_SCALAR) {
+		return MAX_ACOUSTIC_SCALAR;
+	}
+	if (value < -MAX_ACOUSTIC_SCALAR) {
+		return -MAX_ACOUSTIC_SCALAR;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finiteScalar(value));
+}
+
 function clamp01(value: number): number {
-	return Math.max(0, Math.min(1, value));
+	return Math.max(0, Math.min(1, finiteScalar(value)));
 }
 
 function average(a: number, b: number): number {
-	return (a + b) / 2;
+	return finiteScalar((finiteScalar(a) + finiteScalar(b)) / 2);
 }
 
-function materialPair(
-	materialA: AcousticMaterialId,
-	materialB: AcousticMaterialId
-): AcousticMaterial {
-	const a = acousticMaterials[materialA];
-	const b = acousticMaterials[materialB];
+function finitePosition(position: AcousticVector3): AcousticVector3 {
 	return {
-		id: a.id,
-		density: average(a.density, b.density),
-		stiffness: average(a.stiffness, b.stiffness),
-		damping: average(a.damping, b.damping),
-		roughness: average(a.roughness, b.roughness),
-		brightness: average(a.brightness, b.brightness),
-		noise: average(a.noise, b.noise),
-		saturation: average(a.saturation, b.saturation),
-		modeRatios: a.modeRatios.concat(b.modeRatios)
+		x: finiteScalar(position.x),
+		y: finiteScalar(position.y),
+		z: finiteScalar(position.z)
 	};
 }
 
+/**
+ * Blend two semantic materials without inventing a third material identity.
+ *
+ * Material A/B ordering is physics-engine bookkeeping and must not change the
+ * resulting timbre. The pair is therefore canonicalized by material id before
+ * mode lists are combined. Equal-material contacts keep one mode list instead
+ * of duplicating identical resonators.
+ */
+function materialPair(
+	materialA: AcousticMaterialId,
+	materialB: AcousticMaterialId
+): AcousticMaterialBlend {
+	const firstId = materialA <= materialB ? materialA : materialB;
+	const secondId = materialA <= materialB ? materialB : materialA;
+	const first = acousticMaterials[firstId];
+	const second = acousticMaterials[secondId];
+	const modeRatios =
+		firstId === secondId
+			? first.modeRatios.slice()
+			: first.modeRatios.concat(second.modeRatios);
+
+	return {
+		density: average(first.density, second.density),
+		stiffness: average(first.stiffness, second.stiffness),
+		damping: average(first.damping, second.damping),
+		roughness: average(first.roughness, second.roughness),
+		brightness: average(first.brightness, second.brightness),
+		noise: average(first.noise, second.noise),
+		saturation: average(first.saturation, second.saturation),
+		modeRatios
+	};
+}
+
+/**
+ * Kinetic energy normal to the contact. `normalSpeed` may be signed or already
+ * absolute; using its magnitude keeps this scalar aligned with #59 terrain
+ * impact energy so both systems can consume one physical collision description.
+ */
 export function impactEnergy(contact: AcousticContact): number {
-	return 0.5 * Math.max(0, contact.effectiveMass) *
-		Math.pow(Math.max(0, contact.normalSpeed), 2);
+	const mass = positive(contact.effectiveMass);
+	const speed = Math.abs(finiteScalar(contact.normalSpeed));
+	return positive(finiteScalar(0.5 * mass * Math.pow(speed, 2)));
 }
 
 export function deriveAcousticExcitation(
@@ -167,40 +228,66 @@ export function deriveAcousticExcitation(
 ): AcousticExcitation {
 	const pair = materialPair(contact.materialA, contact.materialB);
 	const energy = impactEnergy(contact);
-	const normalizedEnergy = clamp01(
-		energy / Math.max(calibration.referenceImpactEnergy, 0.000001)
+	const damageEnergy = positive(contact.damageEnergy);
+	const referenceImpactEnergy = Math.max(
+		positive(calibration.referenceImpactEnergy),
+		0.000001
 	);
+	const referenceSpeed = Math.max(
+		positive(calibration.referenceSpeed),
+		0.000001
+	);
+	const referenceBodyScale = Math.max(
+		positive(calibration.referenceBodyScale),
+		0.000001
+	);
+	const normalizedEnergy = clamp01(energy / referenceImpactEnergy);
+	const normalizedDamageEnergy = clamp01(damageEnergy / referenceImpactEnergy);
 	const speedRatio = clamp01(
-		contact.normalSpeed / Math.max(calibration.referenceSpeed, 0.000001)
+		Math.abs(finiteScalar(contact.normalSpeed)) / referenceSpeed
 	);
 	const scaleRatio = Math.max(
-		contact.bodyScale / Math.max(calibration.referenceBodyScale, 0.000001),
+		positive(contact.bodyScale) / referenceBodyScale,
 		0.1
 	);
 	const materialPitch = Math.sqrt(
 		Math.max(pair.stiffness, 0.000001) / Math.max(pair.density, 0.000001)
 	);
 	const tangentialRatio = clamp01(
-		contact.tangentialSpeed / Math.max(calibration.referenceSpeed, 0.000001)
+		Math.abs(finiteScalar(contact.tangentialSpeed)) / referenceSpeed
 	);
 	const angularRatio = clamp01(
-		contact.angularSpeed * contact.bodyScale /
-		Math.max(calibration.referenceSpeed, 0.000001)
+		Math.abs(finiteScalar(contact.angularSpeed)) * positive(contact.bodyScale) /
+			referenceSpeed
+	);
+	const fundamentalHz = positive(
+		finiteScalar(
+			positive(calibration.referenceFrequencyHz) * materialPitch / scaleRatio
+		)
+	);
+	const decaySeconds = positive(
+		finiteScalar(
+			positive(calibration.referenceDecaySeconds) * (0.15 + 1 - pair.damping)
+		)
 	);
 
 	return {
-		position: contact.position,
+		position: finitePosition(contact.position),
 		impactEnergy: energy,
 		normalizedEnergy,
-		fundamentalHz:
-			calibration.referenceFrequencyHz * materialPitch / scaleRatio,
-		decaySeconds:
-			calibration.referenceDecaySeconds * (0.15 + 1 - pair.damping),
+		damageEnergy,
+		normalizedDamageEnergy,
+		fundamentalHz,
+		decaySeconds,
 		brightness: clamp01(pair.brightness * (0.5 + speedRatio * 0.5)),
-		noiseMix: clamp01(pair.noise * normalizedEnergy + pair.roughness * tangentialRatio),
-		scrapeMix: clamp01(pair.roughness * Math.max(tangentialRatio, angularRatio)),
+		noiseMix: clamp01(
+			pair.noise * normalizedEnergy + pair.roughness * tangentialRatio
+		),
+		scrapeMix: clamp01(
+			pair.roughness * Math.max(tangentialRatio, angularRatio)
+		),
 		saturation: clamp01(pair.saturation * normalizedEnergy),
-		modeRatios: pair.modeRatios,
-		seed: contact.seed
+		modeRatios: pair.modeRatios.slice(),
+		seed: finiteScalar(contact.seed)
 	};
 }


### PR DESCRIPTION
Refs #53, #52
Related: #58, #59, #60, #61

## Ownership boundary

Pure acoustic-material/contact modeling only. No Babylon, Cannon, WAFXR, Tone, Web Audio, Bevy, Rapier, or Rust integration; no audible output changes.

## Change

Add `src/js/audio/acoustics.ts` with:

- semantic acoustic material IDs independent from visual `StandardMaterial` instances;
- provisional acoustic material profiles for towers, projectiles, enemies, ground, energy reserve, and fragments;
- a physics-facing `AcousticContact` contract carrying normal/tangential/angular motion, effective mass, body scale, position, material pair, damage energy, and deterministic seed;
- an `impactEnergy()` calculation aligned with #59 terrain impact energy;
- a backend-neutral `AcousticExcitation` descriptor derived from contact measurements plus explicit calibration values;
- finite-safe sanitization so malformed contact/calibration values cannot emit NaN/Infinity into DSP planning.

The derived descriptor includes impact energy, normalized energy, damage energy, normalized damage energy, modal fundamental, decay, brightness, noise/scrape mix, saturation, mode ratios, position, and seed. It deliberately contains no playback API.

## Material pair semantics

A collision's `materialA` / `materialB` ordering is physics-engine bookkeeping, not acoustic meaning. The blended material must therefore be commutative.

The model now:
- canonicalizes material order before combining mode lists;
- averages material coefficients symmetrically;
- does **not** invent a pair material id by reusing material A's id;
- avoids duplicating identical mode ratios for same-material contacts;
- returns a copied mode list so a backend cannot mutate the global material table through an excitation descriptor.

Local validation should prove `deriveAcousticExcitation(A,B) === deriveAcousticExcitation(B,A)` for every semantic material pair when all physical inputs are otherwise equal.

## Shared impact-energy convention

`normalSpeed` may now be signed or absolute. `impactEnergy()` uses its magnitude, matching #59 `terrainImpactEnergy()` so terrain deformation and acoustic excitation can consume the same signed contact-normal velocity without one subsystem silently treating an approaching contact as zero energy.

This should become part of the simulation/contact protocol used by #66 rather than being re-derived differently in each backend.

## Damage energy

`damageEnergy` was previously accepted by `AcousticContact` and then discarded. It is now preserved in `AcousticExcitation` as both raw `damageEnergy` and `normalizedDamageEnergy` using the same provisional impact-energy reference scale.

This PR deliberately does **not** use damage energy to retune brightness, saturation, pitch, or decay yet. Listening fixtures should determine whether damage should produce resonance instability/fracture coloration rather than baking an untested mapping into the first contract.

## Why

Defend's existing sound engine is procedural and positional, but its synthesis parameters are mostly selected by named events, level, HP, or object counts. #53 moves the design toward sound that is caused by the same physical quantities the player sees: impact energy, relative motion, body scale, materials, damage, and contact position.

This module is also intended as a portability seam: a future Web Audio implementation and a Rust/WASM DSP implementation can consume the same conceptual event/model, and Rapier can later source the same contract if #52/#66 advances.

## Important: provisional calibration

The material coefficients and mode ratios in this first slice are hypotheses for controlled listening tests, **not** established gameplay constants. They must not be treated as frozen balance or acoustic truth. The public contract and physical inputs are more important than these initial values.

## Validation required before promotion

Local Codex should:

1. confirm the historical TypeScript 3.2 toolchain accepts the module syntax;
2. property-test all public outputs across zero, negative, NaN, ±Infinity, and very large contact/calibration inputs; every scalar/vector component must remain finite;
3. verify positive and negative `normalSpeed` of equal magnitude produce identical impact energy;
4. verify swapping material A/B produces identical excitation values and identical mode ordering for every material pair;
5. verify same-material contacts do not duplicate their mode list;
6. verify `normalizedDamageEnergy` is bounded `[0,1]` and changes monotonically with raw positive damage energy;
7. confirm ordinary finite fixtures from the previous revision remain unchanged except for the intentionally added damage fields/material-pair ordering fixes;
8. build a small offline/browser synthesis harness that maps `AcousticExcitation` to a simple modal/noise voice without touching production sound;
9. compare projectile→enemy, enemy→ground, and enemy→energy material pairs;
10. identify calibration values that produce useful audible separation without excessive level variance;
11. verify the model can be mirrored straightforwardly in the dependency-light Rust core/runtime and that the TS/Rust excitation fixtures match.

## Gameplay/audio impact

None in this PR. The module is not wired to current sound call sites.

Keep as draft until the pure model and calibration assumptions have been reviewed with deterministic fixtures.