### PR TITLE
Add isolated Storybook experiment laboratory

### DIFF
--- a/experiments/storybook/.gitignore
+++ b/experiments/storybook/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+storybook-static/
+coverage/
+test-results/
+.vitest/

--- a/experiments/storybook/.storybook/main.ts
+++ b/experiments/storybook/.storybook/main.ts
@@ -1,0 +1,9 @@
+import type { StorybookConfig } from "@storybook/html-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(js|ts)"],
+  addons: ["@storybook/addon-vitest"],
+  framework: "@storybook/html-vite"
+};
+
+export default config;

--- a/experiments/storybook/.storybook/preview.ts
+++ b/experiments/storybook/.storybook/preview.ts
@@ -1,0 +1,17 @@
+import type { Preview } from "@storybook/html-vite";
+
+const preview: Preview = {
+  parameters: {
+    layout: "fullscreen",
+    controls: {
+      expanded: true
+    },
+    options: {
+      storySort: {
+        order: ["Diagnostics", "Foundations", "Audio", "Arena", "Gameplay"]
+      }
+    }
+  }
+};
+
+export default preview;

--- a/experiments/storybook/.storybook/vitest.setup.ts
+++ b/experiments/storybook/.storybook/vitest.setup.ts
@@ -1,0 +1,4 @@
+import { setProjectAnnotations } from "@storybook/html-vite";
+import * as previewAnnotations from "./preview";
+
+setProjectAnnotations([previewAnnotations]);

--- a/experiments/storybook/.storybook/vitest.setup.ts
+++ b/experiments/storybook/.storybook/vitest.setup.ts
@@ -1,4 +1,7 @@
 import { setProjectAnnotations } from "@storybook/html-vite";
+import { beforeAll } from "vitest";
 import * as previewAnnotations from "./preview";
 
-setProjectAnnotations([previewAnnotations]);
+const annotations = setProjectAnnotations([previewAnnotations]);
+
+beforeAll(annotations.beforeAll);

--- a/experiments/storybook/README.md
+++ b/experiments/storybook/README.md
@@ -1,0 +1,56 @@
+# Defend Storybook Lab
+
+This package is an isolated modern browser workshop for Defend experiments. It intentionally does not participate in the legacy root Webpack/TypeScript build.
+
+## Requirements
+
+- Node.js 20.19 or newer.
+- Install dependencies from this directory only.
+- Install Playwright Chromium before browser tests when it is not already present.
+
+## Commands
+
+```sh
+cd experiments/storybook
+npm install
+npx playwright install chromium
+npm run storybook
+npm run build-storybook
+npm run test-storybook
+```
+
+Commit the generated lockfile only after local installation confirms the pinned dependency set is coherent.
+
+## Story taxonomy
+
+Use these stable prefixes:
+
+- `Diagnostics/*`
+- `Foundations/Topology/*`
+- `Foundations/Physics/*`
+- `Audio/Materials/*`
+- `Audio/Spatial/*`
+- `Audio/Visualization/*`
+- `Arena/Camera/*`
+- `Arena/Interaction/*`
+- `Gameplay/Towers/*`
+- `Gameplay/Enemies/*`
+- `Gameplay/Projectiles/*`
+
+Tag stories according to their intended use. Prefer `test` and `visual` for deterministic browser-testable stories; use `experimental`, `manual-audio`, or `performance` for states that should not become ordinary blocking gates.
+
+## Ownership boundary
+
+Storybook may mount DOM, SVG, Canvas, Web Audio controls, or explicitly-created Babylon scenes. Stories should import renderer-independent project modules when practical rather than duplicating formulas.
+
+Do not use this package as the sole certification environment for AudioWorklet latency/underruns, full production physics timing, PWA/service-worker behavior, SharedArrayBuffer deployment headers, or long-running soak tests.
+
+## Lifecycle rule
+
+Every story that starts a `requestAnimationFrame` loop, Worker, AudioContext/AudioWorklet, Babylon engine/scene, event subscription, timer, or similar resource must provide deterministic teardown when the story is replaced or reset. Experimental fixtures must not leak state into the next story.
+
+The initial capability story intentionally creates no persistent background work and can therefore serve as the smoke test for the lab itself.
+
+## Root-source imports
+
+Do not broadly expose the repository filesystem through Vite. When a story needs a pure root module, add the narrowest explicit Vite allow-list/alias required and document it in the PR. Modules coupled to the historical Webpack runtime should instead receive a dedicated adapter or standalone fixture.

