### PR TITLE
Define object-based spatial audio primitives

### DIFF
--- a/src/js/audio/spatialAudio.ts
+++ b/src/js/audio/spatialAudio.ts
@@ -67,39 +67,79 @@ export interface SpatialRenderHints {
 	priority: number;
 }
 
+/**
+ * Defensive numeric ceiling for this pure boundary. Real Defend world-space
+ * values are many orders of magnitude smaller; the ceiling only prevents
+ * malformed Infinity/NaN or absurd external state from poisoning an audio
+ * planning pass with non-finite output.
+ */
+const MAX_SPATIAL_SCALAR = 1e150;
+
+function finiteScalar(value: number, fallback = 0): number {
+	if (value !== value) {
+		return fallback;
+	}
+	if (value > MAX_SPATIAL_SCALAR) {
+		return MAX_SPATIAL_SCALAR;
+	}
+	if (value < -MAX_SPATIAL_SCALAR) {
+		return -MAX_SPATIAL_SCALAR;
+	}
+	return value;
+}
+
 function clamp(value: number, minimum: number, maximum: number): number {
-	return Math.max(minimum, Math.min(maximum, value));
+	const safeValue = finiteScalar(value, minimum);
+	return Math.max(minimum, Math.min(maximum, safeValue));
 }
 
 function positive(value: number): number {
-	return Math.max(0, value);
+	return Math.max(0, finiteScalar(value, 0));
 }
 
 function subtract(a: SpatialVector3, b: SpatialVector3): SpatialVector3 {
 	return {
-		x: a.x - b.x,
-		y: a.y - b.y,
-		z: a.z - b.z
+		x: finiteScalar(finiteScalar(a.x) - finiteScalar(b.x)),
+		y: finiteScalar(finiteScalar(a.y) - finiteScalar(b.y)),
+		z: finiteScalar(finiteScalar(a.z) - finiteScalar(b.z))
 	};
 }
 
 function dot(a: SpatialVector3, b: SpatialVector3): number {
-	return a.x * b.x + a.y * b.y + a.z * b.z;
+	return finiteScalar(
+		finiteScalar(a.x) * finiteScalar(b.x) +
+			finiteScalar(a.y) * finiteScalar(b.y) +
+			finiteScalar(a.z) * finiteScalar(b.z)
+	);
 }
 
 function magnitudeSquared(vector: SpatialVector3): number {
-	return dot(vector, vector);
+	return positive(dot(vector, vector));
 }
 
 function magnitude(vector: SpatialVector3): number {
-	return Math.sqrt(magnitudeSquared(vector));
+	return finiteScalar(Math.sqrt(magnitudeSquared(vector)), MAX_SPATIAL_SCALAR);
 }
 
 function scale(vector: SpatialVector3, amount: number): SpatialVector3 {
+	const safeAmount = finiteScalar(amount);
 	return {
-		x: vector.x * amount,
-		y: vector.y * amount,
-		z: vector.z * amount
+		x: finiteScalar(finiteScalar(vector.x) * safeAmount),
+		y: finiteScalar(finiteScalar(vector.y) * safeAmount),
+		z: finiteScalar(finiteScalar(vector.z) * safeAmount)
+	};
+}
+
+function addScaled(
+	position: SpatialVector3,
+	velocity: SpatialVector3,
+	timeSeconds: number
+): SpatialVector3 {
+	const time = finiteScalar(timeSeconds);
+	return {
+		x: finiteScalar(finiteScalar(position.x) + finiteScalar(velocity.x) * time),
+		y: finiteScalar(finiteScalar(position.y) + finiteScalar(velocity.y) * time),
+		z: finiteScalar(finiteScalar(position.z) + finiteScalar(velocity.z) * time)
 	};
 }
 
