### PR TITLE
Plan spatial audio quality tiers and virtualization

### DIFF
--- a/src/js/audio/spatialAudio.ts
+++ b/src/js/audio/spatialAudio.ts
@@ -67,39 +67,79 @@ export interface SpatialRenderHints {
 	priority: number;
 }
 
+/**
+ * Defensive numeric ceiling for this pure boundary. Real Defend world-space
+ * values are many orders of magnitude smaller; the ceiling only prevents
+ * malformed Infinity/NaN or absurd external state from poisoning an audio
+ * planning pass with non-finite output.
+ */
+const MAX_SPATIAL_SCALAR = 1e150;
+
+function finiteScalar(value: number, fallback = 0): number {
+	if (value !== value) {
+		return fallback;
+	}
+	if (value > MAX_SPATIAL_SCALAR) {
+		return MAX_SPATIAL_SCALAR;
+	}
+	if (value < -MAX_SPATIAL_SCALAR) {
+		return -MAX_SPATIAL_SCALAR;
+	}
+	return value;
+}
+
 function clamp(value: number, minimum: number, maximum: number): number {
-	return Math.max(minimum, Math.min(maximum, value));
+	const safeValue = finiteScalar(value, minimum);
+	return Math.max(minimum, Math.min(maximum, safeValue));
 }
 
 function positive(value: number): number {
-	return Math.max(0, value);
+	return Math.max(0, finiteScalar(value, 0));
 }
 
 function subtract(a: SpatialVector3, b: SpatialVector3): SpatialVector3 {
 	return {
-		x: a.x - b.x,
-		y: a.y - b.y,
-		z: a.z - b.z
+		x: finiteScalar(finiteScalar(a.x) - finiteScalar(b.x)),
+		y: finiteScalar(finiteScalar(a.y) - finiteScalar(b.y)),
+		z: finiteScalar(finiteScalar(a.z) - finiteScalar(b.z))
 	};
 }
 
 function dot(a: SpatialVector3, b: SpatialVector3): number {
-	return a.x * b.x + a.y * b.y + a.z * b.z;
+	return finiteScalar(
+		finiteScalar(a.x) * finiteScalar(b.x) +
+			finiteScalar(a.y) * finiteScalar(b.y) +
+			finiteScalar(a.z) * finiteScalar(b.z)
+	);
 }
 
 function magnitudeSquared(vector: SpatialVector3): number {
-	return dot(vector, vector);
+	return positive(dot(vector, vector));
 }
 
 function magnitude(vector: SpatialVector3): number {
-	return Math.sqrt(magnitudeSquared(vector));
+	return finiteScalar(Math.sqrt(magnitudeSquared(vector)), MAX_SPATIAL_SCALAR);
 }
 
 function scale(vector: SpatialVector3, amount: number): SpatialVector3 {
+	const safeAmount = finiteScalar(amount);
 	return {
-		x: vector.x * amount,
-		y: vector.y * amount,
-		z: vector.z * amount
+		x: finiteScalar(finiteScalar(vector.x) * safeAmount),
+		y: finiteScalar(finiteScalar(vector.y) * safeAmount),
+		z: finiteScalar(finiteScalar(vector.z) * safeAmount)
+	};
+}
+
+function addScaled(
+	position: SpatialVector3,
+	velocity: SpatialVector3,
+	timeSeconds: number
+): SpatialVector3 {
+	const time = finiteScalar(timeSeconds);
+	return {
+		x: finiteScalar(finiteScalar(position.x) + finiteScalar(velocity.x) * time),
+		y: finiteScalar(finiteScalar(position.y) + finiteScalar(velocity.y) * time),
+		z: finiteScalar(finiteScalar(position.z) + finiteScalar(velocity.z) * time)
 	};
 }
 