--- a/experiments/storybook/README.md
+++ b/experiments/storybook/README.md
@@ -4,22 +4,26 @@ This package is an isolated modern browser workshop for Defend experiments. It i
 
 ## Requirements
 
-- Node.js 20.19 or newer.
-- Install dependencies from this directory only.
+- Node.js 24.20.x LTS.
+- pnpm 11.25.0, matching the package's pinned `packageManager` field.
+- Install dependencies from this directory only until the repository-wide modern workspace is introduced.
 - Install Playwright Chromium before browser tests when it is not already present.
 
 ## Commands
 
 ```sh
 cd experiments/storybook
-npm install
-npx playwright install chromium
-npm run storybook
-npm run build-storybook
-npm run test-storybook
+pnpm install
+pnpm exec playwright install chromium
+pnpm typecheck
+pnpm dev
+pnpm build
+pnpm test
 ```
 
-Commit the generated lockfile only after local installation confirms the pinned dependency set is coherent.
+The compatibility aliases `pnpm storybook`, `pnpm build-storybook`, and `pnpm test-storybook` remain available for Storybook-oriented workflows.
+
+Commit the generated `pnpm-lock.yaml` only after local installation confirms the pinned dependency set is coherent. Installation/build/test must not mutate the legacy root dependency graph.
 
 ## Story taxonomy
 
@@ -54,3 +58,7 @@ The initial capability story intentionally creates no persistent background work
 ## Root-source imports
 
 Do not broadly expose the repository filesystem through Vite. When a story needs a pure root module, add the narrowest explicit Vite allow-list/alias required and document it in the PR. Modules coupled to the historical Webpack runtime should instead receive a dedicated adapter or standalone fixture.
+
+## Future workspace integration
+
+When #66 introduces the repository-wide modern workspace, this package should become the canonical `apps/storybook`/Storybook package rather than creating a second lab. Preserve the story taxonomy and browser-test lifecycle while relocating only after the workspace layout is locally certified.

--- a/experiments/storybook/package.json
+++ b/experiments/storybook/package.json
@@ -1,15 +1,20 @@
 {
-  "name": "defend-storybook-lab",
+  "name": "@defend/storybook-lab",
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.25.0",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=24.20.0 <25"
   },
   "scripts": {
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
-    "test-storybook": "vitest --project=storybook"
+    "dev": "storybook dev -p 6006",
+    "build": "storybook build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --project=storybook",
+    "storybook": "pnpm dev",
+    "build-storybook": "pnpm build",
+    "test-storybook": "pnpm test"
   },
   "devDependencies": {
     "@storybook/addon-vitest": "10.6.0",

--- a/experiments/storybook/package.json
+++ b/experiments/storybook/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "defend-storybook-lab",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "test-storybook": "vitest --project=storybook"
+  },
+  "devDependencies": {
+    "@storybook/addon-vitest": "10.6.0",
+    "@storybook/html-vite": "10.6.0",
+    "@vitest/browser-playwright": "4.1.11",
+    "playwright": "1.62.1",
+    "storybook": "10.6.0",
+    "typescript": "7.0.2",
+    "vite": "8.2.2",
+    "vitest": "4.1.11"
+  }
+}

