### PR TITLE
Spike a Rust/WASM gameplay core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/defend-core"]
+resolver = "2"

--- a/crates/defend-core/Cargo.toml
+++ b/crates/defend-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "defend-core"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[features]
+default = []
+wasm = ["dep:wasm-bindgen"]
+
+[dependencies]
+wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/defend-core/src/lib.rs
+++ b/crates/defend-core/src/lib.rs
@@ -1,0 +1,131 @@
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn projectile_hit_points(level: u32, base_hit_points: f64) -> f64 {
+    level.pow(3) as f64 * base_hit_points
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn projectile_impulse(level: u32, base_speed: f64) -> f64 {
+    level.pow(3) as f64 * base_speed
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn projectile_mass(level: u32, base_mass: f64) -> f64 {
+    level.pow(2) as f64 * base_mass
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn tower_shot_interval(level: u32, base_rate_of_fire: f64) -> f64 {
+    level.pow(3) as f64 * base_rate_of_fire
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn enemy_diameter(level: u32) -> f64 {
+    level.pow(2) as f64 + 5.0
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn enemy_hit_points(level: u32, base_hit_points: f64) -> f64 {
+    level.pow(2) as f64 * base_hit_points + level as f64 * 440.0
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn enemy_mass(level: u32, base_mass: f64) -> f64 {
+    level.pow(2) as f64 * base_mass
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn enemy_move_impulse(level: u32, base_speed: f64) -> f64 {
+    level.pow(2) as f64 * base_speed
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn enemy_restitution(level: u32, base_restitution: f64) -> f64 {
+    base_restitution - level.pow(2) as f64 / 10.0
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn recovered_energy(
+    current_balance: f64,
+    projectile_hit_points: f64,
+    recovery_ratio: f64,
+    max_balance: f64,
+) -> f64 {
+    (current_balance + projectile_hit_points * recovery_ratio).min(max_balance)
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn bank_damage(enemy_hit_points: f64) -> f64 {
+    enemy_hit_points / 2.0
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn impact_energy(effective_mass: f64, normal_speed: f64) -> f64 {
+    0.5 * effective_mass.max(0.0) * normal_speed.max(0.0).powi(2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64) {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1e-9,
+            "expected {expected}, got {actual} (error {error})"
+        );
+    }
+
+    #[test]
+    fn projectile_tiers_match_legacy_contract() {
+        assert_eq!(projectile_hit_points(2, 220.0), 1760.0);
+        assert_eq!(projectile_hit_points(3, 220.0), 5940.0);
+        assert_eq!(projectile_impulse(2, 3320.0), 26560.0);
+        assert_eq!(projectile_impulse(3, 3320.0), 89640.0);
+        assert_eq!(projectile_mass(2, 30.0), 120.0);
+        assert_eq!(projectile_mass(3, 30.0), 270.0);
+        assert_eq!(tower_shot_interval(2, 26.0), 208.0);
+        assert_eq!(tower_shot_interval(3, 26.0), 702.0);
+    }
+
+    #[test]
+    fn enemy_tiers_match_legacy_contract() {
+        assert_eq!(enemy_diameter(1), 6.0);
+        assert_eq!(enemy_diameter(2), 9.0);
+        assert_eq!(enemy_diameter(3), 14.0);
+
+        assert_eq!(enemy_hit_points(1, 15000.0), 15440.0);
+        assert_eq!(enemy_hit_points(2, 15000.0), 60880.0);
+        assert_eq!(enemy_hit_points(3, 15000.0), 136320.0);
+
+        assert_eq!(enemy_mass(1, 5400.0), 5400.0);
+        assert_eq!(enemy_mass(2, 5400.0), 21600.0);
+        assert_eq!(enemy_mass(3, 5400.0), 48600.0);
+
+        assert_eq!(enemy_move_impulse(1, 7400.0), 7400.0);
+        assert_eq!(enemy_move_impulse(2, 7400.0), 29600.0);
+        assert_eq!(enemy_move_impulse(3, 7400.0), 66600.0);
+
+        assert_close(enemy_restitution(1, 0.08), -0.02);
+        assert_close(enemy_restitution(2, 0.08), -0.32);
+        assert_close(enemy_restitution(3, 0.08), -0.82);
+    }
+
+    #[test]
+    fn economy_matches_legacy_contract() {
+        assert_eq!(recovered_energy(1000.0, 1760.0, 0.14, 30000.0), 1246.4);
+        assert_eq!(recovered_energy(29900.0, 1760.0, 0.14, 30000.0), 30000.0);
+        assert_eq!(bank_damage(15440.0), 7720.0);
+    }
+
+    #[test]
+    fn acoustic_impact_energy_is_physics_derived() {
+        assert_eq!(impact_energy(120.0, 10.0), 6000.0);
+        assert_eq!(impact_energy(-1.0, 10.0), 0.0);
+        assert_eq!(impact_energy(120.0, -10.0), 0.0);
+    }
+}

--- a/crates/defend-core/src/lib.rs
+++ b/crates/defend-core/src/lib.rs
@@ -63,9 +63,15 @@ pub fn bank_damage(enemy_hit_points: f64) -> f64 {
     enemy_hit_points / 2.0
 }
 
+/// Kinetic energy normal to a contact.
+///
+/// `normal_speed` may be signed or already absolute. Using its magnitude keeps
+/// this shared scalar aligned with the TypeScript acoustic and terrain models,
+/// so physics backends can forward one signed contact-normal velocity without
+/// each downstream subsystem silently inventing a different convention.
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub fn impact_energy(effective_mass: f64, normal_speed: f64) -> f64 {
-    0.5 * effective_mass.max(0.0) * normal_speed.max(0.0).powi(2)
+    0.5 * effective_mass.max(0.0) * normal_speed.abs().powi(2)
 }
 
 #[cfg(test)]
@@ -123,9 +129,9 @@ mod tests {
     }
 
     #[test]
-    fn acoustic_impact_energy_is_physics_derived() {
+    fn acoustic_impact_energy_is_physics_derived_and_sign_invariant() {
         assert_eq!(impact_energy(120.0, 10.0), 6000.0);
+        assert_eq!(impact_energy(120.0, -10.0), 6000.0);
         assert_eq!(impact_energy(-1.0, 10.0), 0.0);
-        assert_eq!(impact_energy(120.0, -10.0), 0.0);
     }
 }


### PR DESCRIPTION
Refs #52
Related: #30, #36, #45, #46, #53

## Scope

Experimental Rust/WASM parity spike only. This does **not** replace Babylon, Cannon, TypeScript gameplay, rendering, input, or audio, and it is not intended to merge until the local executor proves the build/interop path is worthwhile.

## Change

- add a minimal Cargo workspace with `crates/defend-core`;
- keep the crate dependency-light: only optional `wasm-bindgen` support;
- expose current characterized projectile, turret, enemy, economy, and acoustic-impact calculations as pure Rust functions;
- add native unit tests for the exact current numeric contracts already documented in #36/#45/#46;
- allow the same functions to be exported to browser JavaScript when built with the `wasm` feature.

No Bevy or Rapier dependency is introduced in this first spike. The goal is to establish a small, testable Rust boundary before evaluating a larger engine migration.

## Mirrored contracts

Projectile/turret:
- L2 HP 1760, impulse 26560, mass 120, cadence 208 ms;
- L3 HP 5940, impulse 89640, mass 270, cadence 702 ms.

Enemy:
- diameters 6 / 9 / 14;
- HP 15440 / 60880 / 136320;
- mass 5400 / 21600 / 48600;
- movement impulse 7400 / 29600 / 66600;
- current legacy restitution -0.02 / -0.32 / -0.82.

Economy:
- projectile recovery uses current hit-points × ratio with max-balance cap;
- bank damage remains remaining enemy HP / 2.

Audio bridge:
- includes only the physically meaningful scalar `impact_energy(effective_mass, normal_speed)` as a first shared primitive for #53.

## Local Codex certification

Please validate this exact head before considering promotion:

1. `cargo test -p defend-core` on the current stable Rust toolchain;
2. `cargo check -p defend-core --features wasm --target wasm32-unknown-unknown`;
3. build browser bindings with a current `wasm-bindgen`/`wasm-pack` workflow and report generated WASM + JS glue sizes (raw and compressed where practical);
4. call several exported functions from a tiny browser harness and verify numeric parity with the current TypeScript formulas;
5. record compile time, incremental compile time, debugging/source-map ergonomics, and any browser/PWA integration friction;
6. evaluate whether the 2024 edition or optional dependency choices create avoidable compatibility constraints;
7. do not add Bevy/Rapier until this lower-level parity boundary is understood.

## Decision gate

This spike should only graduate into the main architecture if Rust/WASM materially improves deterministic testing, shared native/web logic, physics/audio integration, or maintainability at acceptable bundle/build/runtime cost. Otherwise close it as useful evidence and keep Rust limited to systems where it clearly wins.