@@ -135,17 +175,17 @@ export function closestApproach(
 
 	if (velocitySquared > 0.000001) {
 		timeSeconds = clamp(
-			-dot(relativePosition, relativeVelocity) / velocitySquared,
+			finiteScalar(-dot(relativePosition, relativeVelocity) / velocitySquared),
 			0,
 			horizon
 		);
 	}
 
-	const positionAtClosest = {
-		x: relativePosition.x + relativeVelocity.x * timeSeconds,
-		y: relativePosition.y + relativeVelocity.y * timeSeconds,
-		z: relativePosition.z + relativeVelocity.z * timeSeconds
-	};
+	const positionAtClosest = addScaled(
+		relativePosition,
+		relativeVelocity,
+		timeSeconds
+	);
 
 	return {
 		timeSeconds,
@@ -180,9 +220,10 @@ export function dopplerState(
 	}
 
 	const speedOfSound = Math.max(0.0001, positive(calibration.speedOfSound));
-	const radialLimit =
+	const radialLimit = finiteScalar(
 		speedOfSound *
-		clamp(calibration.maxRadialFractionOfSoundSpeed, 0, 0.95);
+			clamp(calibration.maxRadialFractionOfSoundSpeed, 0, 0.95)
+	);
 	const listenerTowardSource = clamp(
 		dot(listenerVelocity, direction),
 		-radialLimit,
@@ -193,13 +234,16 @@ export function dopplerState(
 		-radialLimit,
 		radialLimit
 	);
-	const numerator = speedOfSound + listenerTowardSource;
+	const numerator = finiteScalar(speedOfSound + listenerTowardSource);
 	const denominator = Math.max(
 		speedOfSound * 0.05,
-		speedOfSound + sourceAwayFromListener
+		finiteScalar(speedOfSound + sourceAwayFromListener)
 	);
-	const minimumRatio = Math.max(0.01, calibration.minDopplerRatio);
-	const maximumRatio = Math.max(minimumRatio, calibration.maxDopplerRatio);
+	const minimumRatio = Math.max(0.01, positive(calibration.minDopplerRatio));
+	const maximumRatio = Math.max(
+		minimumRatio,
+		positive(calibration.maxDopplerRatio)
+	);
 
 	return {
 		ratio: clamp(numerator / denominator, minimumRatio, maximumRatio),
@@ -225,7 +269,7 @@ export function distanceGain(
 		positive(distance) / reference - 1
 	);
 	const exponent = Math.max(0.0001, positive(rolloffExponent));
-	return 1 / (1 + Math.pow(normalizedBeyondReference, exponent));
+	return clamp(1 / (1 + Math.pow(normalizedBeyondReference, exponent)), 0, 1);
 }
 
 /**
@@ -241,7 +285,11 @@ export function highFrequencyRetention(
 		0,
 		positive(distance) - positive(referenceDistance)
 	);
-	return Math.exp(-positive(absorptionPerUnit) * beyondReference);
+	return clamp(
+		Math.exp(-positive(absorptionPerUnit) * beyondReference),
+		0,
+		1
+	);
 }
 
 /**
@@ -278,7 +326,7 @@ export function spatialPriority(
 	const closestApproachScore = closestProximity * (0.5 + 0.5 * imminence);
 	const energyReference = Math.max(0.0001, positive(calibration.energyReference));
 	const energy = positive(source.excitationEnergy);
-	const energyScore = energy / (energy + energyReference);
+	const energyScore = clamp(energy / finiteScalar(energy + energyReference), 0, 1);
 	const threat = clamp(source.threat, 0, 1);
 	const continuity = clamp(source.continuity, 0, 1);
 	const proximityWeight = positive(calibration.proximityWeight);
@@ -286,27 +334,27 @@ export function spatialPriority(
 	const energyWeight = positive(calibration.energyWeight);
 	const threatWeight = positive(calibration.threatWeight);
 	const continuityWeight = positive(calibration.continuityWeight);
-	const totalWeight =
+	const totalWeight = finiteScalar(
 		proximityWeight +
-		closestWeight +
-		energyWeight +
-		threatWeight +
-		continuityWeight;
+			closestWeight +
+			energyWeight +
+			threatWeight +
+			continuityWeight
+	);
 
 	if (totalWeight <= 0.000001) {
 		return 0;
 	}
 
-	return clamp(
-		(proximity * proximityWeight +
+	const weightedPriority = finiteScalar(
+		proximity * proximityWeight +
 			closestApproachScore * closestWeight +
 			energyScore * energyWeight +
 			threat * threatWeight +
-			continuity * continuityWeight) /
-			totalWeight,
-		0,
-		1
+			continuity * continuityWeight
 	);
+
+	return clamp(weightedPriority / totalWeight, 0, 1);
 }
 
 export function spatialRenderHints(

--- a/src/js/audio/spatialAudio.ts
+++ b/src/js/audio/spatialAudio.ts
@@ -1,0 +1,340 @@
+export interface SpatialVector3 {
+	x: number;
+	y: number;
+	z: number;
+}
+
+export interface SpatialAudioObjectState {
+	id: string;
+	kind: string;
+	position: SpatialVector3;
+	velocity: SpatialVector3;
+	orientation: SpatialVector3;
+	angularVelocity?: SpatialVector3;
+	radius: number;
+	baseGain: number;
+	excitationEnergy: number;
+	threat: number;
+	continuity: number;
+	seed: number;
+	sustained: boolean;
+}
+
+export interface SpatialListenerState {
+	position: SpatialVector3;
+	velocity: SpatialVector3;
+	forward: SpatialVector3;
+	up: SpatialVector3;
+	focusPosition?: SpatialVector3;
+}
+
+export interface SpatialAudioCalibration {
+	speedOfSound: number;
+	maxRadialFractionOfSoundSpeed: number;
+	minDopplerRatio: number;
+	maxDopplerRatio: number;
+	referenceDistance: number;
+	rolloffExponent: number;
+	airAbsorptionPerUnit: number;
+	predictionHorizonSeconds: number;
+	energyReference: number;
+	proximityWeight: number;
+	closestApproachWeight: number;
+	energyWeight: number;
+	threatWeight: number;
+	continuityWeight: number;
+}
+
+export interface ClosestApproach {
+	timeSeconds: number;
+	distance: number;
+}
+
+export interface DopplerState {
+	ratio: number;
+	listenerTowardSource: number;
+	sourceAwayFromListener: number;
+}
+
+export interface SpatialRenderHints {
+	distance: number;
+	closestApproach: ClosestApproach;
+	doppler: DopplerState;
+	distanceGain: number;
+	highFrequencyRetention: number;
+	priority: number;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, value));
+}
+
+function positive(value: number): number {
+	return Math.max(0, value);
+}
+
+function subtract(a: SpatialVector3, b: SpatialVector3): SpatialVector3 {
+	return {
+		x: a.x - b.x,
+		y: a.y - b.y,
+		z: a.z - b.z
+	};
+}
+
+function dot(a: SpatialVector3, b: SpatialVector3): number {
+	return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function magnitudeSquared(vector: SpatialVector3): number {
+	return dot(vector, vector);
+}
+
+function magnitude(vector: SpatialVector3): number {
+	return Math.sqrt(magnitudeSquared(vector));
+}
+
+function scale(vector: SpatialVector3, amount: number): SpatialVector3 {
+	return {
+		x: vector.x * amount,
+		y: vector.y * amount,
+		z: vector.z * amount
+	};
+}
+
+function normalize(vector: SpatialVector3): SpatialVector3 {
+	const length = magnitude(vector);
+	if (length <= 0.000001) {
+		return { x: 0, y: 0, z: 0 };
+	}
+	return scale(vector, 1 / length);
+}
+
+export function spatialDistance(a: SpatialVector3, b: SpatialVector3): number {
+	return magnitude(subtract(a, b));
+}
+
+/**
+ * Predict the nearest separation between a moving source and listener over a
+ * bounded future horizon. This is useful for prioritizing fast fly-bys before
+ * the source is already beside the camera.
+ */
+export function closestApproach(
+	sourcePosition: SpatialVector3,
+	sourceVelocity: SpatialVector3,
+	listenerPosition: SpatialVector3,
+	listenerVelocity: SpatialVector3,
+	horizonSeconds: number
+): ClosestApproach {
+	const relativePosition = subtract(sourcePosition, listenerPosition);
+	const relativeVelocity = subtract(sourceVelocity, listenerVelocity);
+	const velocitySquared = magnitudeSquared(relativeVelocity);
+	const horizon = positive(horizonSeconds);
+	let timeSeconds = 0;
+
+	if (velocitySquared > 0.000001) {
+		timeSeconds = clamp(
+			-dot(relativePosition, relativeVelocity) / velocitySquared,
+			0,
+			horizon
+		);
+	}
+
+	const positionAtClosest = {
+		x: relativePosition.x + relativeVelocity.x * timeSeconds,
+		y: relativePosition.y + relativeVelocity.y * timeSeconds,
+		z: relativePosition.z + relativeVelocity.z * timeSeconds
+	};
+
+	return {
+		timeSeconds,
+		distance: magnitude(positionAtClosest)
+	};
+}
+
+/**
+ * Explicit Doppler derived from listener/source motion along the line of sight.
+ * Web Audio spatial panners do not expose source/listener velocity, so the
+ * backend can apply this ratio to oscillator phase/frequency or playback rate.
+ *
+ * Positive listenerTowardSource raises pitch. Positive sourceAwayFromListener
+ * lowers pitch. Tangential motion contributes little until its radial component
+ * changes during a pass.
+ */
+export function dopplerState(
+	sourcePosition: SpatialVector3,
+	sourceVelocity: SpatialVector3,
+	listenerPosition: SpatialVector3,
+	listenerVelocity: SpatialVector3,
+	calibration: SpatialAudioCalibration
+): DopplerState {
+	const fromListenerToSource = subtract(sourcePosition, listenerPosition);
+	const direction = normalize(fromListenerToSource);
+	if (magnitudeSquared(direction) === 0) {
+		return {
+			ratio: 1,
+			listenerTowardSource: 0,
+			sourceAwayFromListener: 0
+		};
+	}
+
+	const speedOfSound = Math.max(0.0001, positive(calibration.speedOfSound));
+	const radialLimit =
+		speedOfSound *
+		clamp(calibration.maxRadialFractionOfSoundSpeed, 0, 0.95);
+	const listenerTowardSource = clamp(
+		dot(listenerVelocity, direction),
+		-radialLimit,
+		radialLimit
+	);
+	const sourceAwayFromListener = clamp(
+		dot(sourceVelocity, direction),
+		-radialLimit,
+		radialLimit
+	);
+	const numerator = speedOfSound + listenerTowardSource;
+	const denominator = Math.max(
+		speedOfSound * 0.05,
+		speedOfSound + sourceAwayFromListener
+	);
+	const minimumRatio = Math.max(0.01, calibration.minDopplerRatio);
+	const maximumRatio = Math.max(minimumRatio, calibration.maxDopplerRatio);
+
+	return {
+		ratio: clamp(numerator / denominator, minimumRatio, maximumRatio),
+		listenerTowardSource,
+		sourceAwayFromListener
+	};
+}
+
+/**
+ * A renderer-independent distance gain hint. A Web Audio backend may use its
+ * native PannerNode distance model instead; this scalar remains useful for
+ * prioritization, alternate/native backends and deterministic fixtures.
+ */
+export function distanceGain(
+	distance: number,
+	referenceDistance: number,
+	rolloffExponent: number
+): number {
+	const reference = Math.max(0.0001, positive(referenceDistance));
+	const normalizedDistance = positive(distance) / reference;
+	const exponent = Math.max(0.0001, positive(rolloffExponent));
+	return 1 / (1 + Math.pow(normalizedDistance, exponent));
+}
+
+/**
+ * Simple high-frequency retention hint for distance-dependent air loss. 1 means
+ * no additional loss; values approach zero gradually with distance.
+ */
+export function highFrequencyRetention(
+	distance: number,
+	referenceDistance: number,
+	absorptionPerUnit: number
+): number {
+	const beyondReference = Math.max(
+		0,
+		positive(distance) - positive(referenceDistance)
+	);
+	return Math.exp(-positive(absorptionPerUnit) * beyondReference);
+}
+
+/**
+ * Perceptual/gameplay priority. Nearby sources matter, but predicted close
+ * fly-bys, energetic impacts and threats to the core can outrank merely-near
+ * low-value chatter. Continuity prevents sustained voices from being chopped
+ * aggressively once they are already perceptually established.
+ */
+export function spatialPriority(
+	source: SpatialAudioObjectState,
+	listener: SpatialListenerState,
+	calibration: SpatialAudioCalibration
+): number {
+	const distance = spatialDistance(source.position, listener.position);
+	const approach = closestApproach(
+		source.position,
+		source.velocity,
+		listener.position,
+		listener.velocity,
+		calibration.predictionHorizonSeconds
+	);
+	const proximity = distanceGain(
+		distance,
+		calibration.referenceDistance,
+		calibration.rolloffExponent
+	);
+	const closestProximity = distanceGain(
+		approach.distance,
+		calibration.referenceDistance,
+		calibration.rolloffExponent
+	);
+	const horizon = Math.max(0.0001, positive(calibration.predictionHorizonSeconds));
+	const imminence = 1 - clamp(approach.timeSeconds / horizon, 0, 1);
+	const closestApproachScore = closestProximity * (0.5 + 0.5 * imminence);
+	const energyReference = Math.max(0.0001, positive(calibration.energyReference));
+	const energy = positive(source.excitationEnergy);
+	const energyScore = energy / (energy + energyReference);
+	const threat = clamp(source.threat, 0, 1);
+	const continuity = clamp(source.continuity, 0, 1);
+	const proximityWeight = positive(calibration.proximityWeight);
+	const closestWeight = positive(calibration.closestApproachWeight);
+	const energyWeight = positive(calibration.energyWeight);
+	const threatWeight = positive(calibration.threatWeight);
+	const continuityWeight = positive(calibration.continuityWeight);
+	const totalWeight =
+		proximityWeight +
+		closestWeight +
+		energyWeight +
+		threatWeight +
+		continuityWeight;
+
+	if (totalWeight <= 0.000001) {
+		return 0;
+	}
+
+	return clamp(
+		(proximity * proximityWeight +
+			closestApproachScore * closestWeight +
+			energyScore * energyWeight +
+			threat * threatWeight +
+			continuity * continuityWeight) /
+			totalWeight,
+		0,
+		1
+	);
+}
+
+export function spatialRenderHints(
+	source: SpatialAudioObjectState,
+	listener: SpatialListenerState,
+	calibration: SpatialAudioCalibration
+): SpatialRenderHints {
+	const distance = spatialDistance(source.position, listener.position);
+	return {
+		distance,
+		closestApproach: closestApproach(
+			source.position,
+			source.velocity,
+			listener.position,
+			listener.velocity,
+			calibration.predictionHorizonSeconds
+		),
+		doppler: dopplerState(
+			source.position,
+			source.velocity,
+			listener.position,
+			listener.velocity,
+			calibration
+		),
+		distanceGain: distanceGain(
+			distance,
+			calibration.referenceDistance,
+			calibration.rolloffExponent
+		),
+		highFrequencyRetention: highFrequencyRetention(
+			distance,
+			calibration.referenceDistance,
+			calibration.airAbsorptionPerUnit
+		),
+		priority: spatialPriority(source, listener, calibration)
+	};
+}

--- a/src/js/audio/spatialAudio.ts
+++ b/src/js/audio/spatialAudio.ts
@@ -7,10 +7,12 @@ export interface SpatialVector3 {
 export interface SpatialAudioObjectState {
 	id: string;
 	kind: string;
+	acousticProfile: string;
 	position: SpatialVector3;
 	velocity: SpatialVector3;
 	orientation: SpatialVector3;
 	angularVelocity?: SpatialVector3;
+	directivity: number;
 	radius: number;
 	baseGain: number;
 	excitationEnergy: number;
@@ -207,9 +209,10 @@ export function dopplerState(
 }
 
 /**
- * A renderer-independent distance gain hint. A Web Audio backend may use its
- * native PannerNode distance model instead; this scalar remains useful for
- * prioritization, alternate/native backends and deterministic fixtures.
+ * A renderer-independent distance gain hint. Full gain is retained inside the
+ * reference distance, matching the semantic expectation of a spatial near
+ * field. A Web Audio backend may use its native PannerNode distance model
+ * instead; this scalar remains useful for prioritization and native backends.
  */
 export function distanceGain(
 	distance: number,
@@ -217,9 +220,12 @@ export function distanceGain(
 	rolloffExponent: number
 ): number {
 	const reference = Math.max(0.0001, positive(referenceDistance));
-	const normalizedDistance = positive(distance) / reference;
+	const normalizedBeyondReference = Math.max(
+		0,
+		positive(distance) / reference - 1
+	);
 	const exponent = Math.max(0.0001, positive(rolloffExponent));
-	return 1 / (1 + Math.pow(normalizedDistance, exponent));
+	return 1 / (1 + Math.pow(normalizedBeyondReference, exponent));
 }
 
 /**

--- a/src/js/audio/spatialVoiceBudget.ts
+++ b/src/js/audio/spatialVoiceBudget.ts
@@ -12,6 +12,10 @@ export interface SpatialVoiceBudget {
 	fullVoices: number;
 	standardVoices: number;
 	cheapVoices: number;
+	/**
+	 * Priority margin below the raw rendered/virtual cutoff within which an
+	 * already-rendered voice may be retained for one more planning pass.
+	 */
 	activeVoiceRetention: number;
 }
 
@@ -22,7 +26,10 @@ export interface SpatialVoiceHistory {
 export interface SpatialVoicePlan {
 	id: string;
 	tier: SpatialVoiceTier;
+	/** Raw semantic priority from spatialRenderHints(), unaffected by history. */
 	priority: number;
+	/** Selection score after bounded boundary hysteresis is applied. */
+	selectionPriority: number;
 	rank: number;
 	hints: SpatialRenderHints;
 }
@@ -30,10 +37,15 @@ export interface SpatialVoicePlan {
 interface RankedVoice {
 	id: string;
 	priority: number;
+	selectionPriority: number;
+	wasRendered: boolean;
 	hints: SpatialRenderHints;
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {
+	if (!isFinite(value)) {
+		return minimum;
+	}
 	return Math.max(minimum, Math.min(maximum, value));
 }
 
@@ -54,6 +66,14 @@ function wasRendered(
 	return history[id] !== "virtual";
 }
 
+function renderedVoiceCount(budget: SpatialVoiceBudget): number {
+	return (
+		nonNegativeInteger(budget.fullVoices) +
+		nonNegativeInteger(budget.standardVoices) +
+		nonNegativeInteger(budget.cheapVoices)
+	);
+}
+
 function tierForRank(rank: number, budget: SpatialVoiceBudget): SpatialVoiceTier {
 	const fullEnd = nonNegativeInteger(budget.fullVoices);
 	const standardEnd = fullEnd + nonNegativeInteger(budget.standardVoices);
@@ -71,18 +91,56 @@ function tierForRank(rank: number, budget: SpatialVoiceBudget): SpatialVoiceTier
 	return "virtual";
 }
 
+function compareRawPriority(a: RankedVoice, b: RankedVoice): number {
+	if (a.priority !== b.priority) {
+		return b.priority - a.priority;
+	}
+	if (a.id < b.id) {
+		return -1;
+	}
+	if (a.id > b.id) {
+		return 1;
+	}
+	return 0;
+}
+
+function compareSelectionPriority(a: RankedVoice, b: RankedVoice): number {
+	if (a.selectionPriority !== b.selectionPriority) {
+		return b.selectionPriority - a.selectionPriority;
+	}
+
+	// A retained voice only receives precedence when it has been lifted exactly
+	// to the raw cutoff. Voices with genuinely higher raw priority are never
+	// demoted by this tie-breaker because their selection priority is higher.
+	if (a.wasRendered !== b.wasRendered) {
+		return a.wasRendered ? -1 : 1;
+	}
+	if (a.priority !== b.priority) {
+		return b.priority - a.priority;
+	}
+	if (a.id < b.id) {
+		return -1;
+	}
+	if (a.id > b.id) {
+		return 1;
+	}
+	return 0;
+}
+
 /**
  * Deterministically rank world-space emitters into renderer quality tiers.
  *
  * The underlying spatial priority comes from distance, predicted closest
- * approach, excitation energy, threat, and continuity. A small bounded bonus
- * can be applied to voices that were already rendered during the previous
- * planning pass so objects near a tier boundary do not chatter rapidly between
- * rendered and virtual states.
+ * approach, excitation energy, threat, and continuity. History is used only at
+ * the rendered/virtual boundary: an already-rendered voice that falls within a
+ * small priority margin below the current raw cutoff may be lifted to that
+ * cutoff for one planning pass.
  *
- * `activeVoiceRetention` is intentionally capped at 0.25. Hysteresis is useful,
- * but a previously audible low-value voice must never receive enough history
- * bonus to indefinitely starve a newly important fly-by or core threat.
+ * This is deliberately safer than adding a retention bonus to every old voice.
+ * A new projectile/core threat with raw priority above the cutoff always keeps
+ * its higher selection score and cannot be starved by historical allocation.
+ * Internal `full`/`standard`/`cheap` boundaries do not currently use hysteresis;
+ * renderer-side crossfades can make those quality transitions less audible.
  *
  * This function only chooses semantic quality tiers. A concrete backend decides
  * whether those tiers map to HRTF/equal-power panning, modal count, update rate,
@@ -95,39 +153,47 @@ export function planSpatialVoiceBudget(
 	budget: SpatialVoiceBudget,
 	history?: SpatialVoiceHistory
 ): SpatialVoicePlan[] {
-	const retention = clamp(budget.activeVoiceRetention, 0, 0.25);
+	const retentionMargin = clamp(budget.activeVoiceRetention, 0, 0.25);
+	const renderedCount = renderedVoiceCount(budget);
 	const ranked: RankedVoice[] = sources.map(source => {
 		const hints = spatialRenderHints(source, listener, calibration);
-		const retainedPriority = wasRendered(source.id, history)
-			? clamp(hints.priority + retention, 0, 1)
-			: hints.priority;
-
 		return {
 			id: source.id,
-			priority: retainedPriority,
+			priority: hints.priority,
+			selectionPriority: hints.priority,
+			wasRendered: wasRendered(source.id, history),
 			hints
 		};
 	});
 
-	// The id tie-breaker makes the ordering deterministic even on runtimes where
-	// Array#sort does not guarantee stability for equal comparator values.
-	ranked.sort((a, b) => {
-		if (a.priority !== b.priority) {
-			return b.priority - a.priority;
-		}
-		if (a.id < b.id) {
-			return -1;
-		}
-		if (a.id > b.id) {
-			return 1;
-		}
-		return 0;
-	});
+	// Establish the current rendered/virtual boundary from raw semantic priority
+	// before history is allowed to influence the selection order.
+	const rawRanked = ranked.slice().sort(compareRawPriority);
+	const hasVirtualBoundary = renderedCount > 0 && renderedCount < rawRanked.length;
+	const rawCutoff = hasVirtualBoundary
+		? rawRanked[renderedCount - 1].priority
+		: 0;
+
+	if (hasVirtualBoundary && retentionMargin > 0) {
+		const minimumRetainedPriority = Math.max(0, rawCutoff - retentionMargin);
+		ranked.forEach(voice => {
+			if (
+				voice.wasRendered &&
+				voice.priority < rawCutoff &&
+				voice.priority >= minimumRetainedPriority
+			) {
+				voice.selectionPriority = rawCutoff;
+			}
+		});
+	}
+
+	ranked.sort(compareSelectionPriority);
 
 	return ranked.map((voice, rank) => ({
 		id: voice.id,
 		tier: tierForRank(rank, budget),
 		priority: voice.priority,
+		selectionPriority: voice.selectionPriority,
 		rank,
 		hints: voice.hints
 	}));

--- a/src/js/audio/spatialVoiceBudget.ts
+++ b/src/js/audio/spatialVoiceBudget.ts
@@ -1,0 +1,145 @@
+import {
+	SpatialAudioCalibration,
+	SpatialAudioObjectState,
+	SpatialListenerState,
+	SpatialRenderHints,
+	spatialRenderHints
+} from "./spatialAudio";
+
+export type SpatialVoiceTier = "full" | "standard" | "cheap" | "virtual";
+
+export interface SpatialVoiceBudget {
+	fullVoices: number;
+	standardVoices: number;
+	cheapVoices: number;
+	activeVoiceRetention: number;
+}
+
+export interface SpatialVoiceHistory {
+	[id: string]: SpatialVoiceTier;
+}
+
+export interface SpatialVoicePlan {
+	id: string;
+	tier: SpatialVoiceTier;
+	priority: number;
+	rank: number;
+	hints: SpatialRenderHints;
+}
+
+interface RankedVoice {
+	id: string;
+	priority: number;
+	hints: SpatialRenderHints;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, value));
+}
+
+function nonNegativeInteger(value: number): number {
+	if (!isFinite(value)) {
+		return 0;
+	}
+	return Math.max(0, Math.floor(value));
+}
+
+function wasRendered(
+	id: string,
+	history: SpatialVoiceHistory | undefined
+): boolean {
+	if (!history || !Object.prototype.hasOwnProperty.call(history, id)) {
+		return false;
+	}
+	return history[id] !== "virtual";
+}
+
+function tierForRank(rank: number, budget: SpatialVoiceBudget): SpatialVoiceTier {
+	const fullEnd = nonNegativeInteger(budget.fullVoices);
+	const standardEnd = fullEnd + nonNegativeInteger(budget.standardVoices);
+	const cheapEnd = standardEnd + nonNegativeInteger(budget.cheapVoices);
+
+	if (rank < fullEnd) {
+		return "full";
+	}
+	if (rank < standardEnd) {
+		return "standard";
+	}
+	if (rank < cheapEnd) {
+		return "cheap";
+	}
+	return "virtual";
+}
+
+/**
+ * Deterministically rank world-space emitters into renderer quality tiers.
+ *
+ * The underlying spatial priority comes from distance, predicted closest
+ * approach, excitation energy, threat, and continuity. A small bounded bonus
+ * can be applied to voices that were already rendered during the previous
+ * planning pass so objects near a tier boundary do not chatter rapidly between
+ * rendered and virtual states.
+ *
+ * This function only chooses semantic quality tiers. A concrete backend decides
+ * whether those tiers map to HRTF/equal-power panning, modal count, update rate,
+ * filter complexity, or another rendering strategy after profiling.
+ */
+export function planSpatialVoiceBudget(
+	sources: SpatialAudioObjectState[],
+	listener: SpatialListenerState,
+	calibration: SpatialAudioCalibration,
+	budget: SpatialVoiceBudget,
+	history?: SpatialVoiceHistory
+): SpatialVoicePlan[] {
+	const retention = clamp(budget.activeVoiceRetention, 0, 1);
+	const ranked: RankedVoice[] = sources.map(source => {
+		const hints = spatialRenderHints(source, listener, calibration);
+		const retainedPriority = wasRendered(source.id, history)
+			? clamp(hints.priority + retention, 0, 1)
+			: hints.priority;
+
+		return {
+			id: source.id,
+			priority: retainedPriority,
+			hints
+		};
+	});
+
+	// The id tie-breaker makes the ordering deterministic even on runtimes where
+	// Array#sort does not guarantee stability for equal comparator values.
+	ranked.sort((a, b) => {
+		if (a.priority !== b.priority) {
+			return b.priority - a.priority;
+		}
+		if (a.id < b.id) {
+			return -1;
+		}
+		if (a.id > b.id) {
+			return 1;
+		}
+		return 0;
+	});
+
+	return ranked.map((voice, rank) => ({
+		id: voice.id,
+		tier: tierForRank(rank, budget),
+		priority: voice.priority,
+		rank,
+		hints: voice.hints
+	}));
+}
+
+/**
+ * Convert a plan into the compact history representation expected by the next
+ * planning pass. Virtual voices remain present so a renderer can keep their
+ * semantic lifecycle alive without spending DSP on them.
+ */
+export function spatialVoiceHistory(
+	plans: SpatialVoicePlan[]
+): SpatialVoiceHistory {
+	const history: SpatialVoiceHistory = {};
+	plans.forEach(plan => {
+		history[plan.id] = plan.tier;
+	});
+	return history;
+}

--- a/src/js/audio/spatialVoiceBudget.ts
+++ b/src/js/audio/spatialVoiceBudget.ts
@@ -80,6 +80,10 @@ function tierForRank(rank: number, budget: SpatialVoiceBudget): SpatialVoiceTier
  * planning pass so objects near a tier boundary do not chatter rapidly between
  * rendered and virtual states.
  *
+ * `activeVoiceRetention` is intentionally capped at 0.25. Hysteresis is useful,
+ * but a previously audible low-value voice must never receive enough history
+ * bonus to indefinitely starve a newly important fly-by or core threat.
+ *
  * This function only chooses semantic quality tiers. A concrete backend decides
  * whether those tiers map to HRTF/equal-power panning, modal count, update rate,
  * filter complexity, or another rendering strategy after profiling.
@@ -91,7 +95,7 @@ export function planSpatialVoiceBudget(
 	budget: SpatialVoiceBudget,
 	history?: SpatialVoiceHistory
 ): SpatialVoicePlan[] {
-	const retention = clamp(budget.activeVoiceRetention, 0, 1);
+	const retention = clamp(budget.activeVoiceRetention, 0, 0.25);
 	const ranked: RankedVoice[] = sources.map(source => {
 		const hints = spatialRenderHints(source, listener, calibration);
 		const retainedPriority = wasRendered(source.id, history)
@@ -137,7 +141,7 @@ export function planSpatialVoiceBudget(
 export function spatialVoiceHistory(
 	plans: SpatialVoicePlan[]
 ): SpatialVoiceHistory {
-	const history: SpatialVoiceHistory = {};
+	const history = Object.create(null) as SpatialVoiceHistory;
 	plans.forEach(plan => {
 		history[plan.id] = plan.tier;
 	});


### PR DESCRIPTION
Refs #60
Depends on #61

## Scope

Pure deterministic voice-budget planning only. This stacked PR adds no sound rendering, WAFXR/Tone changes, Worker, AudioWorklet, HRTF selection, visualization, or gameplay changes.

## Change

Add `src/js/audio/spatialVoiceBudget.ts` on top of #61:

- semantic renderer tiers: `full`, `standard`, `cheap`, `virtual`;
- deterministic ranking from #61 `spatialRenderHints()`;
- configurable counts for each rendered tier;
- explicit raw `priority` plus history-adjusted `selectionPriority` for diagnostics;
- stable emitter-id tie breaking for deterministic results;
- prototype-safe history state for successive planning passes;
- virtual voices remain semantically alive while consuming no rendering tier.

## Retention model

`activeVoiceRetention` is now a **rendered/virtual cutoff margin**, not an additive score bonus.

The planner first computes the raw priority ordering with no history. If there is a rendered/virtual boundary, a voice that was rendered on the previous pass may be retained only when its raw priority is below but within the configured margin of that cutoff. Its selection score is lifted only to the cutoff.

Consequences:

- a new source whose raw priority is above the cutoff always stays above retained boundary voices;
- history cannot globally boost stale voices above materially more important projectile fly-bys/core threats;
- hysteresis is limited to the audible rendered/virtual transition where churn matters most;
- `full`/`standard`/`cheap` quality transitions do not yet use history and should be made perceptually smooth by renderer-side crossfades/interpolation.

The retention margin remains capped at 0.25.

## Research rationale

Current Web Audio exposes both `equalpower` and `HRTF` spatialization. HRTF is the richer stereo localization mode, but the appropriate number of simultaneous HRTF/material-DSP voices should be measured per browser/device rather than hard-coded globally. The allocator therefore chooses abstract quality tiers only; a renderer later maps those tiers to HRTF/equal-power, modal count, update frequency, filters, or virtualization.

AudioWorklet is the preferred low-latency custom-DSP thread, while Worker is suitable for control/planning work. Keeping the planner pure means it may run on the main thread initially, in a Dedicated Worker, in Rust/WASM, or as part of a future native/Bevy path without changing semantics.

Primary references recorded in #60:
- Web Audio 1.1: https://webaudio.github.io/web-audio-api/
- PannerNode panning model: https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/panningModel
- AudioWorklet: https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet
- Chrome AudioWorklet/WASM/Worker patterns: https://developer.chrome.com/blog/audio-worklet-design-pattern

## Local certification before promotion

1. Confirm TypeScript 3.2 accepts #61 + this file.
2. Generate 100+ deterministic emitters and verify plan output is repeatable across runs.
3. Verify tier counts exactly respect the configured budget.
4. Verify a high-priority newcomer above the raw cutoff cannot be displaced by a retained lower-priority voice.
5. Verify a previously rendered voice just below the cutoff can remain rendered when within `activeVoiceRetention`.
6. Verify a previously rendered voice outside the retention margin receives no history advantage.
7. Verify `priority` remains raw semantic priority while `selectionPriority` reflects boundary hysteresis only.
8. Verify `__proto__` or other unusual emitter ids cannot corrupt history state.
9. Measure planning cost for 100 / 500 / 1000 emitters on representative browsers; move planning to a Worker only if profiling justifies the messaging overhead.
10. Build the #63 fly-by fixture with several budgets and compare HRTF/equal-power CPU cost and localization quality before assigning concrete renderer behavior to tiers.

## Gameplay/audio impact

None. This PR is not connected to production audio.

Keep stacked/draft until #61 is certified and the deterministic stress fixtures are posted.