--- a/experiments/storybook/src/Diagnostics/CapabilityMatrix.stories.ts
+++ b/experiments/storybook/src/Diagnostics/CapabilityMatrix.stories.ts
@@ -1,0 +1,247 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+type Capability = {
+  label: string;
+  supported: boolean;
+  detail: string;
+};
+
+function supportsWebGl2(): boolean {
+  const canvas = document.createElement("canvas");
+  return canvas.getContext("webgl2") !== null;
+}
+
+function collectCapabilities(): Capability[] {
+  return [
+    {
+      label: "AudioWorklet",
+      supported: "AudioWorkletNode" in window,
+      detail: "Low-latency custom procedural DSP"
+    },
+    {
+      label: "Dedicated Worker",
+      supported: "Worker" in window,
+      detail: "Event aggregation and planning off the gameplay thread"
+    },
+    {
+      label: "OffscreenCanvas",
+      supported: "OffscreenCanvas" in window,
+      detail: "Optional worker-side diagnostics and sound visualization"
+    },
+    {
+      label: "WebGL2",
+      supported: supportsWebGl2(),
+      detail: "Wide-support accelerated presentation baseline"
+    },
+    {
+      label: "WebGPU",
+      supported: "gpu" in navigator,
+      detail: "Optional experimental presentation path"
+    },
+    {
+      label: "SharedArrayBuffer",
+      supported: typeof SharedArrayBuffer !== "undefined",
+      detail: "Optional shared-memory control path"
+    },
+    {
+      label: "Cross-origin isolated",
+      supported: self.crossOriginIsolated === true,
+      detail: "Required before relying on SharedArrayBuffer"
+    }
+  ];
+}
+
+function capabilityMarkup(capability: Capability): string {
+  const state = capability.supported ? "available" : "unavailable";
+  return `
+    <li class="capability capability--${state}">
+      <span class="capability__state" aria-hidden="true"></span>
+      <span>
+        <strong>${capability.label}</strong>
+        <small>${capability.detail}</small>
+      </span>
+      <span class="capability__value">${state}</span>
+    </li>
+  `;
+}
+
+function renderCapabilityList(target: HTMLElement): void {
+  target.innerHTML = collectCapabilities().map(capabilityMarkup).join("");
+}
+
+const meta = {
+  title: "Diagnostics/Capability Matrix",
+  tags: ["test", "visual"],
+  render: () => {
+    const root = document.createElement("main");
+    root.className = "lab";
+    root.innerHTML = `
+      <style>
+        .lab {
+          min-height: 100vh;
+          box-sizing: border-box;
+          padding: clamp(24px, 5vw, 72px);
+          color: #f4edf7;
+          background:
+            radial-gradient(circle at 50% 35%, rgba(173, 97, 26, 0.14), transparent 28%),
+            #1c0530;
+          font: 14px/1.45 system-ui, sans-serif;
+        }
+        .lab__frame {
+          width: min(900px, 100%);
+          margin: 0 auto;
+        }
+        .lab__eyebrow {
+          margin: 0 0 8px;
+          color: #d7a46c;
+          text-transform: uppercase;
+          letter-spacing: 0.14em;
+          font-size: 11px;
+        }
+        h1 {
+          margin: 0;
+          font-size: clamp(28px, 5vw, 52px);
+          font-weight: 540;
+          letter-spacing: -0.035em;
+        }
+        .lab__intro {
+          max-width: 720px;
+          margin: 16px 0 32px;
+          color: rgba(244, 237, 247, 0.68);
+          font-size: 16px;
+        }
+        .lab__visual {
+          display: grid;
+          place-items: center;
+          min-height: 210px;
+          margin: 28px 0;
+          border: 1px solid rgba(215, 164, 108, 0.2);
+          background: rgba(10, 2, 18, 0.34);
+        }
+        .lab__visual svg {
+          width: min(340px, 72vw);
+          overflow: visible;
+        }
+        .lab__visual polygon,
+        .lab__visual circle {
+          fill: none;
+          stroke: #d7a46c;
+          vector-effect: non-scaling-stroke;
+        }
+        .lab__visual polygon { opacity: 0.9; }
+        .lab__visual circle { opacity: 0.22; }
+        .capabilities {
+          display: grid;
+          gap: 1px;
+          padding: 0;
+          margin: 0;
+          list-style: none;
+          background: rgba(215, 164, 108, 0.12);
+          border: 1px solid rgba(215, 164, 108, 0.12);
+        }
+        .capability {
+          display: grid;
+          grid-template-columns: 10px 1fr auto;
+          gap: 14px;
+          align-items: center;
+          padding: 13px 15px;
+          background: rgba(18, 4, 31, 0.92);
+        }
+        .capability__state {
+          width: 7px;
+          height: 7px;
+          border-radius: 50%;
+          background: currentColor;
+        }
+        .capability--available { color: #e4b980; }
+        .capability--unavailable { color: rgba(244, 237, 247, 0.38); }
+        .capability strong,
+        .capability small {
+          display: block;
+        }
+        .capability small {
+          margin-top: 2px;
+          color: rgba(244, 237, 247, 0.54);
+        }
+        .capability__value {
+          color: rgba(244, 237, 247, 0.5);
+          font-size: 12px;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+        }
+        .lab__actions {
+          margin-top: 18px;
+        }
+        button {
+          appearance: none;
+          border: 1px solid rgba(215, 164, 108, 0.45);
+          border-radius: 0;
+          padding: 10px 14px;
+          color: #f4edf7;
+          background: rgba(173, 97, 26, 0.12);
+          font: inherit;
+          cursor: pointer;
+        }
+        button:focus-visible {
+          outline: 2px solid #e4b980;
+          outline-offset: 3px;
+        }
+      </style>
+      <section class="lab__frame">
+        <p class="lab__eyebrow">Diagnostics / Browser laboratory</p>
+        <h1>Defend Storybook Lab</h1>
+        <p class="lab__intro">
+          A separate modern browser workshop for deterministic gameplay, spatial audio,
+          vector presentation, camera, and interaction experiments. Production remains
+          on the historical application toolchain until migration is explicitly certified.
+        </p>
+        <div class="lab__visual" aria-hidden="true">
+          <svg viewBox="-120 -120 240 240">
+            <circle r="96" />
+            <circle r="68" />
+            <circle r="40" />
+            <polygon points="0,-28 24,-14 24,14 0,28 -24,14 -24,-14" />
+          </svg>
+        </div>
+        <ul class="capabilities" data-capabilities></ul>
+        <div class="lab__actions">
+          <button type="button" data-recheck data-check-count="0">Recheck capabilities</button>
+        </div>
+      </section>
+    `;
+
+    const list = root.querySelector<HTMLElement>("[data-capabilities]");
+    const button = root.querySelector<HTMLButtonElement>("[data-recheck]");
+
+    if (list) {
+      renderCapabilityList(list);
+    }
+
+    button?.addEventListener("click", () => {
+      if (list) {
+        renderCapabilityList(list);
+      }
+      const checks = Number(button.dataset.checkCount || "0") + 1;
+      button.dataset.checkCount = String(checks);
+    });
+
+    return root;
+  }
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BrowserCapabilities: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", { name: "Defend Storybook Lab" })
+    ).toBeVisible();
+
+    const recheck = canvas.getByRole("button", { name: "Recheck capabilities" });
+    await userEvent.click(recheck);
+    await expect(recheck).toHaveAttribute("data-check-count", "1");
+  }
+};

