### PR TITLE
experiment: prototype finite-energy raider mothership and crash

### DIFF
--- a/experiments/hybrid-engine/mothership.html
+++ b/experiments/hybrid-engine/mothership.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defend Mothership Lab</title>
+    <style>
+      :root { color-scheme: dark; }
+      html, body, #app, canvas { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #08050d; color: #d9f5f5; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      canvas { display: block; touch-action: none; }
+      #metrics {
+        position: fixed;
+        top: 12px;
+        left: 12px;
+        z-index: 2;
+        min-width: 260px;
+        padding: 9px 11px;
+        border: 1px solid rgba(67, 218, 213, .32);
+        background: rgba(8, 5, 13, .82);
+        font-size: 12px;
+        line-height: 1.5;
+        pointer-events: none;
+        white-space: pre;
+      }
+      #controls {
+        position: fixed;
+        right: 12px;
+        top: 12px;
+        z-index: 3;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 6px;
+        max-width: 420px;
+      }
+      button {
+        border: 1px solid rgba(67, 218, 213, .36);
+        background: rgba(22, 10, 33, .86);
+        color: #d9f5f5;
+        padding: 7px 9px;
+        font: inherit;
+        cursor: pointer;
+      }
+      button:hover, button:focus-visible { border-color: rgba(67, 218, 213, .9); outline: none; }
+      #caption {
+        position: fixed;
+        left: 50%;
+        bottom: 14px;
+        transform: translateX(-50%);
+        z-index: 2;
+        padding: 7px 10px;
+        background: rgba(8, 5, 13, .7);
+        color: rgba(217, 245, 245, .82);
+        font-size: 12px;
+        pointer-events: none;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"><canvas id="renderCanvas"></canvas></div>
+    <div id="metrics">initializing…</div>
+    <div id="controls" aria-label="Mothership prototype controls">
+      <button id="reset" type="button">Reset [R]</button>
+      <button id="pause" type="button">Pause drain [Space]</button>
+      <button id="fast" type="button">Fast drain [F]</button>
+      <button id="camera" type="button">Defender view [C]</button>
+    </div>
+    <div id="caption">Finite teal reserve sustains hover. Depletion weakens suspension until gravity wins.</div>
+    <script type="module" src="/src/mothershipPrototype.ts"></script>
+  </body>
+</html>

