### PR TITLE
Document exact-head GitHub promotion and CI contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,36 @@ Each PR should explain what was validated and what could not be validated online
 
 Prefer behavioral assertions over snapshots of implementation details. Preserve deterministic seams for stochastic behavior where practical, but do not replace emergent physics with a fake deterministic simulation merely to make tests easy.
 
+## GitHub review and promotion contract
+
+GitHub state must communicate the real readiness of a change rather than merely whether Git can merge it.
+
+- **Draft PR** means implementation, investigation, or required certification is incomplete. Runtime-sensitive work remains draft until the local executor posts the required evidence.
+- **Ready for review** means the PR's stated validation contract has evidence against the current head SHA. Do not mark a PR ready merely because GitHub reports it as conflict-free.
+- Record substantive online architectural/static review as a formal PR review tied to the exact head being reviewed. If the head moves materially afterward, treat that review as stale until the delta is inspected.
+- Before promotion or merge, inspect the current head/base, changed files, unresolved review threads, submitted reviews, branch drift, commit status, and any available workflow results.
+- `mergeable=true` only means Git can currently construct a merge. It is never validation or certification.
+- Merge with an expected/current head SHA when the API supports it so a concurrent push cannot silently change what is being merged.
+- Do not force-update another executor's branch to remove an inconvenient behind count. Update an owned branch only when the integration delta is actually needed.
+- For stacked PRs, keep the child branch based on the current parent head. Prefer a normal fast-forward/merge commit over history rewriting; verify that the child diff relative to its parent contains only the intended additional scope.
+
+### GitHub write safety
+
+- Never probe a write API by creating placeholder files/commits/refs.
+- Do not use Git data/ref operations against `master` for experimentation.
+- Blob/tree/commit/ref primitives are appropriate for deliberate atomic multi-file work or non-destructive merges on branches this executor owns.
+- Ref updates should be fast-forward by default. Force updates require explicit coordination and a concrete reason.
+
+### CI and Actions
+
+The project intentionally distinguishes local runtime certification from hosted CI.
+
+- Absence of a status check or workflow run is not a passing check.
+- Do not add hosted CI solely because Actions APIs are available; local Codex remains the authority for expensive/historical/browser/physics/audio/PWA certification unless the project explicitly adopts a hosted gate.
+- If workflows are introduced, inspect the run, jobs, steps/logs, and relevant artifacts before acting on the result.
+- Retry only failed jobs/runs when the failure is plausibly transient or the underlying cause has been corrected; do not rerun repeatedly to obtain a green result by chance.
+- Preserve exact head-SHA linkage between workflow/local evidence and the PR being promoted.
+
 ## Modernization policy
 
 The repository contains a stale backlog of dependency-update PRs from the historical toolchain. Treat them as evidence of obsolete/security-sensitive dependencies, not as a required merge sequence. Follow issue #31 and migrate the stack coherently.


### PR DESCRIPTION
Refs #29, #30

## Scope

Process documentation only. Updates `AGENTS.md`; no source, dependencies, scripts, build configuration, CI workflow, gameplay, rendering, physics, audio, or runtime behavior changes.

## Change

Document how newly available GitHub capabilities should be used by parallel executors:

- draft/ready/merged states represent actual certification state;
- online static/architectural reviews are tied to exact head SHAs;
- `mergeable` is conflict information, not validation;
- promotion inspects review threads, reviews, branch drift, statuses and workflows when present;
- merge uses an expected head SHA where supported;
- stacked PRs stay current without force-rewriting history;
- Git blob/tree/commit/ref operations are branch-owned, deliberate, and never probed against `master`;
- absence of CI is not success;
- hosted Actions remain optional and must not replace local browser/physics/audio/PWA certification merely because the APIs are available;
- workflow retries are evidence-driven, not repeated until green.

This codifies the policy already recorded on #29/#30 so future online and local executors see it directly in repository instructions.