### PR TITLE
Define pure hex topology primitives

### DIFF
--- a/src/js/gameplay/hexGrid.ts
+++ b/src/js/gameplay/hexGrid.ts
@@ -15,42 +15,84 @@ interface WorldPoint2D {
 }
 
 const SQRT_3 = Math.sqrt(3);
+const MIN_HEX_SIZE = 0.000001;
+const MAX_HEX_SCALAR = 1e100;
 
-const HEX_DIRECTIONS: HexCell[] = [
-	{ q: 1, r: 0 },
-	{ q: 1, r: -1 },
-	{ q: 0, r: -1 },
-	{ q: -1, r: 0 },
-	{ q: -1, r: 1 },
-	{ q: 0, r: 1 }
-];
+function finiteScalar(value: number, fallback = 0): number {
+	if (value !== value) {
+		return fallback;
+	}
+	if (value > MAX_HEX_SCALAR) {
+		return MAX_HEX_SCALAR;
+	}
+	if (value < -MAX_HEX_SCALAR) {
+		return -MAX_HEX_SCALAR;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finiteScalar(value));
+}
+
+function hexSize(size: number): number {
+	return Math.max(MIN_HEX_SIZE, Math.abs(finiteScalar(size, 1)));
+}
+
+function normalizedDirection(direction: number): number {
+	const integerDirection = Math.floor(finiteScalar(direction));
+	return ((integerDirection % 6) + 6) % 6;
+}
+
+const HEX_DIRECTIONS: HexCell[] = Object.freeze([
+	Object.freeze({ q: 1, r: 0 }),
+	Object.freeze({ q: 1, r: -1 }),
+	Object.freeze({ q: 0, r: -1 }),
+	Object.freeze({ q: -1, r: 0 }),
+	Object.freeze({ q: -1, r: 1 }),
+	Object.freeze({ q: 0, r: 1 })
+]) as HexCell[];
 
 function hexToCube(cell: HexCell): HexCube {
+	const q = finiteScalar(cell.q);
+	const r = finiteScalar(cell.r);
 	return {
-		q: cell.q,
-		r: cell.r,
-		s: -cell.q - cell.r
+		q,
+		r,
+		s: finiteScalar(-q - r)
 	};
 }
 
 function cubeToHex(cube: HexCube): HexCell {
-	return { q: cube.q, r: cube.r };
+	return { q: finiteScalar(cube.q), r: finiteScalar(cube.r) };
 }
 
 function hexToWorld(cell: HexCell, size: number): WorldPoint2D {
+	const safeSize = hexSize(size);
+	const q = finiteScalar(cell.q);
+	const r = finiteScalar(cell.r);
 	return {
-		x: size * SQRT_3 * (cell.q + cell.r / 2),
-		z: size * 1.5 * cell.r
+		x: finiteScalar(safeSize * SQRT_3 * (q + r / 2)),
+		z: finiteScalar(safeSize * 1.5 * r)
 	};
 }
 
 function worldToFractionalHex(point: WorldPoint2D, size: number): HexCell {
+	const safeSize = hexSize(size);
+	const x = finiteScalar(point.x);
+	const z = finiteScalar(point.z);
 	return {
-		q: ((SQRT_3 / 3) * point.x - point.z / 3) / size,
-		r: ((2 / 3) * point.z) / size
+		q: finiteScalar(((SQRT_3 / 3) * x - z / 3) / safeSize),
+		r: finiteScalar(((2 / 3) * z) / safeSize)
 	};
 }
 