--- a/experiments/hybrid-engine/src/mothershipPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipPrototype.ts
@@ -1,0 +1,616 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Engine,
+  HemisphericLight,
+  MeshBuilder,
+  PointLight,
+  Scene,
+  StandardMaterial,
+  TransformNode,
+  Vector3,
+} from "@babylonjs/core/pure";
+
+type MothershipPhase = "stable" | "low-reserve" | "critical" | "falling" | "hulk";
+type CameraMode = "raider" | "defender";
+
+const START_RESERVE = 1;
+const LOW_RESERVE = 0.38;
+const CRITICAL_RESERVE = 0.2;
+const FALL_RESERVE = 0.1;
+const HOVER_DRAIN_PER_SECOND = 0.0065;
+const FALL_DRAIN_PER_SECOND = 0.002;
+const FAST_DRAIN_MULTIPLIER = 8;
+const START_ALTITUDE = 56;
+const HULK_CENTER_Y = 18;
+const GRAVITY = 9.81;
+const MAX_FRAME_DELTA_SECONDS = 0.05;
+
+interface MothershipState {
+  reserve: number;
+  phase: MothershipPhase;
+  verticalVelocity: number;
+  angularVelocity: Vector3;
+  elapsedSeconds: number;
+  impactCount: number;
+  paused: boolean;
+  fastDrain: boolean;
+  cameraMode: CameraMode;
+}
+
+function phaseForReserve(reserve: number): MothershipPhase {
+  if (reserve <= FALL_RESERVE) return "falling";
+  if (reserve <= CRITICAL_RESERVE) return "critical";
+  if (reserve <= LOW_RESERVE) return "low-reserve";
+  return "stable";
+}
+
+function createMaterial(
+  name: string,
+  scene: Scene,
+  diffuse: Color3,
+  emissive: Color3,
+  alpha = 1,
+): StandardMaterial {
+  const material = new StandardMaterial(name, scene);
+  material.diffuseColor = diffuse;
+  material.emissiveColor = emissive;
+  material.specularColor = new Color3(0.08, 0.08, 0.1);
+  material.alpha = alpha;
+  return material;
+}
+
+function createMothership(scene: Scene) {
+  const root = new TransformNode("mothership-root", scene);
+  root.position.set(0, START_ALTITUDE, 0);
+
+  const shellMaterial = createMaterial(
+    "mothership-shell",
+    scene,
+    new Color3(0.22, 0.055, 0.34),
+    new Color3(0.07, 0.012, 0.1),
+    0.92,
+  );
+  shellMaterial.wireframe = true;
+
+  const structureMaterial = createMaterial(
+    "mothership-structure",
+    scene,
+    new Color3(0.16, 0.035, 0.24),
+    new Color3(0.035, 0.006, 0.055),
+    0.96,
+  );
+
+  const activeStructureMaterial = createMaterial(
+    "mothership-active-structure",
+    scene,
+    new Color3(0.08, 0.24, 0.27),
+    new Color3(0.025, 0.18, 0.2),
+    0.9,
+  );
+
+  const coreMaterial = createMaterial(
+    "mothership-energy-core",
+    scene,
+    new Color3(0.04, 0.58, 0.58),
+    new Color3(0.02, 0.52, 0.54),
+    0.92,
+  );
+  coreMaterial.specularColor = new Color3(0.2, 0.95, 0.92);
+
+  const shell = MeshBuilder.CreateSphere(
+    "mothership-shell-cage",
+    { diameter: 38, segments: 8 },
+    scene,
+  );
+  shell.parent = root;
+  shell.material = shellMaterial;
+  shell.isPickable = false;
+
+  const core = MeshBuilder.CreateSphere(
+    "mothership-core",
+    { diameter: 15, segments: 12 },
+    scene,
+  );
+  core.parent = root;
+  core.material = coreMaterial;
+  core.isPickable = false;
+
+  const equator = MeshBuilder.CreateTorus(
+    "mothership-equator",
+    { diameter: 35, thickness: 1.25, tessellation: 16 },
+    scene,
+  );
+  equator.parent = root;
+  equator.material = structureMaterial;
+
+  const meridianX = MeshBuilder.CreateTorus(
+    "mothership-meridian-x",
+    { diameter: 35, thickness: 1.05, tessellation: 16 },
+    scene,
+  );
+  meridianX.parent = root;
+  meridianX.rotation.x = Math.PI / 2;
+  meridianX.material = structureMaterial;
+
+  const meridianZ = MeshBuilder.CreateTorus(
+    "mothership-meridian-z",
+    { diameter: 35, thickness: 1.05, tessellation: 16 },
+    scene,
+  );
+  meridianZ.parent = root;
+  meridianZ.rotation.z = Math.PI / 2;
+  meridianZ.material = structureMaterial;
+
+  const launchRing = MeshBuilder.CreateTorus(
+    "mothership-launch-ring",
+    { diameter: 21, thickness: 0.75, tessellation: 14 },
+    scene,
+  );
+  launchRing.parent = root;
+  launchRing.position.y = -6.2;
+  launchRing.material = activeStructureMaterial;
+
+  const strutX = MeshBuilder.CreateBox(
+    "mothership-strut-x",
+    { width: 30, height: 0.85, depth: 0.85 },
+    scene,
+  );
+  strutX.parent = root;
+  strutX.material = structureMaterial;
+
+  const strutY = MeshBuilder.CreateBox(
+    "mothership-strut-y",
+    { width: 0.85, height: 30, depth: 0.85 },
+    scene,
+  );
+  strutY.parent = root;
+  strutY.material = structureMaterial;
+
+  const strutZ = MeshBuilder.CreateBox(
+    "mothership-strut-z",
+    { width: 0.85, height: 0.85, depth: 30 },
+    scene,
+  );
+  strutZ.parent = root;
+  strutZ.material = structureMaterial;
+
+  const nodePositions = [
+    new Vector3(17, 0, 0),
+    new Vector3(-17, 0, 0),
+    new Vector3(0, 17, 0),
+    new Vector3(0, -17, 0),
+    new Vector3(0, 0, 17),
+    new Vector3(0, 0, -17),
+    new Vector3(11.5, 11.5, 0),
+    new Vector3(-11.5, 11.5, 0),
+    new Vector3(0, 11.5, 11.5),
+    new Vector3(0, 11.5, -11.5),
+  ];
+
+  const fieldNodes = nodePositions.map((position, index) => {
+    const node = MeshBuilder.CreateSphere(
+      `mothership-field-node-${index}`,
+      { diameter: index < 6 ? 3.2 : 2.5, segments: 5 },
+      scene,
+    );
+    node.parent = root;
+    node.position.copyFrom(position);
+    node.material = index % 3 === 0 ? activeStructureMaterial : structureMaterial;
+    return node;
+  });
+
+  return {
+    root,
+    core,
+    coreMaterial,
+    shellMaterial,
+    structureMaterial,
+    activeStructureMaterial,
+    launchRing,
+    fieldNodes,
+  };
+}
+
+function createArena(scene: Scene) {
+  const groundMaterial = createMaterial(
+    "arena-ground",
+    scene,
+    new Color3(0.025, 0.018, 0.035),
+    new Color3(0.008, 0.005, 0.012),
+  );
+
+  const ground = MeshBuilder.CreateGround(
+    "arena-ground",
+    { width: 180, height: 180, subdivisions: 1 },
+    scene,
+  );
+  ground.material = groundMaterial;
+  ground.position.y = 0;
+
+  const towerMaterial = createMaterial(
+    "defender-structure",
+    scene,
+    new Color3(0.09, 0.31, 0.17),
+    new Color3(0.015, 0.07, 0.03),
+  );
+  const siloEnergyMaterial = createMaterial(
+    "defender-silo-energy",
+    scene,
+    new Color3(0.05, 0.5, 0.52),
+    new Color3(0.02, 0.3, 0.32),
+    0.82,
+  );
+
+  const silo = MeshBuilder.CreateBox(
+    "defender-silo",
+    { width: 24, height: 3.5, depth: 24 },
+    scene,
+  );
+  silo.position.y = 1.75;
+  silo.material = towerMaterial;
+
+  const siloCore = MeshBuilder.CreateBox(
+    "defender-silo-core",
+    { width: 17, height: 1.2, depth: 17 },
+    scene,
+  );
+  siloCore.position.y = 4.1;
+  siloCore.material = siloEnergyMaterial;
+
+  const barrierPositions = [
+    new Vector3(-22, 2, -18),
+    new Vector3(22, 2, -18),
+    new Vector3(-22, 2, 18),
+    new Vector3(22, 2, 18),
+  ];
+  barrierPositions.forEach((position, index) => {
+    const barrier = MeshBuilder.CreateBox(
+      `defender-barrier-${index}`,
+      { width: 10, height: 4, depth: 10 },
+      scene,
+    );
+    barrier.position.copyFrom(position);
+    barrier.material = towerMaterial;
+  });
+
+  const raiderShellMaterial = createMaterial(
+    "raider-reference-shell",
+    scene,
+    new Color3(0.28, 0.06, 0.4),
+    new Color3(0.06, 0.01, 0.09),
+  );
+  raiderShellMaterial.wireframe = true;
+  const raiderCoreMaterial = createMaterial(
+    "raider-reference-core",
+    scene,
+    new Color3(0.04, 0.5, 0.52),
+    new Color3(0.015, 0.24, 0.27),
+    0.8,
+  );
+
+  [6, 9, 14].forEach((diameter, index) => {
+    const x = -34 + index * 17;
+    const shell = MeshBuilder.CreateSphere(
+      `raider-reference-shell-${index + 1}`,
+      { diameter, segments: 5 + index },
+      scene,
+    );
+    shell.position.set(x, diameter / 2, 48);
+    shell.material = raiderShellMaterial;
+
+    const core = MeshBuilder.CreateSphere(
+      `raider-reference-core-${index + 1}`,
+      { diameter: diameter * 0.42, segments: 6 },
+      scene,
+    );
+    core.position.copyFrom(shell.position);
+    core.material = raiderCoreMaterial;
+  });
+}
+
+function setCameraMode(camera: ArcRotateCamera, mode: CameraMode, target: Vector3): void {
+  if (mode === "raider") {
+    camera.alpha = -Math.PI / 2.2;
+    camera.beta = 0.9;
+    camera.radius = 58;
+    camera.setTarget(target);
+  } else {
+    camera.alpha = -Math.PI / 3.5;
+    camera.beta = 1.92;
+    camera.radius = 126;
+    camera.setTarget(new Vector3(0, 30, 0));
+  }
+}
+
+function resetState(state: MothershipState, root: TransformNode): void {
+  state.reserve = START_RESERVE;
+  state.phase = "stable";
+  state.verticalVelocity = 0;
+  state.angularVelocity.set(0, 0, 0);
+  state.elapsedSeconds = 0;
+  state.impactCount = 0;
+  state.paused = false;
+  state.fastDrain = false;
+
+  root.position.set(0, START_ALTITUDE, 0);
+  root.rotation.set(0, 0, 0);
+}
+
+async function main(): Promise<void> {
+  const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas");
+  const metrics = document.querySelector<HTMLElement>("#metrics");
+  const resetButton = document.querySelector<HTMLButtonElement>("#reset");
+  const pauseButton = document.querySelector<HTMLButtonElement>("#pause");
+  const fastButton = document.querySelector<HTMLButtonElement>("#fast");
+  const cameraButton = document.querySelector<HTMLButtonElement>("#camera");
+
+  if (!canvas || !metrics || !resetButton || !pauseButton || !fastButton || !cameraButton) {
+    throw new Error("Mothership lab DOM is incomplete");
+  }
+
+  const engine = new Engine(canvas, true, {
+    adaptToDeviceRatio: true,
+    antialias: true,
+  });
+  const scene = new Scene(engine);
+  scene.clearColor.set(0.02, 0.012, 0.034, 1);
+
+  const camera = new ArcRotateCamera(
+    "mothership-camera",
+    -Math.PI / 2.2,
+    0.9,
+    58,
+    new Vector3(0, START_ALTITUDE - 8, 0),
+    scene,
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 36;
+  camera.upperRadiusLimit = 180;
+  camera.lowerBetaLimit = 0.3;
+  camera.upperBetaLimit = 2.35;
+
+  const ambient = new HemisphericLight(
+    "ambient",
+    new Vector3(0.15, 1, 0.2),
+    scene,
+  );
+  ambient.intensity = 0.72;
+
+  const coreLight = new PointLight("core-light", new Vector3(0, START_ALTITUDE, 0), scene);
+  coreLight.diffuse = new Color3(0.12, 0.9, 0.88);
+  coreLight.intensity = 0.65;
+  coreLight.range = 62;
+
+  createArena(scene);
+  const mothership = createMothership(scene);
+
+  const state: MothershipState = {
+    reserve: START_RESERVE,
+    phase: "stable",
+    verticalVelocity: 0,
+    angularVelocity: Vector3.Zero(),
+    elapsedSeconds: 0,
+    impactCount: 0,
+    paused: false,
+    fastDrain: false,
+    cameraMode: "raider",
+  };
+
+  setCameraMode(camera, state.cameraMode, mothership.root.position);
+
+  let inspectable: { dispose(): void } | undefined;
+  if (new URLSearchParams(location.search).has("inspect")) {
+    const { StartInspectable } = await import("@babylonjs/inspector");
+    inspectable = StartInspectable(scene);
+  }
+
+  const updateButtons = () => {
+    pauseButton.textContent = state.paused ? "Resume drain [Space]" : "Pause drain [Space]";
+    fastButton.textContent = state.fastDrain ? "Normal drain [F]" : "Fast drain [F]";
+    cameraButton.textContent = state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
+  };
+
+  const doReset = () => {
+    resetState(state, mothership.root);
+    setCameraMode(camera, state.cameraMode, mothership.root.position);
+    updateButtons();
+  };
+
+  const togglePause = () => {
+    state.paused = !state.paused;
+    updateButtons();
+  };
+
+  const toggleFast = () => {
+    state.fastDrain = !state.fastDrain;
+    updateButtons();
+  };
+
+  const toggleCamera = () => {
+    state.cameraMode = state.cameraMode === "raider" ? "defender" : "raider";
+    setCameraMode(camera, state.cameraMode, mothership.root.position);
+    updateButtons();
+  };
+
+  resetButton.addEventListener("click", doReset);
+  pauseButton.addEventListener("click", togglePause);
+  fastButton.addEventListener("click", toggleFast);
+  cameraButton.addEventListener("click", toggleCamera);
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.repeat) return;
+    if (event.code === "KeyR") doReset();
+    if (event.code === "Space") {
+      event.preventDefault();
+      togglePause();
+    }
+    if (event.code === "KeyF") toggleFast();
+    if (event.code === "KeyC") toggleCamera();
+  };
+  window.addEventListener("keydown", onKeyDown);
+
+  let frame = 0;
+
+  engine.runRenderLoop(() => {
+    const deltaSeconds = Math.min(
+      MAX_FRAME_DELTA_SECONDS,
+      engine.getDeltaTime() / 1000,
+    );
+    state.elapsedSeconds += deltaSeconds;
+
+    if (!state.paused && state.phase !== "hulk") {
+      const drainMultiplier = state.fastDrain ? FAST_DRAIN_MULTIPLIER : 1;
+      const drainRate =
+        state.phase === "falling" ? FALL_DRAIN_PER_SECOND : HOVER_DRAIN_PER_SECOND;
+      state.reserve = Math.max(
+        0,
+        state.reserve - drainRate * drainMultiplier * deltaSeconds,
+      );
+    }
+
+    if (state.phase !== "falling" && state.phase !== "hulk") {
+      state.phase = phaseForReserve(state.reserve);
+    }
+
+    if (state.phase === "falling") {
+      state.verticalVelocity -= GRAVITY * deltaSeconds;
+      mothership.root.position.y += state.verticalVelocity * deltaSeconds;
+      mothership.root.rotation.x += state.angularVelocity.x * deltaSeconds;
+      mothership.root.rotation.y += state.angularVelocity.y * deltaSeconds;
+      mothership.root.rotation.z += state.angularVelocity.z * deltaSeconds;
+
+      if (state.angularVelocity.lengthSquared() < 0.0001) {
+        state.angularVelocity.set(0.22, 0.08, -0.16);
+      }
+
+      if (mothership.root.position.y <= HULK_CENTER_Y) {
+        mothership.root.position.y = HULK_CENTER_Y;
+        state.impactCount += 1;
+        if (state.impactCount === 1 && Math.abs(state.verticalVelocity) > 4) {
+          state.verticalVelocity = Math.abs(state.verticalVelocity) * 0.12;
+          state.angularVelocity.scaleInPlace(0.72);
+        } else {
+          state.verticalVelocity = 0;
+          state.angularVelocity.set(0, 0, 0);
+          state.phase = "hulk";
+        }
+      }
+    } else if (state.phase !== "hulk") {
+      const liftFraction = Math.max(
+        0,
+        Math.min(1, (state.reserve - FALL_RESERVE) / (START_RESERVE - FALL_RESERVE)),
+      );
+      const depletion = 1 - liftFraction;
+      const targetAltitude = START_ALTITUDE - depletion * 12;
+      const stiffness = 4.4 * (0.32 + liftFraction * 0.68);
+      const damping = 1.1 + liftFraction * 3.1;
+      const wobbleAmplitude = 0.08 + depletion * depletion * 1.5;
+      const wobble =
+        Math.sin(state.elapsedSeconds * (1.2 + depletion * 1.8)) * wobbleAmplitude;
+      const acceleration =
+        (targetAltitude - mothership.root.position.y) * stiffness -
+        state.verticalVelocity * damping +
+        wobble;
+
+      state.verticalVelocity += acceleration * deltaSeconds;
+      mothership.root.position.y += state.verticalVelocity * deltaSeconds;
+
+      const orientationAmplitude = depletion * depletion * 0.14;
+      const targetPitch = Math.sin(state.elapsedSeconds * 0.72) * orientationAmplitude;
+      const targetRoll = Math.cos(state.elapsedSeconds * 0.58) * orientationAmplitude;
+      const correction = Math.max(0.35, 2.6 * liftFraction) * deltaSeconds;
+      mothership.root.rotation.x +=
+        (targetPitch - mothership.root.rotation.x) * correction;
+      mothership.root.rotation.z +=
+        (targetRoll - mothership.root.rotation.z) * correction;
+      mothership.root.rotation.y += deltaSeconds * (0.035 + depletion * 0.025);
+    }
+
+    if (state.phase !== "hulk" && state.reserve <= FALL_RESERVE) {
+      state.phase = "falling";
+      state.angularVelocity.set(0.22, 0.08, -0.16);
+    }
+
+    const visibleReserve = state.phase === "hulk" ? Math.min(state.reserve, 0.025) : state.reserve;
+    const coreScale = 0.26 + Math.cbrt(Math.max(0, visibleReserve)) * 0.74;
+    mothership.core.scaling.set(coreScale, coreScale, coreScale);
+
+    mothership.coreMaterial.emissiveColor.set(
+      0.015 + visibleReserve * 0.05,
+      0.07 + visibleReserve * 0.48,
+      0.08 + visibleReserve * 0.5,
+    );
+    mothership.coreMaterial.diffuseColor.set(
+      0.025 + visibleReserve * 0.04,
+      0.16 + visibleReserve * 0.42,
+      0.17 + visibleReserve * 0.41,
+    );
+
+    const structureEnergy = state.phase === "hulk" ? 0.02 : Math.max(0.03, state.reserve);
+    mothership.activeStructureMaterial.emissiveColor.set(
+      0.01,
+      0.04 + structureEnergy * 0.15,
+      0.05 + structureEnergy * 0.16,
+    );
+    mothership.shellMaterial.emissiveColor.set(
+      0.018 + structureEnergy * 0.045,
+      0.003 + structureEnergy * 0.012,
+      0.03 + structureEnergy * 0.07,
+    );
+
+    coreLight.position.copyFrom(mothership.root.position);
+    coreLight.intensity = state.phase === "hulk" ? 0.05 : 0.12 + state.reserve * 0.72;
+
+    if (state.cameraMode === "raider") {
+      const target = mothership.root.position.clone();
+      target.y -= 8;
+      camera.setTarget(target);
+    }
+
+    scene.render();
+
+    frame += 1;
+    if (frame % 8 === 0) {
+      const drainMultiplier = state.fastDrain ? FAST_DRAIN_MULTIPLIER : 1;
+      metrics.textContent = [
+        "Defend mothership PoC — issue #80",
+        `phase: ${state.phase}`,
+        `reserve: ${(state.reserve * 100).toFixed(1)}%`,
+        `altitude: ${mothership.root.position.y.toFixed(2)}`,
+        `vertical velocity: ${state.verticalVelocity.toFixed(2)}`,
+        `hover drain: x${drainMultiplier}${state.paused ? " (paused)" : ""}`,
+        `camera: ${state.cameraMode}`,
+        `impacts: ${state.impactCount}`,
+        `meshes: ${scene.meshes.length}`,
+        `fps: ${engine.getFps().toFixed(1)}`,
+        "",
+        "R reset · Space pause · F fast drain · C camera",
+        "?inspect=1 enables Babylon Inspector",
+      ].join("\n");
+    }
+  });
+
+  updateButtons();
+
+  const resize = () => engine.resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("keydown", onKeyDown);
+      resetButton.removeEventListener("click", doReset);
+      pauseButton.removeEventListener("click", togglePause);
+      fastButton.removeEventListener("click", toggleFast);
+      cameraButton.removeEventListener("click", toggleCamera);
+      inspectable?.dispose();
+      engine.stopRenderLoop();
+      scene.dispose();
+      engine.dispose();
+    },
+    { once: true },
+  );
+}
+
+void main();