--- a/experiments/storybook/tsconfig.json
+++ b/experiments/storybook/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    ".storybook/**/*.ts",
+    "src/**/*.ts",
+    "vite.config.ts",
+    "vitest.config.ts"
+  ]
+}

--- a/experiments/storybook/vite.config.ts
+++ b/experiments/storybook/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    fs: {
+      strict: true
+    }
+  }
+});

--- a/experiments/storybook/vitest.config.ts
+++ b/experiments/storybook/vitest.config.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      projects: [
+        {
+          extends: true,
+          plugins: [
+            storybookTest({
+              configDir: path.join(dirname, ".storybook"),
+              storybookScript: "npm run storybook -- --no-open"
+            })
+          ],
+          test: {
+            name: "storybook",
+            browser: {
+              enabled: true,
+              provider: playwright({}),
+              headless: true,
+              instances: [{ browser: "chromium" }]
+            },
+            setupFiles: ["./.storybook/vitest.setup.ts"]
+          }
+        }
+      ]
+    }
+  })
+);

--- a/experiments/storybook/vitest.config.ts
+++ b/experiments/storybook/vitest.config.ts
@@ -17,7 +17,11 @@ export default mergeConfig(
           plugins: [
             storybookTest({
               configDir: path.join(dirname, ".storybook"),
-              storybookScript: "npm run storybook -- --no-open"
+              storybookScript: "pnpm dev -- --no-open",
+              tags: {
+                include: ["test"],
+                exclude: ["experimental", "manual-audio", "performance"]
+              }
             })
           ],
           test: {


### PR DESCRIPTION
Refs #64
Related: #31, #52, #53, #56, #58, #60, #63, #66

## Scope

Add a modern Storybook/Vite browser laboratory under `experiments/storybook/` without changing the root application package, Webpack 4 configuration, production bundle, gameplay code, audio code, or runtime behavior.

## Why isolated

The historical game currently uses TypeScript 3.2.2 + Webpack 4.28.0. Current Storybook 10.6 is ESM-only and targets a modern Node/Vite toolchain. Putting Storybook directly into the legacy root would unnecessarily couple experimental tooling to the production modernization path.

This PR instead creates a separate private package that can evolve independently and later become the canonical Storybook app inside the modern workspace from #66.

## Modern toolchain alignment

The lab now uses the same modern baseline as #66/#67 instead of introducing a second convention:

- Node 24.20.x LTS;
- pnpm 11.25.0 via the package `packageManager` field;
- Storybook 10.6.0 + `@storybook/html-vite` 10.6.0;
- Vite 8.2.2;
- TypeScript 7.0.2;
- Vitest 4.1.11 + Storybook Vitest addon;
- Playwright 1.62.1 Chromium browser provider.

The root legacy package remains untouched.

## Included

- fullscreen Storybook preview and stable story taxonomy;
- isolated `vite.config.ts` with strict filesystem serving;
- browser-test project using `storybookTest()`;
- project-annotation setup for portable story tests, including the returned Storybook `beforeAll` hook;
- automated test selection that includes `test` stories and excludes `experimental`, `manual-audio`, and `performance` stories;
- first `Diagnostics/Capability Matrix` story;
- deterministic interaction assertion for the capability recheck control;
- documentation for story ownership, teardown, tags, and what Storybook must not replace;
- local output ignores;
- pnpm-compatible `dev`, `build`, `typecheck`, and deterministic `test` scripts plus Storybook naming aliases.

## First story

`Diagnostics/Capability Matrix` renders a restrained Defend-aligned vector surface and reports availability for:

- AudioWorklet;
- Dedicated Worker;
- OffscreenCanvas;
- WebGL2;
- WebGPU;
- SharedArrayBuffer;
- cross-origin isolation.

It deliberately creates no AudioContext, Worker, RAF loop, Babylon scene, timer, or persistent resource, so it is suitable as the initial smoke/interaction fixture.

The story carries `test` and `visual` tags and includes a `play` test that confirms rendering and interaction state.

## Research basis

Current Storybook guidance recommends Vite-backed Vitest browser tests for real-browser story testing. The current Vitest-addon configuration follows the documented Vitest 4 project pattern and applies Storybook project annotations in setup.

Relevant current references:
- https://storybook.js.org/docs/get-started/install
- https://storybook.js.org/docs/writing-tests/integrations/vitest-addon
- https://storybook.js.org/docs/writing-tests/interaction-testing
- https://storybook.js.org/docs/builders/vite
- https://storybook.js.org/releases/10.6

## Story/test policy

Storybook is both a human playground and a deterministic browser fixture catalog, but not every experiment should block normal validation.

- `test`: deterministic automated story gate;
- `visual`: useful for screenshot/alignment inspection;
- `experimental`: excluded from ordinary automated tests;
- `manual-audio`: requires listening/user gesture and is excluded from the deterministic test project;
- `performance`: measurement fixture, not a normal correctness gate.

## Not included

- no root `package.json` changes;
- no root lockfile changes;
- no CI/workflow changes;
- no import of draft gameplay/audio modules yet;
- no Babylon mounting yet;
- no AudioWorklet or Worker runtime yet;
- no visual regression service;
- no PWA/COOP/COEP changes.

## Local certification before promotion

From `experiments/storybook/`:

1. use Node 24.20.x LTS and pnpm 11.25.0;
2. run `pnpm install` and commit the generated local lockfile only after the dependency graph is confirmed coherent;
3. run `pnpm exec playwright install chromium` if Chromium is not installed;
4. run `pnpm typecheck`;
5. run `pnpm dev` and confirm the capability story renders/interacts;
6. run `pnpm build`;
7. run `pnpm test` and confirm the story browser test passes;
8. verify an `experimental` story would be excluded from the normal `storybook` Vitest project;
9. verify no root tracked files change during install/build/test;
10. verify static output and caches remain ignored;
11. inspect browser console for Storybook/Vite/HTML renderer warnings;
12. profile startup/build enough to ensure this lab does not create an unreasonable local executor burden.

After this passes, follow-up stories should be stacked separately for #57 hex topology, #59 terrain deformation, #54 material acoustics, #61/#62 spatial audio, and #67 hybrid-renderer diagnostics rather than broadening this scaffold PR.

## Gameplay impact

None. Keep draft until local install/build/browser-test evidence is posted.