@@ -135,17 +175,17 @@ export function closestApproach(
 
 	if (velocitySquared > 0.000001) {
 		timeSeconds = clamp(
-			-dot(relativePosition, relativeVelocity) / velocitySquared,
+			finiteScalar(-dot(relativePosition, relativeVelocity) / velocitySquared),
 			0,
 			horizon
 		);
 	}
 
-	const positionAtClosest = {
-		x: relativePosition.x + relativeVelocity.x * timeSeconds,
-		y: relativePosition.y + relativeVelocity.y * timeSeconds,
-		z: relativePosition.z + relativeVelocity.z * timeSeconds
-	};
+	const positionAtClosest = addScaled(
+		relativePosition,
+		relativeVelocity,
+		timeSeconds
+	);
 
 	return {
 		timeSeconds,
@@ -180,9 +220,10 @@ export function dopplerState(
 	}
 
 	const speedOfSound = Math.max(0.0001, positive(calibration.speedOfSound));
-	const radialLimit =
+	const radialLimit = finiteScalar(
 		speedOfSound *
-		clamp(calibration.maxRadialFractionOfSoundSpeed, 0, 0.95);
+			clamp(calibration.maxRadialFractionOfSoundSpeed, 0, 0.95)
+	);
 	const listenerTowardSource = clamp(
 		dot(listenerVelocity, direction),
 		-radialLimit,
@@ -193,13 +234,16 @@ export function dopplerState(
 		-radialLimit,
 		radialLimit
 	);
-	const numerator = speedOfSound + listenerTowardSource;
+	const numerator = finiteScalar(speedOfSound + listenerTowardSource);
 	const denominator = Math.max(
 		speedOfSound * 0.05,
-		speedOfSound + sourceAwayFromListener
+		finiteScalar(speedOfSound + sourceAwayFromListener)
 	);
-	const minimumRatio = Math.max(0.01, calibration.minDopplerRatio);
-	const maximumRatio = Math.max(minimumRatio, calibration.maxDopplerRatio);
+	const minimumRatio = Math.max(0.01, positive(calibration.minDopplerRatio));
+	const maximumRatio = Math.max(
+		minimumRatio,
+		positive(calibration.maxDopplerRatio)
+	);
 
 	return {
 		ratio: clamp(numerator / denominator, minimumRatio, maximumRatio),
@@ -225,7 +269,7 @@ export function distanceGain(
 		positive(distance) / reference - 1
 	);
 	const exponent = Math.max(0.0001, positive(rolloffExponent));
-	return 1 / (1 + Math.pow(normalizedBeyondReference, exponent));
+	return clamp(1 / (1 + Math.pow(normalizedBeyondReference, exponent)), 0, 1);
 }
 
 /**
@@ -241,7 +285,11 @@ export function highFrequencyRetention(
 		0,
 		positive(distance) - positive(referenceDistance)
 	);
-	return Math.exp(-positive(absorptionPerUnit) * beyondReference);
+	return clamp(
+		Math.exp(-positive(absorptionPerUnit) * beyondReference),
+		0,
+		1
+	);
 }
 
 /**
@@ -278,7 +326,7 @@ export function spatialPriority(
 	const closestApproachScore = closestProximity * (0.5 + 0.5 * imminence);
 	const energyReference = Math.max(0.0001, positive(calibration.energyReference));
 	const energy = positive(source.excitationEnergy);
-	const energyScore = energy / (energy + energyReference);
+	const energyScore = clamp(energy / finiteScalar(energy + energyReference), 0, 1);
 	const threat = clamp(source.threat, 0, 1);
 	const continuity = clamp(source.continuity, 0, 1);
 	const proximityWeight = positive(calibration.proximityWeight);
@@ -286,27 +334,27 @@ export function spatialPriority(
 	const energyWeight = positive(calibration.energyWeight);
 	const threatWeight = positive(calibration.threatWeight);
 	const continuityWeight = positive(calibration.continuityWeight);
-	const totalWeight =
+	const totalWeight = finiteScalar(
 		proximityWeight +
-		closestWeight +
-		energyWeight +
-		threatWeight +
-		continuityWeight;
+			closestWeight +
+			energyWeight +
+			threatWeight +
+			continuityWeight
+	);
 
 	if (totalWeight <= 0.000001) {
 		return 0;
 	}
 
-	return clamp(
-		(proximity * proximityWeight +
+	const weightedPriority = finiteScalar(
+		proximity * proximityWeight +
 			closestApproachScore * closestWeight +
 			energyScore * energyWeight +
 			threat * threatWeight +
-			continuity * continuityWeight) /
-			totalWeight,
-		0,
-		1
+			continuity * continuityWeight
 	);
+
+	return clamp(weightedPriority / totalWeight, 0, 1);
 }
 
 export function spatialRenderHints(

--- a/src/js/audio/spatialAudio.ts
+++ b/src/js/audio/spatialAudio.ts
@@ -1,0 +1,340 @@
+export interface SpatialVector3 {
+	x: number;
+	y: number;
+	z: number;
+}
+
+export interface SpatialAudioObjectState {
+	id: string;
+	kind: string;
+	position: SpatialVector3;
+	velocity: SpatialVector3;
+	orientation: SpatialVector3;
+	angularVelocity?: SpatialVector3;
+	radius: number;
+	baseGain: number;
+	excitationEnergy: number;
+	threat: number;
+	continuity: number;
+	seed: number;
+	sustained: boolean;
+}
+
+export interface SpatialListenerState {
+	position: SpatialVector3;
+	velocity: SpatialVector3;
+	forward: SpatialVector3;
+	up: SpatialVector3;
+	focusPosition?: SpatialVector3;
+}
+
+export interface SpatialAudioCalibration {
+	speedOfSound: number;
+	maxRadialFractionOfSoundSpeed: number;
+	minDopplerRatio: number;
+	maxDopplerRatio: number;
+	referenceDistance: number;
+	rolloffExponent: number;
+	airAbsorptionPerUnit: number;
+	predictionHorizonSeconds: number;
+	energyReference: number;
+	proximityWeight: number;
+	closestApproachWeight: number;
+	energyWeight: number;
+	threatWeight: number;
+	continuityWeight: number;
+}
+
+export interface ClosestApproach {
+	timeSeconds: number;
+	distance: number;
+}
+
+export interface DopplerState {
+	ratio: number;
+	listenerTowardSource: number;
+	sourceAwayFromListener: number;
+}
+
+export interface SpatialRenderHints {
+	distance: number;
+	closestApproach: ClosestApproach;
+	doppler: DopplerState;
+	distanceGain: number;
+	highFrequencyRetention: number;
+	priority: number;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, value));
+}
+
+function positive(value: number): number {
+	return Math.max(0, value);
+}
+
+function subtract(a: SpatialVector3, b: SpatialVector3): SpatialVector3 {
+	return {
+		x: a.x - b.x,
+		y: a.y - b.y,
+		z: a.z - b.z
+	};
+}
+
+function dot(a: SpatialVector3, b: SpatialVector3): number {
+	return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function magnitudeSquared(vector: SpatialVector3): number {
+	return dot(vector, vector);
+}
+
+function magnitude(vector: SpatialVector3): number {
+	return Math.sqrt(magnitudeSquared(vector));
+}
+
+function scale(vector: SpatialVector3, amount: number): SpatialVector3 {
+	return {
+		x: vector.x * amount,
+		y: vector.y * amount,
+		z: vector.z * amount
+	};
+}
+
+function normalize(vector: SpatialVector3): SpatialVector3 {
+	const length = magnitude(vector);
+	if (length <= 0.000001) {
+		return { x: 0, y: 0, z: 0 };
+	}
+	return scale(vector, 1 / length);
+}
+
+export function spatialDistance(a: SpatialVector3, b: SpatialVector3): number {
+	return magnitude(subtract(a, b));
+}
+
+/**
+ * Predict the nearest separation between a moving source and listener over a
+ * bounded future horizon. This is useful for prioritizing fast fly-bys before
+ * the source is already beside the camera.
+ */
+export function closestApproach(
+	sourcePosition: SpatialVector3,
+	sourceVelocity: SpatialVector3,
+	listenerPosition: SpatialVector3,
+	listenerVelocity: SpatialVector3,
+	horizonSeconds: number
+): ClosestApproach {
+	const relativePosition = subtract(sourcePosition, listenerPosition);
+	const relativeVelocity = subtract(sourceVelocity, listenerVelocity);
+	const velocitySquared = magnitudeSquared(relativeVelocity);
+	const horizon = positive(horizonSeconds);
+	let timeSeconds = 0;
+
+	if (velocitySquared > 0.000001) {
+		timeSeconds = clamp(
+			-dot(relativePosition, relativeVelocity) / velocitySquared,
+			0,
+			horizon
+		);
+	}
+
+	const positionAtClosest = {
+		x: relativePosition.x + relativeVelocity.x * timeSeconds,
+		y: relativePosition.y + relativeVelocity.y * timeSeconds,
+		z: relativePosition.z + relativeVelocity.z * timeSeconds
+	};
+
+	return {
+		timeSeconds,
+		distance: magnitude(positionAtClosest)
+	};
+}
+
+/**
+ * Explicit Doppler derived from listener/source motion along the line of sight.
+ * Web Audio spatial panners do not expose source/listener velocity, so the
+ * backend can apply this ratio to oscillator phase/frequency or playback rate.
+ *
+ * Positive listenerTowardSource raises pitch. Positive sourceAwayFromListener
+ * lowers pitch. Tangential motion contributes little until its radial component
+ * changes during a pass.
+ */
+export function dopplerState(
+	sourcePosition: SpatialVector3,
+	sourceVelocity: SpatialVector3,
+	listenerPosition: SpatialVector3,
+	listenerVelocity: SpatialVector3,
+	calibration: SpatialAudioCalibration
+): DopplerState {
+	const fromListenerToSource = subtract(sourcePosition, listenerPosition);
+	const direction = normalize(fromListenerToSource);
+	if (magnitudeSquared(direction) === 0) {
+		return {
+			ratio: 1,
+			listenerTowardSource: 0,
+			sourceAwayFromListener: 0
+		};
+	}
+
+	const speedOfSound = Math.max(0.0001, positive(calibration.speedOfSound));
+	const radialLimit =
+		speedOfSound *
+		clamp(calibration.maxRadialFractionOfSoundSpeed, 0, 0.95);
+	const listenerTowardSource = clamp(
+		dot(listenerVelocity, direction),
+		-radialLimit,
+		radialLimit
+	);
+	const sourceAwayFromListener = clamp(
+		dot(sourceVelocity, direction),
+		-radialLimit,
+		radialLimit
+	);
+	const numerator = speedOfSound + listenerTowardSource;
+	const denominator = Math.max(
+		speedOfSound * 0.05,
+		speedOfSound + sourceAwayFromListener
+	);
+	const minimumRatio = Math.max(0.01, calibration.minDopplerRatio);
+	const maximumRatio = Math.max(minimumRatio, calibration.maxDopplerRatio);
+
+	return {
+		ratio: clamp(numerator / denominator, minimumRatio, maximumRatio),
+		listenerTowardSource,
+		sourceAwayFromListener
+	};
+}
+
+/**
+ * A renderer-independent distance gain hint. A Web Audio backend may use its
+ * native PannerNode distance model instead; this scalar remains useful for
+ * prioritization, alternate/native backends and deterministic fixtures.
+ */
+export function distanceGain(
+	distance: number,
+	referenceDistance: number,
+	rolloffExponent: number
+): number {
+	const reference = Math.max(0.0001, positive(referenceDistance));
+	const normalizedDistance = positive(distance) / reference;
+	const exponent = Math.max(0.0001, positive(rolloffExponent));
+	return 1 / (1 + Math.pow(normalizedDistance, exponent));
+}
+
+/**
+ * Simple high-frequency retention hint for distance-dependent air loss. 1 means
+ * no additional loss; values approach zero gradually with distance.
+ */
+export function highFrequencyRetention(
+	distance: number,
+	referenceDistance: number,
+	absorptionPerUnit: number
+): number {
+	const beyondReference = Math.max(
+		0,
+		positive(distance) - positive(referenceDistance)
+	);
+	return Math.exp(-positive(absorptionPerUnit) * beyondReference);
+}
+
+/**
+ * Perceptual/gameplay priority. Nearby sources matter, but predicted close
+ * fly-bys, energetic impacts and threats to the core can outrank merely-near
+ * low-value chatter. Continuity prevents sustained voices from being chopped
+ * aggressively once they are already perceptually established.
+ */
+export function spatialPriority(
+	source: SpatialAudioObjectState,
+	listener: SpatialListenerState,
+	calibration: SpatialAudioCalibration
+): number {
+	const distance = spatialDistance(source.position, listener.position);
+	const approach = closestApproach(
+		source.position,
+		source.velocity,
+		listener.position,
+		listener.velocity,
+		calibration.predictionHorizonSeconds
+	);
+	const proximity = distanceGain(
+		distance,
+		calibration.referenceDistance,
+		calibration.rolloffExponent
+	);
+	const closestProximity = distanceGain(
+		approach.distance,
+		calibration.referenceDistance,
+		calibration.rolloffExponent
+	);
+	const horizon = Math.max(0.0001, positive(calibration.predictionHorizonSeconds));
+	const imminence = 1 - clamp(approach.timeSeconds / horizon, 0, 1);
+	const closestApproachScore = closestProximity * (0.5 + 0.5 * imminence);
+	const energyReference = Math.max(0.0001, positive(calibration.energyReference));
+	const energy = positive(source.excitationEnergy);
+	const energyScore = energy / (energy + energyReference);
+	const threat = clamp(source.threat, 0, 1);
+	const continuity = clamp(source.continuity, 0, 1);
+	const proximityWeight = positive(calibration.proximityWeight);
+	const closestWeight = positive(calibration.closestApproachWeight);
+	const energyWeight = positive(calibration.energyWeight);
+	const threatWeight = positive(calibration.threatWeight);
+	const continuityWeight = positive(calibration.continuityWeight);
+	const totalWeight =
+		proximityWeight +
+		closestWeight +
+		energyWeight +
+		threatWeight +
+		continuityWeight;
+
+	if (totalWeight <= 0.000001) {
+		return 0;
+	}
+
+	return clamp(
+		(proximity * proximityWeight +
+			closestApproachScore * closestWeight +
+			energyScore * energyWeight +
+			threat * threatWeight +
+			continuity * continuityWeight) /
+			totalWeight,
+		0,
+		1
+	);
+}
+
+export function spatialRenderHints(
+	source: SpatialAudioObjectState,
+	listener: SpatialListenerState,
+	calibration: SpatialAudioCalibration
+): SpatialRenderHints {
+	const distance = spatialDistance(source.position, listener.position);
+	return {
+		distance,
+		closestApproach: closestApproach(
+			source.position,
+			source.velocity,
+			listener.position,
+			listener.velocity,
+			calibration.predictionHorizonSeconds
+		),
+		doppler: dopplerState(
+			source.position,
+			source.velocity,
+			listener.position,
+			listener.velocity,
+			calibration
+		),
+		distanceGain: distanceGain(
+			distance,
+			calibration.referenceDistance,
+			calibration.rolloffExponent
+		),
+		highFrequencyRetention: highFrequencyRetention(
+			distance,
+			calibration.referenceDistance,
+			calibration.airAbsorptionPerUnit
+		),
+		priority: spatialPriority(source, listener, calibration)
+	};
+}

--- a/src/js/audio/spatialAudio.ts
+++ b/src/js/audio/spatialAudio.ts
@@ -7,10 +7,12 @@ export interface SpatialVector3 {
 export interface SpatialAudioObjectState {
 	id: string;
 	kind: string;
+	acousticProfile: string;
 	position: SpatialVector3;
 	velocity: SpatialVector3;
 	orientation: SpatialVector3;
 	angularVelocity?: SpatialVector3;
+	directivity: number;
 	radius: number;
 	baseGain: number;
 	excitationEnergy: number;
@@ -207,9 +209,10 @@ export function dopplerState(
 }
 
 /**
- * A renderer-independent distance gain hint. A Web Audio backend may use its
- * native PannerNode distance model instead; this scalar remains useful for
- * prioritization, alternate/native backends and deterministic fixtures.
+ * A renderer-independent distance gain hint. Full gain is retained inside the
+ * reference distance, matching the semantic expectation of a spatial near
+ * field. A Web Audio backend may use its native PannerNode distance model
+ * instead; this scalar remains useful for prioritization and native backends.
  */
 export function distanceGain(
 	distance: number,
@@ -217,9 +220,12 @@ export function distanceGain(
 	rolloffExponent: number
 ): number {
 	const reference = Math.max(0.0001, positive(referenceDistance));
-	const normalizedDistance = positive(distance) / reference;
+	const normalizedBeyondReference = Math.max(
+		0,
+		positive(distance) / reference - 1
+	);
 	const exponent = Math.max(0.0001, positive(rolloffExponent));
-	return 1 / (1 + Math.pow(normalizedDistance, exponent));
+	return 1 / (1 + Math.pow(normalizedBeyondReference, exponent));
 }
 
 /**


### PR DESCRIPTION
Refs #60
Related: #52, #53, #56, #58

## Scope

Pure spatial-audio scene math only. No production sound routing, WAFXR/Tone changes, AudioWorklet, Worker, visualization, listener wiring, or gameplay behavior changes.

## Change

Add `src/js/audio/spatialAudio.ts` with backend-neutral primitives for:

- world-space emitter objects with stable id, acoustic profile, position, velocity, orientation/directivity, size, excitation, threat and continuity state;
- listener position, velocity and orientation;
- source/listener distance;
- bounded future closest-approach prediction for fly-by prioritization;
- explicit Doppler ratio from relative radial source/listener velocity;
- distance-gain hints with a preserved near field;
- distance-dependent high-frequency retention / air-loss hints;
- deterministic perceptual/gameplay priority combining proximity, predicted close pass, excitation energy, threat and sustained-voice continuity;
- one aggregate `spatialRenderHints()` output for renderer backends;
- defensive numeric sanitization so malformed/non-finite emitter or calibration state cannot poison a complete planning pass.

## Why

The current WAFXR path already positions many one-shot sounds using `soundX/Y/Z`, and `arcCamera.ts` updates the listener each frame. However source positions are sampled only when sounds start, source/listener velocity is not represented, current Web Audio panners do not provide automatic velocity/Doppler behavior, and the existing voice budget is timer/counter based.

This PR establishes a scene-object contract before changing the renderer.

## Numeric boundary

Spatial/audio planning must remain finite even when an upstream transform, physics event, worker message, debug control, or calibration briefly contains invalid state.

The pure math now:
- maps `NaN` to neutral scalar values;
- saturates infinite/absurd scalar magnitudes at an internal `1e150` defensive ceiling;
- performs vector subtraction, scaling, dot products and closest-approach projection through the same finite boundary;
- clamps distance gain, high-frequency retention, energy score and final priority to their semantic `[0,1]` ranges;
- keeps all ordinary Defend world values many orders of magnitude below the defensive ceiling, so normal physical behavior is unchanged.

This is robustness, not gameplay calibration. The ceiling is not a world-size design limit and should not appear in UI or simulation rules.

## Doppler convention

The line-of-sight vector runs from listener to source.

- positive listener radial velocity toward the source raises pitch;
- positive source radial velocity away from the listener lowers pitch;
- tangential velocity has little instantaneous contribution;
- radial velocities and final pitch ratio are explicitly bounded for robustness.

A later backend may apply the returned ratio to oscillator frequency/phase, granular playback or playback rate as appropriate.

## Threading boundary

This module is intentionally synchronous/pure and tiny. It can execute in the current thread, a Dedicated Worker, an AudioWorklet control layer, Rust/WASM, or native code. It does not assume any threading primitive.

The intended runtime split in #60 is:

- simulation/main thread emits compact state/events;
- worker aggregates/prioritizes/plans where useful;
- AudioWorklet performs sample/block DSP;
- optional SharedArrayBuffer only when cross-origin isolation is available and measured useful;
- rendering/sound-wave visualization consumes presentation state independently.

## Local validation before promotion

1. Confirm TypeScript 3.2 accepts this file, including default parameters used by the finite-scalar helper.
2. Property-check every public function across zero, negative, `NaN`, ±Infinity, and very large finite distance/speed/calibration inputs; outputs must remain finite.
3. Confirm ordinary finite fixtures from before the hardening commit produce the same outputs within floating-point tolerance.
4. Stationary source/listener => Doppler ratio exactly 1.
5. Source approaching listener => ratio > 1; receding => ratio < 1.
6. Listener approaching source => ratio > 1; receding => ratio < 1.
7. Pure tangential motion at a fixed instant should be approximately neutral.
8. Validate closest-approach fixtures for direct fly-by, receding source, stationary relative motion and horizon clipping.
9. Verify full distance gain inside `referenceDistance` and monotonic attenuation beyond it.
10. Verify high-frequency retention is 1 inside the reference distance and monotonic afterward.
11. Verify all public normalized scalars (`distanceGain`, high-frequency retention, priority) stay in `[0,1]` under malformed inputs.
12. Stress-sort 100+ representative emitters and verify near fly-bys/high-threat events outrank distant low-energy chatter.
13. Mirror the pure fixtures in `defend-core` once #55 is ready.

## Gameplay impact

None. This module is not imported by production code.

Keep draft until numeric fixtures and a browser fly-by harness validate the conventions and calibration.