--- a/experiments/hybrid-engine/vite.config.ts
+++ b/experiments/hybrid-engine/vite.config.ts
@@ -8,5 +8,11 @@ export default defineConfig({
   },
   build: {
     target: "es2022",
+    rollupOptions: {
+      input: {
+        main: "index.html",
+        mothership: "mothership.html",
+      },
+    },
   },
 });


### PR DESCRIPTION
Refs #80, #79, #30, #55

## Purpose

Prototype the raider mothership as a visible finite-energy physical vessel in the isolated modern Babylon 9.23 hybrid-engine lab.

This tests the first raider-perspective design claims without touching production gameplay:

- raider family is spherical/mobile while defensive structures are rectilinear/rooted;
- the mothership is organized around an exposed central teal reserve;
- the mothership has no weapon;
- finite reserve sustains hover;
- depletion becomes visible through core volume/light and growing instability;
- catastrophic depletion removes lift and lets gravity/velocity carry the vessel into a persistent hulk;
- the same event can be viewed from raider and defender perspectives.

## Scope

Only `experiments/hybrid-engine` changes.

### New `mothership.html`

Separate Vite entry with lab-only controls:

- reset;
- pause/resume drain;
- normal/fast drain;
- raider/defender camera toggle;
- metrics overlay;
- optional `?inspect=1` Babylon Inspector.

