### PR TITLE
Define bounded terrain deformation primitives

### DIFF
--- a/src/js/gameplay/terrainDeformation.ts
+++ b/src/js/gameplay/terrainDeformation.ts
@@ -24,14 +24,36 @@ export interface TerrainImpactProfile {
 	footprintRadius: number;
 }
 
+export interface TerrainDepthBounds {
+	minimum: number;
+	maximum: number;
+	/** False means the supplied neighbor snapshot already violates the slope cap. */
+	consistent: boolean;
+}
+
 const LN2 = Math.log(2);
+const MAX_TERRAIN_SCALAR = 1e100;
+
+function finiteScalar(value: number, fallback = 0): number {
+	if (value !== value) {
+		return fallback;
+	}
+	if (value > MAX_TERRAIN_SCALAR) {
+		return MAX_TERRAIN_SCALAR;
+	}
+	if (value < -MAX_TERRAIN_SCALAR) {
+		return -MAX_TERRAIN_SCALAR;
+	}
+	return value;
+}
 
 function clamp(value: number, minimum: number, maximum: number): number {
-	return Math.max(minimum, Math.min(maximum, value));
+	const safeValue = finiteScalar(value, minimum);
+	return Math.max(minimum, Math.min(maximum, safeValue));
 }
 
 function positive(value: number): number {
-	return Math.max(0, value);
+	return Math.max(0, finiteScalar(value, 0));
 }
 
 /**
@@ -43,7 +65,9 @@ export function terrainImpactEnergy(
 	effectiveMass: number,
 	normalSpeed: number
 ): number {
-	return 0.5 * positive(effectiveMass) * Math.pow(Math.abs(normalSpeed), 2);
+	const mass = positive(effectiveMass);
+	const speed = Math.abs(finiteScalar(normalSpeed));
+	return positive(finiteScalar(0.5 * mass * Math.pow(speed, 2)));
 }
 
 /**
@@ -59,31 +83,30 @@ export function terrainImpactProfile(
 	const energy = terrainImpactEnergy(impact.effectiveMass, impact.normalSpeed);
 	const compliance = positive(impact.compliance);
 	const stabilization = clamp(impact.stabilization, 0, 1);
-	const depthEnergyScale = Math.max(1, calibration.energyForMaxDepth);
-	const radiusEnergyScale = Math.max(1, calibration.energyForMaxRadius);
-	const normalizedDepthEnergy = (energy * compliance) / depthEnergyScale;
-	const normalizedRadiusEnergy = Math.log(1 + energy / radiusEnergyScale);
-	const depth =
-		positive(calibration.maxDepth) *
-		Math.tanh(normalizedDepthEnergy) *
-		(1 - stabilization);
-	const baseRadius = Math.max(
-		positive(calibration.minFootprintRadius),
-		positive(impact.bodyRadius)
+	const depthEnergyScale = Math.max(1, positive(calibration.energyForMaxDepth));
+	const radiusEnergyScale = Math.max(1, positive(calibration.energyForMaxRadius));
+	const normalizedDepthEnergy = positive(
+		finiteScalar((energy * compliance) / depthEnergyScale)
 	);
-	const radius = baseRadius * (1 + normalizedRadiusEnergy);
+	const normalizedRadiusEnergy = positive(
+		finiteScalar(Math.log(1 + energy / radiusEnergyScale))
+	);
+	const maximumDepth = positive(calibration.maxDepth);
+	const depth = finiteScalar(
+		maximumDepth * Math.tanh(normalizedDepthEnergy) * (1 - stabilization)
+	);
+	const minimumRadius = positive(calibration.minFootprintRadius);
+	const maximumRadius = Math.max(
+		minimumRadius,
+		positive(calibration.maxFootprintRadius)
+	);
+	const baseRadius = Math.max(minimumRadius, positive(impact.bodyRadius));
+	const radius = finiteScalar(baseRadius * (1 + normalizedRadiusEnergy));
 
 	return {
 		energy,
-		depth: clamp(depth, 0, positive(calibration.maxDepth)),
-		footprintRadius: clamp(
-			radius,
-			positive(calibration.minFootprintRadius),
-			Math.max(
-				positive(calibration.minFootprintRadius),
-				positive(calibration.maxFootprintRadius)
-			)
-		)
+		depth: clamp(depth, 0, maximumDepth),
+		footprintRadius: clamp(radius, minimumRadius, maximumRadius)
 	};
 }
 
@@ -95,7 +118,7 @@ export function radialDeformationDepth(
 	distanceFromImpact: number,
 	profile: TerrainImpactProfile
 ): number {
-	const radius = Math.max(0.0001, profile.footprintRadius);
+	const radius = Math.max(0.0001, positive(profile.footprintRadius));
 	const distance = positive(distanceFromImpact);
 	if (distance >= radius) {
 		return 0;
@@ -103,7 +126,7 @@ export function radialDeformationDepth(
 
 	const normalizedDistance = distance / radius;
 	const smooth = 1 - normalizedDistance * normalizedDistance;
-	return profile.depth * smooth * smooth;
+	return positive(finiteScalar(positive(profile.depth) * smooth * smooth));
 }
 
 /**
@@ -124,13 +147,100 @@ export function accumulateDepression(
 	const remaining = limit - current;
 	const addition = positive(addedDepth);
 	const diminishingAddition = remaining * (1 - Math.exp(-addition / limit));
-	return clamp(current + diminishingAddition, 0, limit);
+	return clamp(finiteScalar(current + diminishingAddition), 0, limit);
 }
 
 /**
- * Limit the depth difference between two neighboring terrain samples. Applying
- * this against every neighbor prevents a narrow pit or ridge from exceeding the
- * configured rise/run slope while retaining a separate absolute depth cap.
+ * Compute the depth interval that satisfies the configured slope against a
+ * snapshot of neighboring samples.
+ *
+ * This must be evaluated from one immutable field snapshot. Mutating a cell and
+ * then feeding that result into the next neighbor would make the outcome depend
+ * on neighbor iteration order, which is especially undesirable for deterministic
+ * replay and six-neighbor hex updates.
+ *
+ * If the neighboring snapshot is already mutually inconsistent, no single value
+ * can satisfy every pairwise slope constraint. In that case `consistent` is
+ * false and the returned minimum/maximum preserve the conflicting bounds so the
+ * caller can apply the deterministic minimax fallback in
+ * `limitDepthByNeighborSlopes()` while diffusion/recovery resolves the field.
+ */
+export function terrainDepthBoundsFromNeighbors(
+	neighborDepths: number[],
+	sampleSpacing: number,
+	maxSlope: number,
+	maxDepth: number
+): TerrainDepthBounds {
+	const depthLimit = positive(maxDepth);
+	const spacing = positive(sampleSpacing);
+	if (depthLimit === 0) {
+		return { minimum: 0, maximum: 0, consistent: true };
+	}
+	if (spacing === 0 || neighborDepths.length === 0) {
+		return { minimum: 0, maximum: depthLimit, consistent: true };
+	}
+
+	const maximumDifference = positive(finiteScalar(spacing * positive(maxSlope)));
+	let minimumAllowed = 0;
+	let maximumAllowed = depthLimit;
+
+	neighborDepths.forEach(neighborDepth => {
+		const neighbor = clamp(neighborDepth, 0, depthLimit);
+		minimumAllowed = Math.max(
+			minimumAllowed,
+			Math.max(0, neighbor - maximumDifference)
+		);
+		maximumAllowed = Math.min(
+			maximumAllowed,
+			Math.min(depthLimit, neighbor + maximumDifference)
+		);
+	});
+
+	return {
+		minimum: minimumAllowed,
+		maximum: maximumAllowed,
+		consistent: minimumAllowed <= maximumAllowed
+	};
+}
+
+/**
+ * Order-independent slope limiting against all neighbors from one field
+ * snapshot. For an already-inconsistent neighbor set, return the midpoint of
+ * the conflicting bounds. That midpoint minimizes the worst symmetric bound
+ * violation deterministically; subsequent snapshot-based diffusion/slope passes
+ * can then converge without depending on neighbor iteration order.
+ */
+export function limitDepthByNeighborSlopes(
+	currentDepth: number,
+	neighborDepths: number[],
+	sampleSpacing: number,
+	maxSlope: number,
+	maxDepth: number
+): number {
+	const depthLimit = positive(maxDepth);
+	const current = clamp(currentDepth, 0, depthLimit);
+	const bounds = terrainDepthBoundsFromNeighbors(
+		neighborDepths,
+		sampleSpacing,
+		maxSlope,
+		depthLimit
+	);
+
+	if (bounds.consistent) {
+		return clamp(current, bounds.minimum, bounds.maximum);
+	}
+
+	return clamp(
+		finiteScalar((bounds.minimum + bounds.maximum) / 2),
+		0,
+		depthLimit
+	);
+}
+
+/**
+ * Pairwise compatibility helper. Field implementations should prefer
+ * `limitDepthByNeighborSlopes()` so all neighbor constraints are evaluated from
+ * one immutable snapshot rather than sequential mutation order.
  */
 export function limitDepthBySlope(
 	currentDepth: number,
@@ -139,17 +249,13 @@ export function limitDepthBySlope(
 	maxSlope: number,
 	maxDepth: number
 ): number {
-	const spacing = positive(sampleSpacing);
-	const depthLimit = positive(maxDepth);
-	if (spacing === 0 || depthLimit === 0) {
-		return clamp(currentDepth, 0, depthLimit);
-	}
-
-	const neighbor = clamp(neighborDepth, 0, depthLimit);
-	const maximumDifference = spacing * positive(maxSlope);
-	const minimumAllowed = Math.max(0, neighbor - maximumDifference);
-	const maximumAllowed = Math.min(depthLimit, neighbor + maximumDifference);
-	return clamp(currentDepth, minimumAllowed, maximumAllowed);
+	return limitDepthByNeighborSlopes(
+		currentDepth,
+		[neighborDepth],
+		sampleSpacing,
+		maxSlope,
+		maxDepth
+	);
 }
 
 /**
@@ -162,11 +268,12 @@ export function structuralStabilization(
 	strength: number
 ): number {
 	const radius = positive(stabilizationRadius);
-	if (radius === 0 || distanceFromStructure >= radius) {
+	const distance = positive(distanceFromStructure);
+	if (radius === 0 || distance >= radius) {
 		return 0;
 	}
 
-	const normalizedDistance = positive(distanceFromStructure) / radius;
+	const normalizedDistance = distance / radius;
 	const smooth = 1 - normalizedDistance * normalizedDistance;
 	return clamp(strength, 0, 1) * smooth * smooth;
 }
@@ -181,10 +288,10 @@ export function relaxDepression(
 	stabilization: number,
 	calibration: TerrainDeformationCalibration
 ): number {
-	const baseHalfLife = Math.max(1, calibration.baseRecoveryHalfLifeMs);
+	const baseHalfLife = Math.max(1, positive(calibration.baseRecoveryHalfLifeMs));
 	const minimumHalfLife = Math.max(
 		1,
-		Math.min(baseHalfLife, calibration.minimumRecoveryHalfLifeMs)
+		Math.min(baseHalfLife, positive(calibration.minimumRecoveryHalfLifeMs))
 	);
 	const stabilizedHalfLife =
 		baseHalfLife -
@@ -192,7 +299,7 @@ export function relaxDepression(
 	const decay = Math.exp(
 		(-LN2 * positive(deltaTimeMs)) / Math.max(1, stabilizedHalfLife)
 	);
-	return positive(currentDepth) * decay;
+	return positive(finiteScalar(positive(currentDepth) * decay));
 }
 
 /**
@@ -207,13 +314,18 @@ export function diffuseDepression(
 	stabilization: number,
 	calibration: TerrainDeformationCalibration
 ): number {
+	const current = positive(currentDepth);
+	const neighborAverage = positive(neighborAverageDepth);
 	const rate =
 		positive(calibration.diffusionPerSecond) *
 		(1 + clamp(stabilization, 0, 1));
-	const blend = 1 - Math.exp(-rate * positive(deltaTimeMs) / 1000);
-	return Math.max(
+	const blend = clamp(
+		1 - Math.exp(-rate * positive(deltaTimeMs) / 1000),
 		0,
-		currentDepth + (positive(neighborAverageDepth) - currentDepth) * blend
+		1
+	);
+	return positive(
+		finiteScalar(current + (neighborAverage - current) * blend)
 	);
 }
 
@@ -229,15 +341,39 @@ export function settleSupportHeight(
 	halfLifeMs: number,
 	maxSpeed: number
 ): number {
-	const dtSeconds = positive(deltaTimeMs) / 1000;
+	const current = finiteScalar(currentHeight);
+	const target = finiteScalar(targetHeight, current);
+	const dtMs = positive(deltaTimeMs);
+	const dtSeconds = dtMs / 1000;
 	if (dtSeconds === 0) {
-		return currentHeight;
+		return current;
 	}
 
-	const halfLife = Math.max(1, halfLifeMs);
-	const blend = 1 - Math.exp((-LN2 * positive(deltaTimeMs)) / halfLife);
-	const desiredChange = (targetHeight - currentHeight) * blend;
-	const maximumChange = positive(maxSpeed) * dtSeconds;
+	const halfLife = Math.max(1, positive(halfLifeMs));
+	const blend = clamp(1 - Math.exp((-LN2 * dtMs) / halfLife), 0, 1);
+	const desiredChange = finiteScalar((target - current) * blend);
+	const maximumChange = positive(finiteScalar(positive(maxSpeed) * dtSeconds));
 	const appliedChange = clamp(desiredChange, -maximumChange, maximumChange);
-	return currentHeight + appliedChange;
+	return finiteScalar(current + appliedChange, current);
+}
+
+/**
+ * Calibration-aware support follower. This prevents `maxSupportSpeed` from
+ * becoming a disconnected configuration value while retaining the generic
+ * `settleSupportHeight()` primitive for fixtures that need an explicit cap.
+ */
+export function settleCalibratedSupportHeight(
+	currentHeight: number,
+	targetHeight: number,
+	deltaTimeMs: number,
+	halfLifeMs: number,
+	calibration: TerrainDeformationCalibration
+): number {
+	return settleSupportHeight(
+		currentHeight,
+		targetHeight,
+		deltaTimeMs,
+		halfLifeMs,
+		calibration.maxSupportSpeed
+	);
 }

--- a/src/js/gameplay/terrainDeformation.ts
+++ b/src/js/gameplay/terrainDeformation.ts
@@ -35,15 +35,15 @@ function positive(value: number): number {
 }
 
 /**
- * Kinetic energy normal to the terrain. This is intentionally the same
- * physically meaningful scalar used by the acoustic work so terrain and sound
- * can react to one collision description without becoming coupled systems.
+ * Kinetic energy normal to the terrain. normalSpeed is treated as a magnitude
+ * so callers may pass either a signed contact-normal velocity or an absolute
+ * speed without changing the result.
  */
 export function terrainImpactEnergy(
 	effectiveMass: number,
 	normalSpeed: number
 ): number {
-	return 0.5 * positive(effectiveMass) * Math.pow(positive(normalSpeed), 2);
+	return 0.5 * positive(effectiveMass) * Math.pow(Math.abs(normalSpeed), 2);
 }
 
 /**
@@ -125,6 +125,31 @@ export function accumulateDepression(
 	const addition = positive(addedDepth);
 	const diminishingAddition = remaining * (1 - Math.exp(-addition / limit));
 	return clamp(current + diminishingAddition, 0, limit);
+}
+
+/**
+ * Limit the depth difference between two neighboring terrain samples. Applying
+ * this against every neighbor prevents a narrow pit or ridge from exceeding the
+ * configured rise/run slope while retaining a separate absolute depth cap.
+ */
+export function limitDepthBySlope(
+	currentDepth: number,
+	neighborDepth: number,
+	sampleSpacing: number,
+	maxSlope: number,
+	maxDepth: number
+): number {
+	const spacing = positive(sampleSpacing);
+	const depthLimit = positive(maxDepth);
+	if (spacing === 0 || depthLimit === 0) {
+		return clamp(currentDepth, 0, depthLimit);
+	}
+
+	const neighbor = clamp(neighborDepth, 0, depthLimit);
+	const maximumDifference = spacing * positive(maxSlope);
+	const minimumAllowed = Math.max(0, neighbor - maximumDifference);
+	const maximumAllowed = Math.min(depthLimit, neighbor + maximumDifference);
+	return clamp(currentDepth, minimumAllowed, maximumAllowed);
 }
 
 /**

--- a/src/js/gameplay/terrainDeformation.ts
+++ b/src/js/gameplay/terrainDeformation.ts
@@ -1,0 +1,218 @@
+export interface TerrainDeformationCalibration {
+	maxDepth: number;
+	minFootprintRadius: number;
+	maxFootprintRadius: number;
+	energyForMaxDepth: number;
+	energyForMaxRadius: number;
+	baseRecoveryHalfLifeMs: number;
+	minimumRecoveryHalfLifeMs: number;
+	diffusionPerSecond: number;
+	maxSupportSpeed: number;
+}
+
+export interface TerrainImpact {
+	effectiveMass: number;
+	normalSpeed: number;
+	bodyRadius: number;
+	compliance: number;
+	stabilization: number;
+}
+
+export interface TerrainImpactProfile {
+	energy: number;
+	depth: number;
+	footprintRadius: number;
+}
+
+const LN2 = Math.log(2);
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, value));
+}
+
+function positive(value: number): number {
+	return Math.max(0, value);
+}
+
+/**
+ * Kinetic energy normal to the terrain. This is intentionally the same
+ * physically meaningful scalar used by the acoustic work so terrain and sound
+ * can react to one collision description without becoming coupled systems.
+ */
+export function terrainImpactEnergy(
+	effectiveMass: number,
+	normalSpeed: number
+): number {
+	return 0.5 * positive(effectiveMass) * Math.pow(positive(normalSpeed), 2);
+}
+
+/**
+ * Produce a bounded deformation profile. Energy increases depth only through a
+ * saturating tanh response while body size and energy primarily broaden the
+ * affected footprint. Structural stabilization reduces depth without changing
+ * the incoming collision energy.
+ */
+export function terrainImpactProfile(
+	impact: TerrainImpact,
+	calibration: TerrainDeformationCalibration
+): TerrainImpactProfile {
+	const energy = terrainImpactEnergy(impact.effectiveMass, impact.normalSpeed);
+	const compliance = positive(impact.compliance);
+	const stabilization = clamp(impact.stabilization, 0, 1);
+	const depthEnergyScale = Math.max(1, calibration.energyForMaxDepth);
+	const radiusEnergyScale = Math.max(1, calibration.energyForMaxRadius);
+	const normalizedDepthEnergy = (energy * compliance) / depthEnergyScale;
+	const normalizedRadiusEnergy = Math.log(1 + energy / radiusEnergyScale);
+	const depth =
+		positive(calibration.maxDepth) *
+		Math.tanh(normalizedDepthEnergy) *
+		(1 - stabilization);
+	const baseRadius = Math.max(
+		positive(calibration.minFootprintRadius),
+		positive(impact.bodyRadius)
+	);
+	const radius = baseRadius * (1 + normalizedRadiusEnergy);
+
+	return {
+		energy,
+		depth: clamp(depth, 0, positive(calibration.maxDepth)),
+		footprintRadius: clamp(
+			radius,
+			positive(calibration.minFootprintRadius),
+			Math.max(
+				positive(calibration.minFootprintRadius),
+				positive(calibration.maxFootprintRadius)
+			)
+		)
+	};
+}
+
+/**
+ * Smooth radial depression kernel. Returns a positive depth contribution; the
+ * caller may store ground displacement as a negative height if desired.
+ */
+export function radialDeformationDepth(
+	distanceFromImpact: number,
+	profile: TerrainImpactProfile
+): number {
+	const radius = Math.max(0.0001, profile.footprintRadius);
+	const distance = positive(distanceFromImpact);
+	if (distance >= radius) {
+		return 0;
+	}
+
+	const normalizedDistance = distance / radius;
+	const smooth = 1 - normalizedDistance * normalizedDistance;
+	return profile.depth * smooth * smooth;
+}
+
+/**
+ * Accumulate a new depression while respecting the global depth cap. Existing
+ * displacement is represented as a positive depression depth.
+ */
+export function accumulateDepression(
+	currentDepth: number,
+	addedDepth: number,
+	maxDepth: number
+): number {
+	const limit = positive(maxDepth);
+	if (limit === 0) {
+		return 0;
+	}
+
+	const current = clamp(currentDepth, 0, limit);
+	const remaining = limit - current;
+	const addition = positive(addedDepth);
+	const diminishingAddition = remaining * (1 - Math.exp(-addition / limit));
+	return clamp(current + diminishingAddition, 0, limit);
+}
+
+/**
+ * Foundation influence. The result is 0 outside the stabilization radius and
+ * approaches strength at the structure center with a smooth falloff.
+ */
+export function structuralStabilization(
+	distanceFromStructure: number,
+	stabilizationRadius: number,
+	strength: number
+): number {
+	const radius = positive(stabilizationRadius);
+	if (radius === 0 || distanceFromStructure >= radius) {
+		return 0;
+	}
+
+	const normalizedDistance = positive(distanceFromStructure) / radius;
+	const smooth = 1 - normalizedDistance * normalizedDistance;
+	return clamp(strength, 0, 1) * smooth * smooth;
+}
+
+/**
+ * Frame-rate independent recovery toward baseline. Stabilization shortens the
+ * half-life but never below the configured minimum.
+ */
+export function relaxDepression(
+	currentDepth: number,
+	deltaTimeMs: number,
+	stabilization: number,
+	calibration: TerrainDeformationCalibration
+): number {
+	const baseHalfLife = Math.max(1, calibration.baseRecoveryHalfLifeMs);
+	const minimumHalfLife = Math.max(
+		1,
+		Math.min(baseHalfLife, calibration.minimumRecoveryHalfLifeMs)
+	);
+	const stabilizedHalfLife =
+		baseHalfLife -
+		(baseHalfLife - minimumHalfLife) * clamp(stabilization, 0, 1);
+	const decay = Math.exp(
+		(-LN2 * positive(deltaTimeMs)) / Math.max(1, stabilizedHalfLife)
+	);
+	return positive(currentDepth) * decay;
+}
+
+/**
+ * Diffuse a sample toward the mean of its neighboring terrain samples. A hex
+ * field can pass the average of its six neighbors; another topology can use the
+ * same semantic function without changing the deformation model.
+ */
+export function diffuseDepression(
+	currentDepth: number,
+	neighborAverageDepth: number,
+	deltaTimeMs: number,
+	stabilization: number,
+	calibration: TerrainDeformationCalibration
+): number {
+	const rate =
+		positive(calibration.diffusionPerSecond) *
+		(1 + clamp(stabilization, 0, 1));
+	const blend = 1 - Math.exp(-rate * positive(deltaTimeMs) / 1000);
+	return Math.max(
+		0,
+		currentDepth + (positive(neighborAverageDepth) - currentDepth) * blend
+	);
+}
+
+/**
+ * Damped support-height follower for towers, walls, the core and camera target.
+ * This does not move anything laterally and caps vertical speed so a single
+ * impact cannot produce a visible snap.
+ */
+export function settleSupportHeight(
+	currentHeight: number,
+	targetHeight: number,
+	deltaTimeMs: number,
+	halfLifeMs: number,
+	maxSpeed: number
+): number {
+	const dtSeconds = positive(deltaTimeMs) / 1000;
+	if (dtSeconds === 0) {
+		return currentHeight;
+	}
+
+	const halfLife = Math.max(1, halfLifeMs);
+	const blend = 1 - Math.exp((-LN2 * positive(deltaTimeMs)) / halfLife);
+	const desiredChange = (targetHeight - currentHeight) * blend;
+	const maximumChange = positive(maxSpeed) * dtSeconds;
+	const appliedChange = clamp(desiredChange, -maximumChange, maximumChange);
+	return currentHeight + appliedChange;
+}


### PR DESCRIPTION
Refs #58
Related: #52, #53, #56, #57, #66

## Scope

Pure terrain-deformation math only. No production ground mesh mutation, collision changes, structure movement, camera movement, audio output, or gameplay balance changes.

## Change

Add `src/js/gameplay/terrainDeformation.ts` with renderer/physics-independent primitives for:

- physically meaningful normal-impact energy;
- bounded impact depth and footprint calculation;
- smooth radial deformation deposition;
- repeated-impact accumulation with diminishing returns at a hard depth cap;
- finite-safe handling of malformed/extreme numeric state;
- structure stabilization weighting;
- frame-rate-independent vertical recovery toward baseline;
- lateral diffusion toward neighboring terrain samples;
- pairwise slope limiting plus order-independent multi-neighbor slope bounds;
- damped/capped support-height settling for towers, walls, the core, and camera target;
- calibration-aware support settling using `maxSupportSpeed`.

## Important behavior

The model intentionally makes mass/energy broaden the affected area more readily than deepen it. Maximum depth is always explicit and repeated impacts cannot accumulate without bound.

The functions do not assume a square or hex grid. A future hex field can pass the mean of its six neighbors to `diffuseDepression()` and the same six-neighbor snapshot to `limitDepthByNeighborSlopes()`.

`terrainImpactEnergy()` uses the same scalar physical concept as #53's acoustic work so terrain and sound may react coherently to one collision description without either subsystem becoming authoritative over the other.

## Deterministic slope rule

Sequentially mutating one sample against neighbor A, then feeding that result into neighbor B, makes slope limiting depend on neighbor iteration order. That would undermine deterministic replay and make future six-neighbor hex updates fragile.

The module now exposes:
- `terrainDepthBoundsFromNeighbors()` to compute the allowed depth interval from one immutable neighbor snapshot;
- `limitDepthByNeighborSlopes()` to apply those bounds once, independent of neighbor ordering;
- `limitDepthBySlope()` retained as a pairwise compatibility wrapper.

If the neighboring snapshot is itself inconsistent (no single depth can satisfy every pairwise slope cap), the multi-neighbor helper returns the midpoint of the conflicting bounds. This deterministic minimax fallback reduces the worst symmetric violation; subsequent snapshot-based diffusion/slope passes are expected to converge. It does not pretend an impossible local constraint set was satisfied.

## Numeric boundary

Pure terrain helpers now sanitize malformed values and saturate absurd scalar magnitudes at an internal defensive ceiling. Ordinary game values are vastly below this ceiling. The goal is only to guarantee finite state propagation when a physics/contact/debug input is briefly invalid; this is not a gameplay/world-size limit.

## Support settlement

`settleSupportHeight()` remains the generic primitive with an explicit speed cap. `settleCalibratedSupportHeight()` now routes `TerrainDeformationCalibration.maxSupportSpeed` through that primitive so the calibration field is not disconnected from the model.

## Not included

- no Babylon mesh edits;
- no Cannon heightfield/trimesh work;
- no Rapier dependency;
- no calibration constants wired into production;
- no automatic tower/core/camera settling yet;
- no visual crater effects;
- no persistence/serialization wiring.

## Local validation before promotion

1. Confirm TypeScript 3.2 accepts the file.
2. Property-test every public function across zero/extreme/NaN/±Infinity mass, speed, compliance, stabilization, timing, slope and support inputs; outputs must remain finite.
3. Verify depth is monotonic with energy but never exceeds `maxDepth`.
4. Verify increasing body radius/energy broadens footprint while depth remains saturated.
5. Repeated deposits at one point must asymptotically approach, never exceed, `maxDepth`.
6. Recovery should respect configured half-life independent of frame step.
7. Stabilized samples should recover faster but remain continuous.
8. Diffusion must reduce sharp local differences without producing negative depth.
9. `settleSupportHeight()` and `settleCalibratedSupportHeight()` must obey maximum vertical speed and not snap on large target changes.
10. For a consistent neighbor snapshot, verify `limitDepthByNeighborSlopes()` is invariant under all neighbor permutations and satisfies every pairwise slope cap.
11. For an inconsistent neighbor snapshot, verify the result is permutation-invariant, bounded, and equals the midpoint of the conflicting aggregate bounds.
12. Run repeated six-neighbor snapshot-based slope + diffusion passes and verify convergence/no oscillatory order artifact on sharp synthetic pits/ridges.
13. Mirror these pure functions in the Rust `defend-core`/runtime path once #55/#67 are ready, then compare deterministic fixtures.
14. Build the Storybook terrain playground after #65 is certified; visualize raw deposits, aggregate slope bounds, diffusion/recovery, stabilization and support settlement separately.

## Gameplay impact

None in this PR. This module is not imported by production code.

Keep as draft until local numeric/property fixtures are posted and initial deformation calibration is informed by browser physics experiments.