### PR TITLE
Spike Babylon 9 rendering with a headless Bevy ECS WASM runtime

### DIFF
--- a/experiments/hybrid-engine/.gitignore
+++ b/experiments/hybrid-engine/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+pkg/
+rust/target/
+*.log

--- a/experiments/hybrid-engine/README.md
+++ b/experiments/hybrid-engine/README.md
@@ -20,6 +20,7 @@ The initial runtime intentionally uses only `bevy_app`, `bevy_ecs` and `bevy_mat
 - Vite 8.2.2
 - TypeScript 7.0.2
 - Biome 2.5.11
+- Vitest 4.1.11
 - Babylon.js 9.23.0
 - Rust 1.98.0 / edition 2024
 - Bevy modular crates 0.19.1
@@ -36,16 +37,45 @@ Install `wasm-pack` 0.15.0 and use Node 24 LTS, then from this directory:
 
 ```sh
 pnpm install
+pnpm test
+pnpm check
+pnpm build
 pnpm dev
 ```
 
-`pnpm dev` first compiles `rust/` to `pkg/`, then starts Vite.
+`pnpm build` and `pnpm dev` first compile `rust/` to `pkg/`.
 
 Use `?inspect=1` to start Babylon's headless Inspector bridge for agent-driven scene inspection.
 
 ## Current fixture
 
-The first fixture creates 128 semantic bodies in the Rust/Bevy ECS runtime and returns flat xyz triples every frame. Babylon creates lightweight instances and renders those positions.
+The fixture creates 128 semantic bodies in the Rust/Bevy ECS runtime. Babylon creates lightweight instances and renders a copied xyz snapshot from the authoritative runtime.
+
+Two protocol rules are explicit even in this first lab:
+
+1. **Stable external identity.** The runtime assigns monotonic public body ids and keeps a registry mapping them to Bevy `Entity` handles. Babylon never treats ECS query/archetype iteration order as object identity.
+2. **Fixed authoritative time.** The runtime advances only through exact 120 Hz `step_fixed(n)` calls. The browser converts render-frame time into fixed ticks using a pure bounded accumulator. Render cadence and catch-up policy therefore do not become simulation state.
+
+The browser fetches the stable id table once for this no-lifecycle fixture, then receives flat xyz triples in the same registry order each frame. Future spawn/despawn behavior must become explicit lifecycle protocol events rather than relying on array positions.
+
+## Deterministic tests
+
+Rust tests currently cover:
+
+- monotonic public body ids and stable snapshot order;
+- fixed-step partition invariance: advancing 240 ticks in one batch equals advancing 60 then 180 ticks.
+
+Vitest tests cover the browser-side fixed-step accumulator:
+
+- 60 Hz and 120 Hz render cadences produce the same authoritative tick count;
+- fractional render frames accumulate correctly;
+- long frames use bounded catch-up and record discarded backlog;
+- a zero catch-up budget has explicit behavior;
+- non-finite timing input is sanitized.
+
+These tests are committed as executable contracts but remain uncertified until run locally.
+
+## Baseline measurements
 
 The deliberately simple copy boundary gives us a measurable baseline for:
 
@@ -54,9 +84,10 @@ The deliberately simple copy boundary gives us a measurable baseline for:
 - per-frame snapshot size;
 - Babylon frame time;
 - Bevy ECS fixed-step/update cost;
-- bundle size and cold-start behavior.
+- bundle size and cold-start behavior;
+- catch-up behavior under artificial long frames.
 
-Do not introduce shared memory or binary protocol complexity until this baseline shows that the copy is material.
+Do not introduce shared memory, raw WASM memory views or binary protocol complexity until this baseline shows that the copy is material.
 
 ## Next backend comparisons
 
@@ -78,9 +109,11 @@ For physics variants, compare contact/knockback behavior against Defend's charac
 - `cargo fmt --check`, `cargo clippy`, and `cargo test` succeed for the runtime crate.
 - `pnpm check`, `pnpm test`, and `pnpm build` succeed.
 - Browser fixture renders all 128 bodies with no console errors.
-- Babylon Inspector bridge works when requested.
-- Record raw/compressed JS+WASM sizes, initialization time, first interactive frame, steady FPS and transform-copy cost.
-- Confirm no Bevy renderer/window dependencies appear in `cargo tree`.
+- 60/120/144 Hz display cadences preserve the expected fixed simulation rate.
+- an artificial long frame cannot trigger an unbounded catch-up spiral and reports dropped backlog.
+- Babylon Inspector bridge works when requested and disconnects on teardown.
+- record raw/compressed JS+WASM sizes, initialization time, first interactive frame, steady FPS, simulation-step time and transform-copy cost.
+- confirm no Bevy renderer/window dependencies appear in `cargo tree`.
 
 ## Scope boundary
 

--- a/experiments/hybrid-engine/README.md
+++ b/experiments/hybrid-engine/README.md
@@ -1,0 +1,87 @@
+# Defend hybrid engine lab
+
+This isolated experiment tests the architecture proposed in #66:
+
+- Babylon.js 9 owns browser rendering, camera, picking and diagnostics.
+- A headless Bevy 0.19 ECS app compiled to WASM owns semantic body state.
+- Rapier 0.20 and Babylon Havok are pinned for subsequent same-scene physics comparisons.
+- The historical Webpack 4 / Babylon 3 / Cannon application is untouched.
+
+## Why this shape
+
+The useful combination is **Bevy as a modular simulation framework + Babylon as the browser renderer**. Running both complete render engines in one production page would duplicate GPU resources, transforms, scene graphs and debugging surfaces.
+
+The initial runtime intentionally uses only `bevy_app`, `bevy_ecs` and `bevy_math`. It does not enable Bevy rendering, windows, UI, input or audio.
+
+## Toolchain
+
+- Node 24.20 LTS
+- pnpm 11.25.0
+- Vite 8.2.2
+- TypeScript 7.0.2
+- Biome 2.5.11
+- Babylon.js 9.23.0
+- Rust 1.98.0 / edition 2024
+- Bevy modular crates 0.19.1
+- wasm-bindgen 0.2.127
+- wasm-pack 0.15.0
+- Rapier JS 0.20.0
+- Babylon Havok 1.3.14
+
+Versions are pinned for reproducible experiments. They should be updated deliberately rather than floating on `latest` during certification.
+
+## Run locally
+
+Install `wasm-pack` 0.15.0 and use Node 24 LTS, then from this directory:
+
+```sh
+pnpm install
+pnpm dev
+```
+
+`pnpm dev` first compiles `rust/` to `pkg/`, then starts Vite.
+
+Use `?inspect=1` to start Babylon's headless Inspector bridge for agent-driven scene inspection.
+
+## Current fixture
+
+The first fixture creates 128 semantic bodies in the Rust/Bevy ECS runtime and returns flat xyz triples every frame. Babylon creates lightweight instances and renders those positions.
+
+The deliberately simple copy boundary gives us a measurable baseline for:
+
+- WASM initialization cost;
+- JS↔WASM transform copy cost;
+- per-frame snapshot size;
+- Babylon frame time;
+- Bevy ECS fixed-step/update cost;
+- bundle size and cold-start behavior.
+
+Do not introduce shared memory or binary protocol complexity until this baseline shows that the copy is material.
+
+## Next backend comparisons
+
+Use the same visual fixture and seeded initial conditions for:
+
+1. Babylon + JS state only.
+2. Babylon + Rapier JS/WASM 0.20.
+3. Babylon + Bevy ECS WASM (this baseline).
+4. Babylon + Bevy ECS + Rust Rapier WASM.
+5. Babylon + Havok 1.3.14.
+6. A separate full-Bevy web sample for renderer/startup comparison only.
+
+For physics variants, compare contact/knockback behavior against Defend's characterized Cannon baseline before selecting an engine.
+
+## Required local certification before promotion
+
+- `pnpm install` succeeds and produces a committed lockfile without touching the repository root dependency graph.
+- `wasm-pack build ./rust --target web --out-dir ../pkg --out-name defend_hybrid_runtime` succeeds.
+- `cargo fmt --check`, `cargo clippy`, and `cargo test` succeed for the runtime crate.
+- `pnpm check`, `pnpm test`, and `pnpm build` succeed.
+- Browser fixture renders all 128 bodies with no console errors.
+- Babylon Inspector bridge works when requested.
+- Record raw/compressed JS+WASM sizes, initialization time, first interactive frame, steady FPS and transform-copy cost.
+- Confirm no Bevy renderer/window dependencies appear in `cargo tree`.
+
+## Scope boundary
+
+This lab is evidence, not a production migration. Production ownership should only move after the comparative fixtures demonstrate better determinism, maintainability, performance, or cross-platform reuse at acceptable startup and bundle cost.

--- a/experiments/hybrid-engine/biome.json
+++ b/experiments/hybrid-engine/biome.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
+  "files": {
+    "includes": ["**", "!pkg", "!dist", "!node_modules"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/experiments/hybrid-engine/index.html
+++ b/experiments/hybrid-engine/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defend Hybrid Engine Lab</title>
+    <style>
+      html, body, #app, canvas { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #08050d; color: #e8d8c0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      canvas { display: block; touch-action: none; }
+      #metrics { position: fixed; top: 12px; left: 12px; z-index: 2; padding: 8px 10px; border: 1px solid rgba(214, 145, 76, .35); background: rgba(8, 5, 13, .78); font-size: 12px; line-height: 1.45; pointer-events: none; }
+    </style>
+  </head>
+  <body>
+    <div id="app"><canvas id="renderCanvas"></canvas></div>
+    <div id="metrics">initializing…</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/experiments/hybrid-engine/package.json
+++ b/experiments/hybrid-engine/package.json
@@ -11,7 +11,7 @@
     "wasm": "wasm-pack build ./rust --target web --out-dir ../pkg --out-name defend_hybrid_runtime",
     "dev": "pnpm wasm && vite",
     "build": "pnpm wasm && tsc --noEmit && vite build",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "check": "biome check ."
   },
   "dependencies": {

--- a/experiments/hybrid-engine/package.json
+++ b/experiments/hybrid-engine/package.json
@@ -11,7 +11,7 @@
     "wasm": "wasm-pack build ./rust --target web --out-dir ../pkg --out-name defend_hybrid_runtime",
     "dev": "pnpm wasm && vite",
     "build": "pnpm wasm && tsc --noEmit && vite build",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "check": "biome check ."
   },
   "dependencies": {

--- a/experiments/hybrid-engine/package.json
+++ b/experiments/hybrid-engine/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@defend/hybrid-engine-lab",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.25.0",
+  "engines": {
+    "node": ">=24.20.0 <25"
+  },
+  "scripts": {
+    "wasm": "wasm-pack build ./rust --target web --out-dir ../pkg --out-name defend_hybrid_runtime",
+    "dev": "pnpm wasm && vite",
+    "build": "pnpm wasm && tsc --noEmit && vite build",
+    "test": "vitest run",
+    "check": "biome check ."
+  },
+  "dependencies": {
+    "@babylonjs/accessibility": "9.23.0",
+    "@babylonjs/core": "9.23.0",
+    "@babylonjs/havok": "1.3.14",
+    "@dimforge/rapier3d": "0.20.0"
+  },
+  "devDependencies": {
+    "@babylonjs/inspector": "9.23.0",
+    "@biomejs/biome": "2.5.11",
+    "typescript": "7.0.2",
+    "vite": "8.2.2",
+    "vitest": "4.1.11"
+  }
+}

--- a/experiments/hybrid-engine/rust/Cargo.toml
+++ b/experiments/hybrid-engine/rust/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "defend-hybrid-runtime"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.98"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+bevy_app = { version = "0.19.1", default-features = false, features = ["std"] }
+bevy_ecs = { version = "0.19.1", default-features = false, features = ["std"] }
+bevy_math = { version = "0.19.1", default-features = false, features = ["std"] }
+wasm-bindgen = "0.2.127"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+panic = "abort"
+strip = "symbols"

--- a/experiments/hybrid-engine/rust/rust-toolchain.toml
+++ b/experiments/hybrid-engine/rust/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"
+targets = ["wasm32-unknown-unknown"]
+components = ["clippy", "rustfmt"]

--- a/experiments/hybrid-engine/rust/src/lib.rs
+++ b/experiments/hybrid-engine/rust/src/lib.rs
@@ -3,6 +3,8 @@ use bevy_ecs::prelude::*;
 use bevy_math::Vec3;
 use wasm_bindgen::prelude::*;
 
+const FIXED_DELTA_SECONDS: f32 = 1.0 / 120.0;
+
 #[derive(Component)]
 struct Position(Vec3);
 
@@ -12,6 +14,12 @@ struct Velocity(Vec3);
 #[derive(Resource)]
 struct StepDelta(f32);
 
+#[derive(Clone, Copy)]
+struct BodyHandle {
+    id: u32,
+    entity: Entity,
+}
+
 fn integrate(mut bodies: Query<(&mut Position, &Velocity)>, delta: Res<StepDelta>) {
     for (mut position, velocity) in &mut bodies {
         position.0 += velocity.0 * delta.0;
@@ -20,9 +28,16 @@ fn integrate(mut bodies: Query<(&mut Position, &Velocity)>, delta: Res<StepDelta
 
 /// Headless Bevy ECS runtime used only by the Babylon/Bevy comparative lab.
 /// Babylon owns browser rendering; this runtime owns semantic body state.
+///
+/// The public stepping API is deliberately fixed-tick. Render cadence and wall
+/// clock accumulation belong to the host so replay/certification can request an
+/// exact number of authoritative simulation ticks independent of frame rate.
 #[wasm_bindgen]
 pub struct DefendRuntime {
     app: App,
+    bodies: Vec<BodyHandle>,
+    next_body_id: u32,
+    tick: u32,
 }
 
 #[wasm_bindgen]
@@ -30,11 +45,29 @@ impl DefendRuntime {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         let mut app = App::new();
-        app.insert_resource(StepDelta(0.0));
+        app.insert_resource(StepDelta(FIXED_DELTA_SECONDS));
         app.add_systems(Update, integrate);
-        Self { app }
+        Self {
+            app,
+            bodies: Vec::new(),
+            next_body_id: 0,
+            tick: 0,
+        }
     }
 
+    pub fn fixed_delta_seconds(&self) -> f32 {
+        FIXED_DELTA_SECONDS
+    }
+
+    pub fn tick(&self) -> u32 {
+        self.tick
+    }
+
+    /// Spawn one semantic body and return a stable external id.
+    ///
+    /// Babylon and future protocol consumers must not depend on Bevy query or
+    /// archetype iteration order for identity. The runtime therefore retains an
+    /// explicit stable body order separate from ECS storage order.
     pub fn spawn_body(
         &mut self,
         x: f32,
@@ -43,30 +76,59 @@ impl DefendRuntime {
         velocity_x: f32,
         velocity_y: f32,
         velocity_z: f32,
-    ) {
-        self.app.world_mut().spawn((
-            Position(Vec3::new(x, y, z)),
-            Velocity(Vec3::new(velocity_x, velocity_y, velocity_z)),
-        ));
-    }
+    ) -> u32 {
+        let id = self.next_body_id;
+        self.next_body_id = self
+            .next_body_id
+            .checked_add(1)
+            .expect("hybrid lab body id space exhausted");
 
-    pub fn step(&mut self, delta_seconds: f32) {
-        self.app
+        let entity = self
+            .app
             .world_mut()
-            .resource_mut::<StepDelta>()
-            .0 = delta_seconds.clamp(0.0, 1.0 / 15.0);
-        self.app.update();
+            .spawn((
+                Position(Vec3::new(x, y, z)),
+                Velocity(Vec3::new(velocity_x, velocity_y, velocity_z)),
+            ))
+            .id();
+
+        self.bodies.push(BodyHandle { id, entity });
+        id
     }
 
-    /// Flat xyz triples keep the first interoperability fixture deliberately
-    /// transparent. A binary/shared-memory protocol is only justified after
-    /// profiling shows this copy boundary to be material.
-    pub fn positions(&mut self) -> Vec<f32> {
-        let world = self.app.world_mut();
-        let mut query = world.query::<&Position>();
-        let mut positions = Vec::new();
+    /// Advance the authoritative simulation by exactly `steps` fixed ticks.
+    ///
+    /// The host is responsible for deciding how wall-clock time maps to ticks.
+    /// This makes frame pacing an interpolation concern instead of simulation
+    /// state and gives replay fixtures a deterministic primitive.
+    pub fn step_fixed(&mut self, steps: u32) {
+        for _ in 0..steps {
+            self.app.update();
+            self.tick = self.tick.wrapping_add(1);
+        }
+    }
 
-        for position in query.iter(world) {
+    /// Stable ids in the same order as the flat xyz triples returned by
+    /// `positions()`. This first fixture has no lifecycle changes, so callers can
+    /// fetch the ids once after spawn. Future spawn/despawn events should update
+    /// the protocol explicitly rather than relying on array position identity.
+    pub fn body_ids(&self) -> Vec<u32> {
+        self.bodies.iter().map(|body| body.id).collect()
+    }
+
+    /// Flat xyz triples ordered by the explicit stable body registry.
+    ///
+    /// This intentionally performs a straightforward copied snapshot. A direct
+    /// WASM memory view, shared memory, SoA layout, or binary protocol is only
+    /// justified after profiling shows this baseline copy boundary is material.
+    pub fn positions(&self) -> Vec<f32> {
+        let world = self.app.world();
+        let mut positions = Vec::with_capacity(self.bodies.len() * 3);
+
+        for body in &self.bodies {
+            let position = world
+                .get::<Position>(body.entity)
+                .expect("registered hybrid body missing Position");
             positions.push(position.0.x);
             positions.push(position.0.y);
             positions.push(position.0.z);
@@ -79,5 +141,47 @@ impl DefendRuntime {
 impl Default for DefendRuntime {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spawn_linear(runtime: &mut DefendRuntime, x: f32, velocity_x: f32) -> u32 {
+        runtime.spawn_body(x, 0.0, 0.0, velocity_x, 0.0, 0.0)
+    }
+
+    #[test]
+    fn body_ids_are_monotonic_and_snapshot_order_is_stable() {
+        let mut runtime = DefendRuntime::new();
+        let first = spawn_linear(&mut runtime, 1.0, 1.0);
+        let second = spawn_linear(&mut runtime, 10.0, -2.0);
+
+        assert_eq!((first, second), (0, 1));
+        assert_eq!(runtime.body_ids(), vec![0, 1]);
+
+        runtime.step_fixed(120);
+        let positions = runtime.positions();
+
+        assert_eq!(positions.len(), 6);
+        assert!((positions[0] - 2.0).abs() < 0.0001);
+        assert!((positions[3] - 8.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn fixed_step_partitioning_produces_the_same_state() {
+        let mut one_batch = DefendRuntime::new();
+        let mut split_batches = DefendRuntime::new();
+        spawn_linear(&mut one_batch, -4.0, 3.25);
+        spawn_linear(&mut split_batches, -4.0, 3.25);
+
+        one_batch.step_fixed(240);
+        split_batches.step_fixed(60);
+        split_batches.step_fixed(180);
+
+        assert_eq!(one_batch.tick(), 240);
+        assert_eq!(split_batches.tick(), 240);
+        assert_eq!(one_batch.positions(), split_batches.positions());
     }
 }

--- a/experiments/hybrid-engine/rust/src/lib.rs
+++ b/experiments/hybrid-engine/rust/src/lib.rs
@@ -1,0 +1,83 @@
+use bevy_app::{App, Update};
+use bevy_ecs::prelude::*;
+use bevy_math::Vec3;
+use wasm_bindgen::prelude::*;
+
+#[derive(Component)]
+struct Position(Vec3);
+
+#[derive(Component)]
+struct Velocity(Vec3);
+
+#[derive(Resource)]
+struct StepDelta(f32);
+
+fn integrate(mut bodies: Query<(&mut Position, &Velocity)>, delta: Res<StepDelta>) {
+    for (mut position, velocity) in &mut bodies {
+        position.0 += velocity.0 * delta.0;
+    }
+}
+
+/// Headless Bevy ECS runtime used only by the Babylon/Bevy comparative lab.
+/// Babylon owns browser rendering; this runtime owns semantic body state.
+#[wasm_bindgen]
+pub struct DefendRuntime {
+    app: App,
+}
+
+#[wasm_bindgen]
+impl DefendRuntime {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        let mut app = App::new();
+        app.insert_resource(StepDelta(0.0));
+        app.add_systems(Update, integrate);
+        Self { app }
+    }
+
+    pub fn spawn_body(
+        &mut self,
+        x: f32,
+        y: f32,
+        z: f32,
+        velocity_x: f32,
+        velocity_y: f32,
+        velocity_z: f32,
+    ) {
+        self.app.world_mut().spawn((
+            Position(Vec3::new(x, y, z)),
+            Velocity(Vec3::new(velocity_x, velocity_y, velocity_z)),
+        ));
+    }
+
+    pub fn step(&mut self, delta_seconds: f32) {
+        self.app
+            .world_mut()
+            .resource_mut::<StepDelta>()
+            .0 = delta_seconds.clamp(0.0, 1.0 / 15.0);
+        self.app.update();
+    }
+
+    /// Flat xyz triples keep the first interoperability fixture deliberately
+    /// transparent. A binary/shared-memory protocol is only justified after
+    /// profiling shows this copy boundary to be material.
+    pub fn positions(&mut self) -> Vec<f32> {
+        let world = self.app.world_mut();
+        let mut query = world.query::<&Position>();
+        let mut positions = Vec::with_capacity(query.iter(world).len() * 3);
+
+        for position in query.iter(world) {
+            positions.push(position.0.x);
+            positions.push(position.0.y);
+            positions.push(position.0.z);
+        }
+
+        positions
+    }
+}
+
+impl Default for DefendRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/experiments/hybrid-engine/rust/src/lib.rs
+++ b/experiments/hybrid-engine/rust/src/lib.rs
@@ -4,6 +4,8 @@ use bevy_math::Vec3;
 use wasm_bindgen::prelude::*;
 
 const FIXED_DELTA_SECONDS: f32 = 1.0 / 120.0;
+const FNV1A_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV1A_PRIME: u64 = 0x00000100000001b3;
 
 #[derive(Component)]
 struct Position(Vec3);
@@ -24,6 +26,23 @@ fn integrate(mut bodies: Query<(&mut Position, &Velocity)>, delta: Res<StepDelta
     for (mut position, velocity) in &mut bodies {
         position.0 += velocity.0 * delta.0;
     }
+}
+
+fn hash_bytes(hash: &mut u64, bytes: &[u8]) {
+    for byte in bytes {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(FNV1A_PRIME);
+    }
+}
+
+fn hash_u32(hash: &mut u64, value: u32) {
+    hash_bytes(hash, &value.to_le_bytes());
+}
+
+fn hash_vec3(hash: &mut u64, value: Vec3) {
+    hash_u32(hash, value.x.to_bits());
+    hash_u32(hash, value.y.to_bits());
+    hash_u32(hash, value.z.to_bits());
 }
 
 /// Headless Bevy ECS runtime used only by the Babylon/Bevy comparative lab.
@@ -136,6 +155,38 @@ impl DefendRuntime {
 
         positions
     }
+
+    /// Return a deterministic fingerprint of public semantic state.
+    ///
+    /// The hash deliberately excludes Bevy `Entity` ids and storage layout.
+    /// Stable public body ids, tick, positions, and velocities are hashed by
+    /// their exact little-endian IEEE-754 bit patterns. The hexadecimal string
+    /// avoids exposing a WASM `u64`/BigInt ABI solely for diagnostics.
+    ///
+    /// FNV-1a is used as a lightweight divergence detector, not as a security or
+    /// collision-proof content identifier. Full serialized fixtures remain the
+    /// authority when a hash mismatch needs diagnosis.
+    pub fn state_fingerprint(&self) -> String {
+        let world = self.app.world();
+        let mut hash = FNV1A_OFFSET_BASIS;
+        hash_u32(&mut hash, self.tick);
+        hash_u32(&mut hash, self.bodies.len() as u32);
+
+        for body in &self.bodies {
+            let position = world
+                .get::<Position>(body.entity)
+                .expect("registered hybrid body missing Position");
+            let velocity = world
+                .get::<Velocity>(body.entity)
+                .expect("registered hybrid body missing Velocity");
+
+            hash_u32(&mut hash, body.id);
+            hash_vec3(&mut hash, position.0);
+            hash_vec3(&mut hash, velocity.0);
+        }
+
+        format!("{hash:016x}")
+    }
 }
 
 impl Default for DefendRuntime {
@@ -170,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn fixed_step_partitioning_produces_the_same_state() {
+    fn fixed_step_partitioning_produces_the_same_state_and_fingerprint() {
         let mut one_batch = DefendRuntime::new();
         let mut split_batches = DefendRuntime::new();
         spawn_linear(&mut one_batch, -4.0, 3.25);
@@ -183,5 +234,17 @@ mod tests {
         assert_eq!(one_batch.tick(), 240);
         assert_eq!(split_batches.tick(), 240);
         assert_eq!(one_batch.positions(), split_batches.positions());
+        assert_eq!(one_batch.state_fingerprint(), split_batches.state_fingerprint());
+    }
+
+    #[test]
+    fn fingerprint_changes_when_authoritative_state_changes() {
+        let mut runtime = DefendRuntime::new();
+        spawn_linear(&mut runtime, 0.0, 1.0);
+        let before = runtime.state_fingerprint();
+
+        runtime.step_fixed(1);
+
+        assert_ne!(before, runtime.state_fingerprint());
     }
 }

--- a/experiments/hybrid-engine/rust/src/lib.rs
+++ b/experiments/hybrid-engine/rust/src/lib.rs
@@ -64,7 +64,7 @@ impl DefendRuntime {
     pub fn positions(&mut self) -> Vec<f32> {
         let world = self.app.world_mut();
         let mut query = world.query::<&Position>();
-        let mut positions = Vec::with_capacity(query.iter(world).len() * 3);
+        let mut positions = Vec::new();
 
         for position in query.iter(world) {
             positions.push(position.0.x);

--- a/experiments/hybrid-engine/src/fixedStep.test.ts
+++ b/experiments/hybrid-engine/src/fixedStep.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  INITIAL_FIXED_STEP_STATE,
+  advanceFixedStep,
+  type FixedStepPolicy,
+  type FixedStepState,
+} from "./fixedStep";
+
+const policy: FixedStepPolicy = {
+  fixedDeltaSeconds: 1 / 120,
+  maxCatchUpSteps: 8,
+  maxFrameDeltaSeconds: 0.25,
+};
+
+function simulateFrames(frameCount: number, frameDeltaSeconds: number): {
+  ticks: number;
+  state: FixedStepState;
+} {
+  let state = INITIAL_FIXED_STEP_STATE;
+  let ticks = 0;
+
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    const advance = advanceFixedStep(state, frameDeltaSeconds, policy);
+    state = advance.state;
+    ticks += advance.steps;
+  }
+
+  return { ticks, state };
+}
+
+describe("advanceFixedStep", () => {
+  it("produces the same tick count at 60 Hz and 120 Hz render cadence", () => {
+    const sixtyHz = simulateFrames(60, 1 / 60);
+    const oneTwentyHz = simulateFrames(120, 1 / 120);
+
+    expect(sixtyHz.ticks).toBe(120);
+    expect(oneTwentyHz.ticks).toBe(120);
+    expect(sixtyHz.state.droppedSeconds).toBe(0);
+    expect(oneTwentyHz.state.droppedSeconds).toBe(0);
+  });
+
+  it("accumulates fractional render frames without changing simulation time", () => {
+    const first = advanceFixedStep(INITIAL_FIXED_STEP_STATE, 1 / 240, policy);
+    expect(first.steps).toBe(0);
+    expect(first.alpha).toBeCloseTo(0.5, 8);
+
+    const second = advanceFixedStep(first.state, 1 / 240, policy);
+    expect(second.steps).toBe(1);
+    expect(second.alpha).toBeCloseTo(0, 8);
+  });
+
+  it("bounds catch-up and reports discarded backlog after a long frame", () => {
+    const advance = advanceFixedStep(INITIAL_FIXED_STEP_STATE, 1, policy);
+
+    expect(advance.steps).toBe(policy.maxCatchUpSteps);
+    expect(advance.state.accumulatorSeconds).toBeCloseTo(0, 8);
+    expect(advance.state.droppedSeconds).toBeCloseTo(
+      policy.maxFrameDeltaSeconds -
+        policy.fixedDeltaSeconds * policy.maxCatchUpSteps,
+      8,
+    );
+  });
+
+  it("treats a zero catch-up budget as deliberate full virtualization of time", () => {
+    const advance = advanceFixedStep(
+      { accumulatorSeconds: 0.01, droppedSeconds: 0.02 },
+      0.03,
+      { ...policy, maxCatchUpSteps: 0 },
+    );
+
+    expect(advance.steps).toBe(0);
+    expect(advance.alpha).toBe(0);
+    expect(advance.state.accumulatorSeconds).toBe(0);
+    expect(advance.state.droppedSeconds).toBeCloseTo(0.06, 8);
+  });
+
+  it("sanitizes non-finite timing inputs", () => {
+    const advance = advanceFixedStep(
+      { accumulatorSeconds: Number.NaN, droppedSeconds: Number.POSITIVE_INFINITY },
+      Number.NaN,
+      {
+        fixedDeltaSeconds: Number.NaN,
+        maxCatchUpSteps: Number.NaN,
+        maxFrameDeltaSeconds: Number.NaN,
+      },
+    );
+
+    expect(advance.steps).toBe(0);
+    expect(advance.alpha).toBe(0);
+    expect(advance.state.accumulatorSeconds).toBe(0);
+    expect(advance.state.droppedSeconds).toBe(0);
+  });
+});

--- a/experiments/hybrid-engine/src/fixedStep.ts
+++ b/experiments/hybrid-engine/src/fixedStep.ts
@@ -1,0 +1,105 @@
+export interface FixedStepPolicy {
+  fixedDeltaSeconds: number;
+  maxCatchUpSteps: number;
+  maxFrameDeltaSeconds: number;
+}
+
+export interface FixedStepState {
+  accumulatorSeconds: number;
+  droppedSeconds: number;
+}
+
+export interface FixedStepAdvance {
+  state: FixedStepState;
+  steps: number;
+  alpha: number;
+}
+
+export const INITIAL_FIXED_STEP_STATE: FixedStepState = {
+  accumulatorSeconds: 0,
+  droppedSeconds: 0,
+};
+
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function nonNegative(value: number): number {
+  return Math.max(0, finiteOr(value, 0));
+}
+
+function nonNegativeInteger(value: number): number {
+  return Math.max(0, Math.floor(finiteOr(value, 0)));
+}
+
+/**
+ * Convert one render-frame delta into a bounded number of authoritative fixed
+ * simulation ticks.
+ *
+ * The function is deliberately pure. Rendering owns wall-clock accumulation;
+ * the Rust runtime owns only exact tick advancement. If the host falls too far
+ * behind, excess catch-up time is recorded and dropped instead of creating an
+ * unbounded spiral of death.
+ */
+export function advanceFixedStep(
+  previous: FixedStepState,
+  frameDeltaSeconds: number,
+  policy: FixedStepPolicy,
+): FixedStepAdvance {
+  const fixedDeltaSeconds = Math.max(
+    Number.EPSILON,
+    nonNegative(policy.fixedDeltaSeconds),
+  );
+  const maxCatchUpSteps = nonNegativeInteger(policy.maxCatchUpSteps);
+  const maxFrameDeltaSeconds = nonNegative(policy.maxFrameDeltaSeconds);
+  const frameDelta = Math.min(
+    nonNegative(frameDeltaSeconds),
+    maxFrameDeltaSeconds,
+  );
+  const previousAccumulator = nonNegative(previous.accumulatorSeconds);
+  const previousDropped = nonNegative(previous.droppedSeconds);
+
+  if (maxCatchUpSteps === 0) {
+    return {
+      state: {
+        accumulatorSeconds: 0,
+        droppedSeconds: previousDropped + previousAccumulator + frameDelta,
+      },
+      steps: 0,
+      alpha: 0,
+    };
+  }
+
+  const maxAccumulatorSeconds = fixedDeltaSeconds * maxCatchUpSteps;
+  const requestedAccumulator = previousAccumulator + frameDelta;
+  const droppedThisAdvance = Math.max(
+    0,
+    requestedAccumulator - maxAccumulatorSeconds,
+  );
+  const boundedAccumulator = Math.min(
+    requestedAccumulator,
+    maxAccumulatorSeconds,
+  );
+
+  // Add a tiny scale-relative epsilon before flooring to prevent a value that
+  // should represent an exact integral tick count from falling one tick short
+  // due only to ordinary IEEE-754 accumulation noise.
+  const tickEpsilon = fixedDeltaSeconds * 1e-9;
+  const steps = Math.min(
+    Math.floor((boundedAccumulator + tickEpsilon) / fixedDeltaSeconds),
+    maxCatchUpSteps,
+  );
+  const accumulatorSeconds = Math.max(
+    0,
+    boundedAccumulator - steps * fixedDeltaSeconds,
+  );
+
+  return {
+    state: {
+      accumulatorSeconds,
+      droppedSeconds: previousDropped + droppedThisAdvance,
+    },
+    steps,
+    alpha: Math.min(1, accumulatorSeconds / fixedDeltaSeconds),
+  };
+}

--- a/experiments/hybrid-engine/src/main.ts
+++ b/experiments/hybrid-engine/src/main.ts
@@ -9,6 +9,11 @@ import {
   Vector3,
 } from "@babylonjs/core/pure";
 import initRuntime, { DefendRuntime } from "../pkg/defend_hybrid_runtime.js";
+import {
+  INITIAL_FIXED_STEP_STATE,
+  advanceFixedStep,
+  type FixedStepPolicy,
+} from "./fixedStep";
 
 const BODY_COUNT = 128;
 const ARENA_RADIUS = 72;
@@ -106,32 +111,29 @@ async function main(): Promise<void> {
     inspectable = StartInspectable(scene);
   }
 
-  const fixedDeltaSeconds = runtime.fixed_delta_seconds();
-  const maxAccumulatorSeconds = fixedDeltaSeconds * MAX_CATCH_UP_STEPS;
-  let accumulatorSeconds = 0;
-  let droppedSimulationSeconds = 0;
+  const fixedStepPolicy: FixedStepPolicy = {
+    fixedDeltaSeconds: runtime.fixed_delta_seconds(),
+    maxCatchUpSteps: MAX_CATCH_UP_STEPS,
+    maxFrameDeltaSeconds: MAX_FRAME_DELTA_SECONDS,
+  };
+  let fixedStepState = INITIAL_FIXED_STEP_STATE;
   let frame = 0;
   let snapshotBytes = 0;
   let stepsThisFrame = 0;
+  let renderAlpha = 0;
 
   engine.runRenderLoop(() => {
-    const frameDeltaSeconds = Math.min(
-      Math.max(engine.getDeltaTime() / 1000, 0),
-      MAX_FRAME_DELTA_SECONDS,
+    const advance = advanceFixedStep(
+      fixedStepState,
+      engine.getDeltaTime() / 1000,
+      fixedStepPolicy,
     );
-    const requestedAccumulator = accumulatorSeconds + frameDeltaSeconds;
-    if (requestedAccumulator > maxAccumulatorSeconds) {
-      droppedSimulationSeconds += requestedAccumulator - maxAccumulatorSeconds;
-    }
-    accumulatorSeconds = Math.min(requestedAccumulator, maxAccumulatorSeconds);
+    fixedStepState = advance.state;
+    stepsThisFrame = advance.steps;
+    renderAlpha = advance.alpha;
 
-    stepsThisFrame = Math.min(
-      Math.floor(accumulatorSeconds / fixedDeltaSeconds),
-      MAX_CATCH_UP_STEPS,
-    );
     if (stepsThisFrame > 0) {
       runtime.step_fixed(stepsThisFrame);
-      accumulatorSeconds -= stepsThisFrame * fixedDeltaSeconds;
     }
 
     const positions = runtime.positions();
@@ -156,11 +158,11 @@ async function main(): Promise<void> {
         "Babylon 9.23 renderer + Bevy 0.19 ECS/WASM",
         `bodies: ${BODY_COUNT}`,
         `fps: ${engine.getFps().toFixed(1)}`,
-        `simulation: ${(1 / fixedDeltaSeconds).toFixed(0)} Hz fixed tick`,
+        `simulation: ${(1 / fixedStepPolicy.fixedDeltaSeconds).toFixed(0)} Hz fixed tick`,
         `tick: ${runtime.tick()} (${stepsThisFrame} step(s) this frame)`,
-        `render alpha: ${(accumulatorSeconds / fixedDeltaSeconds).toFixed(2)}`,
+        `render alpha: ${renderAlpha.toFixed(2)}`,
         `snapshot: ${snapshotBytes} B/frame + ${snapshotIds.length * Uint32Array.BYTES_PER_ELEMENT} B identity table`,
-        `dropped catch-up time: ${(droppedSimulationSeconds * 1000).toFixed(1)} ms`,
+        `dropped catch-up time: ${(fixedStepState.droppedSeconds * 1000).toFixed(1)} ms`,
         `WebGPU available: ${"gpu" in navigator}`,
         `crossOriginIsolated: ${String(crossOriginIsolated)}`,
         "?inspect=1 enables Babylon Inspector CLI bridge",

--- a/experiments/hybrid-engine/src/main.ts
+++ b/experiments/hybrid-engine/src/main.ts
@@ -12,6 +12,8 @@ import initRuntime, { DefendRuntime } from "../pkg/defend_hybrid_runtime.js";
 
 const BODY_COUNT = 128;
 const ARENA_RADIUS = 72;
+const MAX_CATCH_UP_STEPS = 8;
+const MAX_FRAME_DELTA_SECONDS = 0.25;
 
 async function main(): Promise<void> {
   await initRuntime();
@@ -66,7 +68,9 @@ async function main(): Promise<void> {
   bodyTemplate.isVisible = false;
 
   const runtime = new DefendRuntime();
-  const bodies = Array.from({ length: BODY_COUNT }, (_, index) => {
+  const bodyInstances = new Map<number, ReturnType<typeof bodyTemplate.createInstance>>();
+
+  for (let index = 0; index < BODY_COUNT; index += 1) {
     const angle = (index / BODY_COUNT) * Math.PI * 2;
     const radius = ARENA_RADIUS * (0.72 + (index % 11) / 40);
     const x = Math.cos(angle) * radius;
@@ -77,7 +81,7 @@ async function main(): Promise<void> {
     const inwardZ = -Math.sin(angle);
     const speed = 2.2 + (index % 7) * 0.35;
 
-    runtime.spawn_body(
+    const bodyId = runtime.spawn_body(
       x,
       1.5 + (index % 3) * 0.4,
       z,
@@ -86,31 +90,63 @@ async function main(): Promise<void> {
       tangentZ * speed + inwardZ * 0.45,
     );
 
-    const instance = bodyTemplate.createInstance(`enemy-${index}`);
+    const instance = bodyTemplate.createInstance(`enemy-${bodyId}`);
     instance.isVisible = true;
-    return instance;
-  });
-
-  if (new URLSearchParams(location.search).has("inspect")) {
-    const { StartInspectable } = await import("@babylonjs/inspector");
-    StartInspectable(scene);
+    bodyInstances.set(bodyId, instance);
   }
 
+  const snapshotIds = Array.from(runtime.body_ids());
+  if (snapshotIds.length !== BODY_COUNT || snapshotIds.some((id) => !bodyInstances.has(id))) {
+    throw new Error("Hybrid runtime body identity contract is inconsistent");
+  }
+
+  let inspectable: { dispose(): void } | undefined;
+  if (new URLSearchParams(location.search).has("inspect")) {
+    const { StartInspectable } = await import("@babylonjs/inspector");
+    inspectable = StartInspectable(scene);
+  }
+
+  const fixedDeltaSeconds = runtime.fixed_delta_seconds();
+  const maxAccumulatorSeconds = fixedDeltaSeconds * MAX_CATCH_UP_STEPS;
+  let accumulatorSeconds = 0;
+  let droppedSimulationSeconds = 0;
   let frame = 0;
   let snapshotBytes = 0;
+  let stepsThisFrame = 0;
+
   engine.runRenderLoop(() => {
-    const deltaSeconds = engine.getDeltaTime() / 1000;
-    runtime.step(deltaSeconds);
+    const frameDeltaSeconds = Math.min(
+      Math.max(engine.getDeltaTime() / 1000, 0),
+      MAX_FRAME_DELTA_SECONDS,
+    );
+    const requestedAccumulator = accumulatorSeconds + frameDeltaSeconds;
+    if (requestedAccumulator > maxAccumulatorSeconds) {
+      droppedSimulationSeconds += requestedAccumulator - maxAccumulatorSeconds;
+    }
+    accumulatorSeconds = Math.min(requestedAccumulator, maxAccumulatorSeconds);
+
+    stepsThisFrame = Math.min(
+      Math.floor(accumulatorSeconds / fixedDeltaSeconds),
+      MAX_CATCH_UP_STEPS,
+    );
+    if (stepsThisFrame > 0) {
+      runtime.step_fixed(stepsThisFrame);
+      accumulatorSeconds -= stepsThisFrame * fixedDeltaSeconds;
+    }
 
     const positions = runtime.positions();
+    if (positions.length !== snapshotIds.length * 3) {
+      throw new Error("Hybrid runtime position snapshot changed without a lifecycle event");
+    }
+
     snapshotBytes = positions.length * Float32Array.BYTES_PER_ELEMENT;
-    for (let index = 0; index < bodies.length; index += 1) {
+    for (let index = 0; index < snapshotIds.length; index += 1) {
+      const body = bodyInstances.get(snapshotIds[index]);
+      if (!body) {
+        throw new Error(`Missing Babylon instance for body ${snapshotIds[index]}`);
+      }
       const offset = index * 3;
-      bodies[index].position.set(
-        positions[offset],
-        positions[offset + 1],
-        positions[offset + 2],
-      );
+      body.position.set(positions[offset], positions[offset + 1], positions[offset + 2]);
     }
 
     scene.render();
@@ -120,7 +156,11 @@ async function main(): Promise<void> {
         "Babylon 9.23 renderer + Bevy 0.19 ECS/WASM",
         `bodies: ${BODY_COUNT}`,
         `fps: ${engine.getFps().toFixed(1)}`,
-        `snapshot: ${snapshotBytes} B/frame`,
+        `simulation: ${(1 / fixedDeltaSeconds).toFixed(0)} Hz fixed tick`,
+        `tick: ${runtime.tick()} (${stepsThisFrame} step(s) this frame)`,
+        `render alpha: ${(accumulatorSeconds / fixedDeltaSeconds).toFixed(2)}`,
+        `snapshot: ${snapshotBytes} B/frame + ${snapshotIds.length * Uint32Array.BYTES_PER_ELEMENT} B identity table`,
+        `dropped catch-up time: ${(droppedSimulationSeconds * 1000).toFixed(1)} ms`,
         `WebGPU available: ${"gpu" in navigator}`,
         `crossOriginIsolated: ${String(crossOriginIsolated)}`,
         "?inspect=1 enables Babylon Inspector CLI bridge",
@@ -128,7 +168,20 @@ async function main(): Promise<void> {
     }
   });
 
-  window.addEventListener("resize", () => engine.resize());
+  const resize = () => engine.resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      window.removeEventListener("resize", resize);
+      inspectable?.dispose();
+      engine.stopRenderLoop();
+      scene.dispose();
+      engine.dispose();
+      runtime.free();
+    },
+    { once: true },
+  );
 }
 
 void main();

--- a/experiments/hybrid-engine/src/main.ts
+++ b/experiments/hybrid-engine/src/main.ts
@@ -1,0 +1,134 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Engine,
+  HemisphericLight,
+  MeshBuilder,
+  Scene,
+  StandardMaterial,
+  Vector3,
+} from "@babylonjs/core/pure";
+import initRuntime, { DefendRuntime } from "../pkg/defend_hybrid_runtime.js";
+
+const BODY_COUNT = 128;
+const ARENA_RADIUS = 72;
+
+async function main(): Promise<void> {
+  await initRuntime();
+
+  const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas");
+  const metrics = document.querySelector<HTMLElement>("#metrics");
+  if (!canvas || !metrics) {
+    throw new Error("Hybrid lab DOM is incomplete");
+  }
+
+  const engine = new Engine(canvas, true, {
+    adaptToDeviceRatio: true,
+    antialias: true,
+  });
+  const scene = new Scene(engine);
+  scene.clearColor.set(0.031, 0.019, 0.051, 1);
+
+  const camera = new ArcRotateCamera(
+    "camera",
+    -Math.PI / 2,
+    Math.PI / 3.2,
+    118,
+    Vector3.Zero(),
+    scene,
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 48;
+  camera.upperRadiusLimit = 180;
+
+  const light = new HemisphericLight("ambient", new Vector3(0.2, 1, 0.1), scene);
+  light.intensity = 0.8;
+
+  const coreMaterial = new StandardMaterial("coreMaterial", scene);
+  coreMaterial.diffuseColor = new Color3(0.66, 0.31, 0.13);
+  coreMaterial.emissiveColor = new Color3(0.18, 0.055, 0.02);
+  MeshBuilder.CreateCylinder(
+    "energy-core",
+    { diameter: 14, height: 4, tessellation: 6 },
+    scene,
+  ).material = coreMaterial;
+
+  const bodyMaterial = new StandardMaterial("bodyMaterial", scene);
+  bodyMaterial.diffuseColor = new Color3(0.28, 0.08, 0.42);
+  bodyMaterial.emissiveColor = new Color3(0.06, 0.01, 0.09);
+
+  const bodyTemplate = MeshBuilder.CreateSphere(
+    "enemy-template",
+    { diameter: 2.8, segments: 8 },
+    scene,
+  );
+  bodyTemplate.material = bodyMaterial;
+  bodyTemplate.isVisible = false;
+
+  const runtime = new DefendRuntime();
+  const bodies = Array.from({ length: BODY_COUNT }, (_, index) => {
+    const angle = (index / BODY_COUNT) * Math.PI * 2;
+    const radius = ARENA_RADIUS * (0.72 + (index % 11) / 40);
+    const x = Math.cos(angle) * radius;
+    const z = Math.sin(angle) * radius;
+    const tangentX = -Math.sin(angle);
+    const tangentZ = Math.cos(angle);
+    const inwardX = -Math.cos(angle);
+    const inwardZ = -Math.sin(angle);
+    const speed = 2.2 + (index % 7) * 0.35;
+
+    runtime.spawn_body(
+      x,
+      1.5 + (index % 3) * 0.4,
+      z,
+      tangentX * speed + inwardX * 0.45,
+      0,
+      tangentZ * speed + inwardZ * 0.45,
+    );
+
+    const instance = bodyTemplate.createInstance(`enemy-${index}`);
+    instance.isVisible = true;
+    return instance;
+  });
+
+  if (new URLSearchParams(location.search).has("inspect")) {
+    const { StartInspectable } = await import("@babylonjs/inspector");
+    StartInspectable(scene);
+  }
+
+  let frame = 0;
+  let snapshotBytes = 0;
+  engine.runRenderLoop(() => {
+    const deltaSeconds = engine.getDeltaTime() / 1000;
+    runtime.step(deltaSeconds);
+
+    const positions = runtime.positions();
+    snapshotBytes = positions.length * Float32Array.BYTES_PER_ELEMENT;
+    for (let index = 0; index < bodies.length; index += 1) {
+      const offset = index * 3;
+      bodies[index].position.set(
+        positions[offset],
+        positions[offset + 1],
+        positions[offset + 2],
+      );
+    }
+
+    scene.render();
+    frame += 1;
+    if (frame % 15 === 0) {
+      metrics.textContent = [
+        "Babylon 9.23 renderer + Bevy 0.19 ECS/WASM",
+        `bodies: ${BODY_COUNT}`,
+        `fps: ${engine.getFps().toFixed(1)}`,
+        `snapshot: ${snapshotBytes} B/frame`,
+        `WebGPU available: ${"gpu" in navigator}`,
+        `crossOriginIsolated: ${String(crossOriginIsolated)}`,
+        "?inspect=1 enables Babylon Inspector CLI bridge",
+      ].join("\n");
+    }
+  });
+
+  window.addEventListener("resize", () => engine.resize());
+}
+
+void main();

--- a/experiments/hybrid-engine/src/main.ts
+++ b/experiments/hybrid-engine/src/main.ts
@@ -154,12 +154,14 @@ async function main(): Promise<void> {
     scene.render();
     frame += 1;
     if (frame % 15 === 0) {
+      const fingerprint = runtime.state_fingerprint();
       metrics.textContent = [
         "Babylon 9.23 renderer + Bevy 0.19 ECS/WASM",
         `bodies: ${BODY_COUNT}`,
         `fps: ${engine.getFps().toFixed(1)}`,
         `simulation: ${(1 / fixedStepPolicy.fixedDeltaSeconds).toFixed(0)} Hz fixed tick`,
         `tick: ${runtime.tick()} (${stepsThisFrame} step(s) this frame)`,
+        `state: ${fingerprint}`,
         `render alpha: ${renderAlpha.toFixed(2)}`,
         `snapshot: ${snapshotBytes} B/frame + ${snapshotIds.length * Uint32Array.BYTES_PER_ELEMENT} B identity table`,
         `dropped catch-up time: ${(fixedStepState.droppedSeconds * 1000).toFixed(1)} ms`,

--- a/experiments/hybrid-engine/tsconfig.json
+++ b/experiments/hybrid-engine/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/experiments/hybrid-engine/vite.config.ts
+++ b/experiments/hybrid-engine/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    fs: {
+      strict: true,
+    },
+  },
+  build: {
+    target: "es2022",
+  },
+});


### PR DESCRIPTION
Refs #66
Related: #52, #55, #64

## Scope

Isolated comparative engine lab only. No changes to the historical application, root package, Webpack 4 build, Cannon physics, gameplay code, or production output.

## What this proves

This PR implements the smallest useful form of the proposed Babylon/Bevy hybrid:

- Babylon.js 9.23.0 is the **only browser renderer**.
- A headless Rust/WASM runtime uses modular Bevy 0.19.1 crates (`bevy_app`, `bevy_ecs`, `bevy_math`) for semantic state and scheduling.
- 128 bodies are owned by the Bevy ECS runtime and returned as flat xyz triples each render frame.
- Babylon renders lightweight instances from that authoritative snapshot.
- external body ids are explicit and stable; Babylon does not rely on Bevy query/archetype iteration order for identity.
- simulation advances through exact 120 Hz fixed ticks, independent from render cadence.
- the browser host owns wall-clock accumulation and bounded catch-up; the Rust runtime exposes exact `step_fixed(n)` semantics for replay/certification.
- no Bevy renderer/window/UI/input/audio dependencies are intentionally enabled.
- `@dimforge/rapier3d` 0.20.0 and `@babylonjs/havok` 1.3.14 are pinned for subsequent same-scene physics comparisons but are not yet authoritative or wired.

## Modern pinned toolchain

Browser lab:
- Node 24.20 LTS baseline
- pnpm 11.25.0
- Vite 8.2.2
- TypeScript 7.0.2 strict mode
- Biome 2.5.11
- Vitest 4.1.11
- Babylon 9.23.0 ESM packages

Rust/WASM:
- Rust 1.98.0 / edition 2024
- Bevy modular crates 0.19.1
- wasm-bindgen 0.2.127
- wasm-pack 0.15.0 expected locally

Versions are exact in this experiment so measurements are reproducible. This does not imply that production should automatically chase every latest release.

## Babylon details

The lab imports Babylon's modern ESM/pure surface and creates:
- an orbiting ArcRotateCamera;
- a hexagonal central core;
- 128 instanced enemy spheres;
- restrained existing-style colors;
- an FPS / simulation tick / snapshot-size capability overlay.

`?inspect=1` starts Babylon 9's headless Inspector bridge so AI executors can query scene state and capture diagnostics without showing the Inspector UI. The inspectable token is explicitly disposed during page teardown.

## Bevy details

The Rust crate deliberately contains only:
- `Position` and `Velocity` components;
- one fixed step-delta resource;
- one integration system;
- a stable external body registry mapping public ids to Bevy `Entity` handles;
- a WASM `DefendRuntime` wrapper with spawn, fixed-step, identity, tick, and position-snapshot methods.

The runtime has no wall-clock authority. `fixed_delta_seconds()` exposes the 120 Hz step duration; `step_fixed(n)` advances exactly `n` simulation ticks. The browser render loop converts frame time into a bounded number of fixed ticks, records any dropped catch-up time, and exposes render interpolation alpha as a diagnostic without feeding it back into simulation state.

This separation is intentional: deterministic replay should be expressed in ticks, not browser frame durations.

## Identity boundary

The original toy version returned positions in raw Bevy query iteration order. That is not a safe protocol contract because ECS storage/archetype ordering can change as entities/components evolve.

The runtime now assigns monotonic external ids at spawn and retains a stable body registry. `body_ids()` and `positions()` use the same registry order. The current fixture has no spawn/despawn after initialization; future lifecycle changes must be explicit protocol events rather than array-index identity assumptions.

Native Rust tests now cover:
- monotonic external ids + stable snapshot ordering;
- fixed-step partition invariance (`240` ticks in one call equals `60 + 180`).

These tests are committed but still require local execution.

## Snapshot boundary

The snapshot is intentionally a simple copied `Vec<f32>` of xyz triples plus a one-time `Vec<u32>` identity table. Do not optimize to SharedArrayBuffer, raw WASM memory views, SoA binary packets, or generated protocol code until profiling shows this copy boundary is material.

The lab reports the copied bytes/frame so later alternatives can be compared against the exact baseline.

## Why not full Bevy + Babylon rendering in one page?

The research in #66 indicates that would duplicate GPU resources, scene graphs, transforms, camera/input ownership, shader/material pipelines and debugging complexity. The useful hybrid is Bevy's modular ECS/runtime in Rust/WASM with Babylon owning presentation.

A full Bevy renderer remains worth a **separate** browser/native comparison fixture.

## Pinned comparison candidates

The lab manifest also pins:
- Rapier JS/WASM 0.20.0, including the option to later test deterministic builds;
- Babylon Havok 1.3.14 as a mature integrated control case;
- Babylon accessibility 9.23.0 for later accessible presentation experiments;
- Babylon Inspector 9.23.0 for agent diagnostics.

Neither physics engine is used in this first PR.

## Required local certification before promotion

From `experiments/hybrid-engine/`:

1. use Node 24.20.x LTS and pnpm 11.25.0;
2. install wasm-pack 0.15.0;
3. run `pnpm install` and commit the generated local lockfile only after inspecting dependency resolution;
4. run `cargo fmt --check` in `rust/`;
5. run `cargo clippy --all-targets --all-features -- -D warnings` or document any feature-specific blocker;
6. run `cargo test` and confirm the identity/fixed-step tests pass;
7. run the WASM build command from the package script;
8. run `pnpm check`;
9. run `pnpm test`;
10. run `pnpm build`;
11. run `pnpm dev` and confirm all 128 bodies render/move with no console errors;
12. confirm simulation tick advancement remains stable across 60/120/144 Hz display/render cadences;
13. introduce an artificial long frame and confirm catch-up is bounded and dropped time is reported rather than causing an unbounded spiral;
14. confirm `?inspect=1` exposes the Babylon Inspector bridge and teardown disconnects it cleanly;
15. use `cargo tree` to confirm no Bevy renderer/window stack is pulled in;
16. record raw + compressed JS/WASM payload size;
17. record WASM initialization, first interactive frame, steady FPS, simulation step time, and per-frame snapshot/copy cost.

## Follow-up comparison slices

Do not broaden this PR. Add separate stacked experiments for:
1. Babylon + Rapier JS 0.20;
2. Babylon + Rust Rapier in the Bevy runtime;
3. Babylon + Havok control case;
4. WebGL2 vs WebGPU presentation;
5. separate full-Bevy WebGL2/WebGPU fixture;
6. importing the certified hex, terrain and spatial-audio contracts.

## Production impact

None. Keep draft until local compile/build/browser evidence is posted and the bundle/runtime measurements justify retaining the experiment.