+/**
+ * Cube rounding with an explicit tie convention. When two axes have the same
+ * rounding error, correction prefers the later axis in q → r → s order
+ * (`s`, then `r`, then `q`). This preserves the original draft's boundary
+ * behavior and gives the Rust mirror a precise rule for exact edge/vertex hits.
+ */
 function roundHex(cell: HexCell): HexCell {
 	const cube = hexToCube(cell);
 	let q = Math.round(cube.q);
@@ -72,29 +114,34 @@ function roundHex(cell: HexCell): HexCell {
 	return cubeToHex({ q, r, s });
 }
 
+function canonicalHex(cell: HexCell): HexCell {
+	return roundHex(cell);
+}
+
 function worldToHex(point: WorldPoint2D, size: number): HexCell {
 	return roundHex(worldToFractionalHex(point, size));
 }
 
 function hexNeighbor(cell: HexCell, direction: number): HexCell {
-	const normalizedDirection = ((direction % 6) + 6) % 6;
-	const delta = HEX_DIRECTIONS[normalizedDirection];
+	const origin = canonicalHex(cell);
+	const delta = HEX_DIRECTIONS[normalizedDirection(direction)];
 	return {
-		q: cell.q + delta.q,
-		r: cell.r + delta.r
+		q: origin.q + delta.q,
+		r: origin.r + delta.r
 	};
 }
 
 function hexNeighbors(cell: HexCell): HexCell[] {
+	const origin = canonicalHex(cell);
 	return HEX_DIRECTIONS.map(delta => ({
-		q: cell.q + delta.q,
-		r: cell.r + delta.r
+		q: origin.q + delta.q,
+		r: origin.r + delta.r
 	}));
 }
 
 function hexDistance(a: HexCell, b: HexCell): number {
-	const ac = hexToCube(a);
-	const bc = hexToCube(b);
+	const ac = hexToCube(canonicalHex(a));
+	const bc = hexToCube(canonicalHex(b));
 	return Math.max(
 		Math.abs(ac.q - bc.q),
 		Math.abs(ac.r - bc.r),
@@ -107,29 +154,64 @@ function hexRing(cell: HexCell): number {
 }
 
 function isHexWithinRadius(cell: HexCell, radius: number): boolean {
-	return hexRing(cell) <= radius;
+	return hexRing(cell) <= Math.floor(positive(radius));
 }
 
 function isHexProtected(cell: HexCell, protectedRadius: number): boolean {
-	return hexRing(cell) <= protectedRadius;
+	return hexRing(cell) <= Math.floor(positive(protectedRadius));
 }
 
+/**
+ * Classify a logical cell into one of six world-relative sectors without atan2.
+ *
+ * For pointy-top axial coordinates, the dot products against the six 60-degree
+ * world directions reduce to these common-factor linear scores:
+ *
+ *   0:  2q + r      3: -2q - r
+ *   1:   q + 2r     4:  -q - 2r
+ *   2:  -q + r      5:   q - r
+ *
+ * The highest score is the nearest sector axis. Exact boundary ties choose the
+ * lowest sector id, making classification deterministic without floating-point
+ * angle behavior and straightforward to mirror in Rust/WASM.
+ *
+ * `size` is retained for API compatibility with the first draft. Positive scale
+ * cannot affect sector identity; it is normalized only so invalid size input is
+ * not silently accepted as a meaningful topology parameter.
+ */
 function hexSector(cell: HexCell, size: number = 1): number {
-	if (cell.q === 0 && cell.r === 0) {
+	hexSize(size);
+	const canonical = canonicalHex(cell);
+	if (canonical.q === 0 && canonical.r === 0) {
 		return -1;
 	}
 
-	const point = hexToWorld(cell, size);
-	let angle = Math.atan2(point.z, point.x);
-	if (angle < 0) {
-		angle += Math.PI * 2;
+	const q = canonical.q;
+	const r = canonical.r;
+	const scores = [
+		2 * q + r,
+		q + 2 * r,
+		-q + r,
+		-2 * q - r,
+		-q - 2 * r,
+		q - r
+	];
+	let sector = 0;
+	let bestScore = scores[0];
+
+	for (let index = 1; index < scores.length; index += 1) {
+		if (scores[index] > bestScore) {
+			bestScore = scores[index];
+			sector = index;
+		}
 	}
 
-	return Math.floor((angle + Math.PI / 6) / (Math.PI / 3)) % 6;
+	return sector;
 }
 
 function hexKey(cell: HexCell): string {
-	return `${cell.q},${cell.r}`;
+	const canonical = canonicalHex(cell);
+	return `${canonical.q},${canonical.r}`;
 }
 
 export {

--- a/src/js/gameplay/hexGrid.ts
+++ b/src/js/gameplay/hexGrid.ts
@@ -1,0 +1,154 @@
+interface HexCell {
+	q: number;
+	r: number;
+}
+
+interface HexCube {
+	q: number;
+	r: number;
+	s: number;
+}
+
+interface WorldPoint2D {
+	x: number;
+	z: number;
+}
+
+const SQRT_3 = Math.sqrt(3);
+
+const HEX_DIRECTIONS: HexCell[] = [
+	{ q: 1, r: 0 },
+	{ q: 1, r: -1 },
+	{ q: 0, r: -1 },
+	{ q: -1, r: 0 },
+	{ q: -1, r: 1 },
+	{ q: 0, r: 1 }
+];
+
+function hexToCube(cell: HexCell): HexCube {
+	return {
+		q: cell.q,
+		r: cell.r,
+		s: -cell.q - cell.r
+	};
+}
+
+function cubeToHex(cube: HexCube): HexCell {
+	return { q: cube.q, r: cube.r };
+}
+
+function hexToWorld(cell: HexCell, size: number): WorldPoint2D {
+	return {
+		x: size * SQRT_3 * (cell.q + cell.r / 2),
+		z: size * 1.5 * cell.r
+	};
+}
+
+function worldToFractionalHex(point: WorldPoint2D, size: number): HexCell {
+	return {
+		q: ((SQRT_3 / 3) * point.x - point.z / 3) / size,
+		r: ((2 / 3) * point.z) / size
+	};
+}
+
+function roundHex(cell: HexCell): HexCell {
+	const cube = hexToCube(cell);
+	let q = Math.round(cube.q);
+	let r = Math.round(cube.r);
+	let s = Math.round(cube.s);
+
+	const qDiff = Math.abs(q - cube.q);
+	const rDiff = Math.abs(r - cube.r);
+	const sDiff = Math.abs(s - cube.s);
+
+	if (qDiff > rDiff && qDiff > sDiff) {
+		q = -r - s;
+	} else if (rDiff > sDiff) {
+		r = -q - s;
+	} else {
+		s = -q - r;
+	}
+
+	return cubeToHex({ q, r, s });
+}
+
+function worldToHex(point: WorldPoint2D, size: number): HexCell {
+	return roundHex(worldToFractionalHex(point, size));
+}
+
+function hexNeighbor(cell: HexCell, direction: number): HexCell {
+	const normalizedDirection = ((direction % 6) + 6) % 6;
+	const delta = HEX_DIRECTIONS[normalizedDirection];
+	return {
+		q: cell.q + delta.q,
+		r: cell.r + delta.r
+	};
+}
+
+function hexNeighbors(cell: HexCell): HexCell[] {
+	return HEX_DIRECTIONS.map(delta => ({
+		q: cell.q + delta.q,
+		r: cell.r + delta.r
+	}));
+}
+
+function hexDistance(a: HexCell, b: HexCell): number {
+	const ac = hexToCube(a);
+	const bc = hexToCube(b);
+	return Math.max(
+		Math.abs(ac.q - bc.q),
+		Math.abs(ac.r - bc.r),
+		Math.abs(ac.s - bc.s)
+	);
+}
+
+function hexRing(cell: HexCell): number {
+	return hexDistance({ q: 0, r: 0 }, cell);
+}
+
+function isHexWithinRadius(cell: HexCell, radius: number): boolean {
+	return hexRing(cell) <= radius;
+}
+
+function isHexProtected(cell: HexCell, protectedRadius: number): boolean {
+	return hexRing(cell) <= protectedRadius;
+}
+
+function hexSector(cell: HexCell, size: number = 1): number {
+	if (cell.q === 0 && cell.r === 0) {
+		return -1;
+	}
+
+	const point = hexToWorld(cell, size);
+	let angle = Math.atan2(point.z, point.x);
+	if (angle < 0) {
+		angle += Math.PI * 2;
+	}
+
+	return Math.floor((angle + Math.PI / 6) / (Math.PI / 3)) % 6;
+}
+
+function hexKey(cell: HexCell): string {
+	return `${cell.q},${cell.r}`;
+}
+
+export {
+	HexCell,
+	HexCube,
+	WorldPoint2D,
+	HEX_DIRECTIONS,
+	hexToCube,
+	cubeToHex,
+	hexToWorld,
+	worldToFractionalHex,
+	roundHex,
+	worldToHex,
+	hexNeighbor,
+	hexNeighbors,
+	hexDistance,
+	hexRing,
+	isHexWithinRadius,
+	isHexProtected,
+	hexSector,
+	hexKey
+};

--- a/src/js/gameplay/hexGrid.ts
+++ b/src/js/gameplay/hexGrid.ts
@@ -44,14 +44,14 @@ function normalizedDirection(direction: number): number {
 	return ((integerDirection % 6) + 6) % 6;
 }
 
-const HEX_DIRECTIONS: HexCell[] = Object.freeze([
+const HEX_DIRECTIONS: ReadonlyArray<Readonly<HexCell>> = Object.freeze([
 	Object.freeze({ q: 1, r: 0 }),
 	Object.freeze({ q: 1, r: -1 }),
 	Object.freeze({ q: 0, r: -1 }),
 	Object.freeze({ q: -1, r: 0 }),
 	Object.freeze({ q: -1, r: 1 }),
 	Object.freeze({ q: 0, r: 1 })
-]) as HexCell[];
+]);
 
 function hexToCube(cell: HexCell): HexCube {
 	const q = finiteScalar(cell.q);


### PR DESCRIPTION
Refs #56, #52
Related: #30, #32, #47, #58, #59, #66

## Scope

Pure hex-grid topology only. No rendering, map mesh, tower placement, spawn behavior, camera, physics, audio, or balance changes.

## Change

Add `src/js/gameplay/hexGrid.ts` with a pointy-top axial-coordinate model:

- `HexCell` axial `(q, r)` and cube conversion;
- hex ↔ world x/z conversion;
- nearest-cell cube rounding for pointer/world hits;
- six canonical readonly neighbors;
- hex distance/ring calculation;
- configurable arena-radius membership;
- configurable protected core radius;
- deterministic six-sector classification around the central energy core;
- stable string cell keys;
- finite-safe handling of zero/invalid size, directions, coordinates and radii.

## Why

The current live game snaps x/z independently onto a 10-unit square lattice, hard-codes sixteen blocked central cells around a 40×40 square energy bank, and uses world x/z equality as cell identity. #56 proposes separating logical topology from continuous physics.

This module is the first low-risk seam for that migration. Hexes organize construction/territory/sector timing, while enemies/projectiles remain unconstrained continuous-world physics bodies.

It is intentionally dependency-free so the exact topology can be mirrored in the Rust `defend-core` / #67 runtime path.

## Orientation

This pass still uses a **pointy-top** orientation. Orientation remains provisional until the Storybook/browser fixture compares camera readability, tower footprint alignment, pointer ownership and arena masks. Changing orientation before production wiring remains cheap.

## Deterministic rounding rule

Cube rounding keeps the original draft's tie behavior but now documents it as protocol semantics. On exact equal rounding-error ties, correction prefers the later axis in q → r → s order (`s`, then `r`, then `q`).

This matters only on exact hex edges/vertices, but those are precisely the cases where TS/Rust implementations could otherwise disagree. The Rust mirror must use the same rule.

Logical operations canonicalize cells through this rounding rule before neighbor/distance/ring/key calculations, so accidental fractional coordinates do not create a second form of cell identity.

## Deterministic sectors without trigonometry

`hexSector()` no longer uses `atan2`. For pointy-top axial coordinates the six world-direction dot products reduce to exact linear scores:

- sector 0: `2q + r`
- sector 1: `q + 2r`
- sector 2: `-q + r`
- sector 3: `-2q - r`
- sector 4: `-q - 2r`
- sector 5: `q - r`

The highest score wins. Exact sector-boundary ties choose the lowest sector id because later equal scores do not replace the current winner.

Benefits:
- no floating-point angle normalization;
- no platform-specific trig boundary behavior;
- sector identity depends only on logical topology, not presentation scale;
- straightforward byte-for-byte TS/Rust parity;
- cheaper classification for wave/pressure/terrain/audio metadata.

The center remains sector `-1`.

## Numeric boundary

Zero/negative/non-finite hex sizes are normalized to a small positive magnitude before coordinate division. Invalid direction indices are normalized through finite integer modulo. Radius/protected-radius inputs are finite, nonnegative integers. Absurd/non-finite scalar state is saturated at an internal defensive ceiling so one malformed debug/input value cannot produce Infinity/NaN topology state.

These are robustness rules, not game-world size or balance limits.

## Readonly direction contract

`HEX_DIRECTIONS` is now both runtime-frozen and typed as `ReadonlyArray<Readonly<HexCell>>`. Consumers may enumerate/copy directions but should not mutate the canonical topology constants.

## Local validation before promotion

1. Confirm TypeScript 3.2 accepts the module, including `ReadonlyArray<Readonly<HexCell>>` and default parameters.
2. Property-check finite output for zero/negative/NaN/±Infinity size, coordinates, directions and radii.
3. Property-check round trips: cell → world → cell for a representative arena radius and several positive/negative sizes.
4. Verify exact edge/vertex fixtures follow the documented cube-round tie convention.
5. Verify every canonical cell has six unique reciprocal neighbors.
6. Verify direction wrapping for negative, >5 and non-integer direction values is deterministic.
7. Verify ring counts are `1` for radius 0 and `6r` cells on each ring `r > 0`.
8. Verify radius/protected-radius membership is invariant for equivalent canonical cells.
9. Verify the six axial sector directions map to sectors 0…5 respectively.
10. Verify exact sector-boundary cells choose the documented lowest-id tie winner and sector classification is independent of positive hex size.
11. Verify sector classification rotated by one canonical 60° hex direction advances coherently modulo 6.
12. Render a Storybook/browser overlay after #65 certification and compare pointy-top vs flat-top readability before wiring placement.
13. Mirror coordinate conversion, cube rounding, neighbors, distance/rings, sector scores/tie rules and key serialization in Rust; compare exhaustive fixtures for a bounded radius.
14. Use the same topology fixtures when #59 moves to six-neighbor terrain updates so neighbor order/topology does not drift between TS and Rust.

## Gameplay impact

None. This file is not imported by production code.

Keep as draft until topology fixtures and camera/interaction testing are posted.