### New `src/mothershipPrototype.ts`

Creates:

- large faceted/wireframe spherical mothership cage;
- centrally exposed teal energy core;
- radial struts, meridian/equator rings and launch/recovery ring;
- simple field nodes/internal structure;
- blocky defender silo/barriers below for visual contrast;
- static R1/R2/R3 spherical reference bodies showing the shared raider language;
- mothership-anchored raider camera plus ground-relative defender camera;
- normalized reserve state machine: `stable → low-reserve → critical → falling → hulk`;
- reserve-linked hover spring/damping, sag and orientation instability;
- deterministic continuous hover drain;
- loss-of-lift threshold;
- gravity/velocity/angular integration after lift loss;
- impact/bounce/settle behavior that preserves the vessel as a recognizable hulk;
- live reserve/altitude/velocity/phase/FPS/mesh metrics.

### `vite.config.ts`

Adds `mothership.html` as a second build entry while preserving the existing `index.html` hybrid lab.

## Explicit non-goals

This PR does not implement:

- production mothership gameplay;
- raider launch/assembly;
- AI defenses;
- extraction/siphon stream;
- raider evacuation;
- strategic teal target signatures;
- production energy constants;
- direct defender attacks against the mothership;
- a separate fuel currency.

## Prototype tuning

All values are intentionally normalized lab values, not campaign balance:

- start reserve: 1.0;
- low reserve: 0.38;
- critical reserve: 0.20;
- loss of lift: 0.10;
- normal hover drain: 0.0065 reserve/s;
- fast lab drain: 8×;
- start altitude: 56;
- gravity: 9.81 units/s².

## Why the crash is not canned

The hover phase integrates target-altitude correction, damping and reserve-linked instability. When reserve crosses the lift threshold, suspension stops being authoritative and the existing vertical/angular state continues under gravity. Impact uses the resulting velocity and leaves the same geometry as the hulk.

This is intentionally simpler than final Havok physics, but it preserves the continuous physical-state hypothesis rather than playing a scripted transform animation.

## Online/static review

Against current `master` `f429d68de64d53bf05bc48014fdc29435a467853`:

- 3 commits ahead / 0 behind;
- 3 files changed;
- 695 additions / 0 deletions;
- existing hybrid-engine `src/main.ts` is untouched;
- no production `src/js` files are touched;
- no dependencies are changed.

## Local Codex certification required

Please validate this exact head before promotion:

1. from `experiments/hybrid-engine`, install/use the declared pnpm/Node environment without modifying unrelated tracked files;
2. run typecheck/build and report exact commands/exit codes;
3. open the default `index.html` lab and confirm it still behaves as before;
4. open `/mothership.html` and verify the mothership/core render correctly;
5. verify normal and fast drain controls;
6. verify reserve/core size/lighting/hover stability degrade together;
7. verify transition to `falling` occurs near the prototype lift threshold;
8. verify the vessel falls through integrated velocity/gravity rather than teleporting;
9. verify impact settles to a persistent recognizable hulk;
10. switch to defender view before depletion and confirm the entire failure sequence is readable from the ground;
11. capture screenshots/video for stable, critical, falling and hulk states from both cameras;
12. record FPS/frame-time/mesh count and any visual clipping/camera discomfort;
13. optionally use `?inspect=1` to inspect transforms/materials.

Keep this PR draft until runtime/browser evidence is posted. The next slice should be visible R1 assembly/deployment from the core only if this visual/temporal hypothesis succeeds.