### PR TITLE
experiment: prototype inertial mothership navigation and silo attraction

### DIFF
--- a/experiments/hybrid-engine/navigation.html
+++ b/experiments/hybrid-engine/navigation.html
@@ -24,7 +24,8 @@
       <button id="far" type="button">Target outer sector [2]</button>
       <button id="camera" type="button">Defender view [C]</button>
     </div>
-    <div id="hint">Tap/click the surface to choose a raid sector. The mothership moves physically toward an offset launch position; unsafe central targets are projected out of the silo field.</div>
+    <div id="hint">Tap/click the surface to choose a raid sector. The mothership moves physically toward an offset launch position; unsafe central targets are projected out of the silo field. The three-set planner can commit a composition or deliberately hold.</div>
     <script type="module" src="/src/mothershipNavigationPrototype.ts"></script>
+    <script type="module" src="/src/raidPlanPrototype.ts"></script>
   </body>
 </html>

--- a/experiments/hybrid-engine/navigation.html
+++ b/experiments/hybrid-engine/navigation.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defend Mothership Navigation Lab</title>
+    <style>
+      html, body, #app, canvas { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #08050d; color: #e8d8c0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      canvas { display: block; touch-action: none; }
+      #metrics { position: fixed; top: 12px; left: 12px; z-index: 3; min-width: 260px; padding: 8px 10px; border: 1px solid rgba(66, 216, 210, .35); background: rgba(8, 5, 13, .8); font-size: 12px; line-height: 1.45; pointer-events: none; white-space: pre; }
+      #controls { position: fixed; right: 12px; top: 12px; z-index: 4; display: flex; gap: 6px; flex-wrap: wrap; max-width: 440px; justify-content: flex-end; }
+      button { border: 1px solid rgba(214, 145, 76, .48); background: rgba(18, 10, 27, .9); color: #e8d8c0; padding: 7px 9px; font: inherit; cursor: pointer; }
+      button:hover, button:focus-visible { border-color: rgba(66, 216, 210, .85); outline: none; }
+      #hint { position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%); z-index: 3; padding: 6px 9px; background: rgba(8, 5, 13, .72); border: 1px solid rgba(214, 145, 76, .25); font-size: 12px; pointer-events: none; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <div id="app"><canvas id="renderCanvas"></canvas></div>
+    <div id="metrics">initializing…</div>
+    <div id="controls">
+      <button id="reset" type="button">Reset [R]</button>
+      <button id="near" type="button">Target near silo [1]</button>
+      <button id="far" type="button">Target outer sector [2]</button>
+      <button id="camera" type="button">Defender view [C]</button>
+    </div>
+    <div id="hint">Tap/click the surface to choose a raid sector. The mothership moves physically toward an offset launch position; unsafe central targets are projected out of the silo field.</div>
+    <script type="module" src="/src/mothershipNavigationPrototype.ts"></script>
+  </body>
+</html>

--- a/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
@@ -1,0 +1,655 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Engine,
+  HemisphericLight,
+  Mesh,
+  MeshBuilder,
+  PointLight,
+  Scene,
+  StandardMaterial,
+  TransformNode,
+  Vector3,
+} from "@babylonjs/core/pure";
+
+type CameraMode = "raider" | "defender";
+type NavigationPhase = "stable" | "warning" | "critical" | "captured";
+
+const START_POSITION = new Vector3(48, 46, 30);
+const START_RESERVE = 1;
+const HOVER_DRAIN_PER_SECOND = 0.0025;
+const MOVEMENT_DRAIN_PER_ACCEL = 0.00028;
+const MAX_ACCELERATION = 7.2;
+const MAX_SPEED = 22;
+const LINEAR_DAMPING = 0.42;
+const ARRIVAL_RADIUS = 4;
+const SURFACE_HALF_EXTENT = 86;
+const SILO_WARNING_RADIUS = 31;
+const SILO_CRITICAL_RADIUS = 17;
+const SAFE_TARGET_RADIUS = 35;
+const TARGET_LAUNCH_OFFSET = 24;
+const ATTRACTION_STRENGTH = 19;
+const CAPTURE_PULL_STRENGTH = 34;
+const MAX_FRAME_DELTA_SECONDS = 0.05;
+
+interface NavigationState {
+  reserve: number;
+  velocity: Vector3;
+  desiredPosition: Vector3;
+  raidSector: Vector3;
+  cameraAnchor: Vector3;
+  cameraMode: CameraMode;
+  phase: NavigationPhase;
+  projectedTargetCount: number;
+  totalMovementEnergy: number;
+  elapsedSeconds: number;
+}
+
+function createMaterial(
+  name: string,
+  scene: Scene,
+  diffuse: Color3,
+  emissive: Color3,
+  alpha = 1,
+): StandardMaterial {
+  const material = new StandardMaterial(name, scene);
+  material.diffuseColor = diffuse;
+  material.emissiveColor = emissive;
+  material.specularColor = new Color3(0.08, 0.08, 0.1);
+  material.alpha = alpha;
+  return material;
+}
+
+function horizontalDistance(position: Vector3): number {
+  return Math.sqrt(position.x * position.x + position.z * position.z);
+}
+
+function horizontalDirection(position: Vector3, fallback: Vector3): Vector3 {
+  const direction = new Vector3(position.x, 0, position.z);
+  if (direction.lengthSquared() < 0.0001) {
+    direction.copyFrom(fallback);
+    direction.y = 0;
+  }
+  if (direction.lengthSquared() < 0.0001) {
+    direction.set(1, 0, 0);
+  }
+  return direction.normalize();
+}
+
+function clampSurfacePoint(point: Vector3): Vector3 {
+  return new Vector3(
+    Math.max(-SURFACE_HALF_EXTENT, Math.min(SURFACE_HALF_EXTENT, point.x)),
+    0.16,
+    Math.max(-SURFACE_HALF_EXTENT, Math.min(SURFACE_HALF_EXTENT, point.z)),
+  );
+}
+
+function desiredShipPositionForSector(
+  sector: Vector3,
+  currentPosition: Vector3,
+): { desired: Vector3; projected: boolean } {
+  const outward = horizontalDirection(sector, currentPosition);
+  const desired = new Vector3(
+    sector.x + outward.x * TARGET_LAUNCH_OFFSET,
+    START_POSITION.y,
+    sector.z + outward.z * TARGET_LAUNCH_OFFSET,
+  );
+
+  const distance = horizontalDistance(desired);
+  if (distance >= SAFE_TARGET_RADIUS) {
+    return { desired, projected: false };
+  }
+
+  desired.x = outward.x * SAFE_TARGET_RADIUS;
+  desired.z = outward.z * SAFE_TARGET_RADIUS;
+  return { desired, projected: true };
+}
+
+function phaseForPosition(position: Vector3): NavigationPhase {
+  const distance = horizontalDistance(position);
+  if (distance <= SILO_CRITICAL_RADIUS) return "critical";
+  if (distance <= SILO_WARNING_RADIUS) return "warning";
+  return "stable";
+}
+
+function createArena(scene: Scene) {
+  const groundMaterial = createMaterial(
+    "navigation-ground",
+    scene,
+    new Color3(0.028, 0.019, 0.038),
+    new Color3(0.008, 0.005, 0.014),
+  );
+  const ground = MeshBuilder.CreateGround(
+    "navigation-ground",
+    { width: 180, height: 180, subdivisions: 1 },
+    scene,
+  );
+  ground.material = groundMaterial;
+
+  const towerMaterial = createMaterial(
+    "navigation-defender",
+    scene,
+    new Color3(0.08, 0.31, 0.17),
+    new Color3(0.012, 0.06, 0.025),
+  );
+  const tealMaterial = createMaterial(
+    "navigation-silo-core",
+    scene,
+    new Color3(0.05, 0.54, 0.55),
+    new Color3(0.025, 0.36, 0.37),
+    0.9,
+  );
+  const warningMaterial = createMaterial(
+    "navigation-warning",
+    scene,
+    new Color3(0.48, 0.26, 0.08),
+    new Color3(0.16, 0.065, 0.01),
+    0.45,
+  );
+  const criticalMaterial = createMaterial(
+    "navigation-critical",
+    scene,
+    new Color3(0.55, 0.08, 0.2),
+    new Color3(0.24, 0.015, 0.05),
+    0.5,
+  );
+
+  const silo = MeshBuilder.CreateBox(
+    "navigation-silo",
+    { width: 24, height: 4, depth: 24 },
+    scene,
+  );
+  silo.position.y = 2;
+  silo.material = towerMaterial;
+
+  const siloCore = MeshBuilder.CreateBox(
+    "navigation-silo-core",
+    { width: 17, height: 1.1, depth: 17 },
+    scene,
+  );
+  siloCore.position.y = 4.6;
+  siloCore.material = tealMaterial;
+
+  const warningRing = MeshBuilder.CreateTorus(
+    "silo-warning-ring",
+    { diameter: SILO_WARNING_RADIUS * 2, thickness: 0.45, tessellation: 48 },
+    scene,
+  );
+  warningRing.rotation.x = Math.PI / 2;
+  warningRing.position.y = 0.28;
+  warningRing.material = warningMaterial;
+  warningRing.isPickable = false;
+
+  const criticalRing = MeshBuilder.CreateTorus(
+    "silo-critical-ring",
+    { diameter: SILO_CRITICAL_RADIUS * 2, thickness: 0.7, tessellation: 40 },
+    scene,
+  );
+  criticalRing.rotation.x = Math.PI / 2;
+  criticalRing.position.y = 0.32;
+  criticalRing.material = criticalMaterial;
+  criticalRing.isPickable = false;
+
+  const barrierPositions = [
+    new Vector3(-30, 2, -24),
+    new Vector3(28, 2, -25),
+    new Vector3(-28, 2, 26),
+    new Vector3(31, 2, 25),
+    new Vector3(-52, 2, 8),
+    new Vector3(52, 2, -5),
+  ];
+  barrierPositions.forEach((position, index) => {
+    const barrier = MeshBuilder.CreateBox(
+      `navigation-barrier-${index}`,
+      { width: 10, height: 4, depth: 10 },
+      scene,
+    );
+    barrier.position.copyFrom(position);
+    barrier.material = towerMaterial;
+  });
+
+  return { ground, siloCore, warningRing, criticalRing };
+}
+
+function createMothership(scene: Scene) {
+  const root = new TransformNode("navigation-mothership-root", scene);
+  root.position.copyFrom(START_POSITION);
+
+  const shellMaterial = createMaterial(
+    "navigation-mothership-shell",
+    scene,
+    new Color3(0.23, 0.055, 0.35),
+    new Color3(0.075, 0.012, 0.105),
+    0.92,
+  );
+  shellMaterial.wireframe = true;
+  const structureMaterial = createMaterial(
+    "navigation-mothership-structure",
+    scene,
+    new Color3(0.15, 0.035, 0.24),
+    new Color3(0.035, 0.006, 0.055),
+    0.96,
+  );
+  const coreMaterial = createMaterial(
+    "navigation-mothership-core",
+    scene,
+    new Color3(0.04, 0.58, 0.58),
+    new Color3(0.02, 0.52, 0.54),
+    0.93,
+  );
+
+  const shell = MeshBuilder.CreateSphere(
+    "navigation-mothership-shell",
+    { diameter: 32, segments: 8 },
+    scene,
+  );
+  shell.parent = root;
+  shell.material = shellMaterial;
+  shell.isPickable = false;
+
+  const core = MeshBuilder.CreateSphere(
+    "navigation-mothership-core",
+    { diameter: 12, segments: 10 },
+    scene,
+  );
+  core.parent = root;
+  core.material = coreMaterial;
+  core.isPickable = false;
+
+  for (const axis of ["equator", "x", "z"] as const) {
+    const ring = MeshBuilder.CreateTorus(
+      `navigation-ring-${axis}`,
+      { diameter: 29, thickness: 0.9, tessellation: 18 },
+      scene,
+    );
+    ring.parent = root;
+    if (axis === "x") ring.rotation.x = Math.PI / 2;
+    if (axis === "z") ring.rotation.z = Math.PI / 2;
+    ring.material = structureMaterial;
+    ring.isPickable = false;
+  }
+
+  const strutX = MeshBuilder.CreateBox(
+    "navigation-strut-x",
+    { width: 25, height: 0.75, depth: 0.75 },
+    scene,
+  );
+  strutX.parent = root;
+  strutX.material = structureMaterial;
+  const strutZ = MeshBuilder.CreateBox(
+    "navigation-strut-z",
+    { width: 0.75, height: 0.75, depth: 25 },
+    scene,
+  );
+  strutZ.parent = root;
+  strutZ.material = structureMaterial;
+
+  return { root, core, coreMaterial, shellMaterial };
+}
+
+function createMarker(
+  name: string,
+  scene: Scene,
+  material: StandardMaterial,
+  diameter: number,
+): Mesh {
+  const marker = MeshBuilder.CreateTorus(
+    name,
+    { diameter, thickness: 0.55, tessellation: 28 },
+    scene,
+  );
+  marker.rotation.x = Math.PI / 2;
+  marker.position.y = 0.3;
+  marker.material = material;
+  marker.isPickable = false;
+  return marker;
+}
+
+function resetState(state: NavigationState, root: TransformNode): void {
+  state.reserve = START_RESERVE;
+  state.velocity.set(0, 0, 0);
+  state.raidSector.set(52, 0.16, 42);
+  const initialTarget = desiredShipPositionForSector(state.raidSector, START_POSITION);
+  state.desiredPosition.copyFrom(initialTarget.desired);
+  state.cameraAnchor.copyFrom(START_POSITION);
+  state.phase = "stable";
+  state.projectedTargetCount = 0;
+  state.totalMovementEnergy = 0;
+  state.elapsedSeconds = 0;
+  root.position.copyFrom(START_POSITION);
+  root.rotation.set(0, 0, 0);
+}
+
+function setTargetSector(
+  state: NavigationState,
+  root: TransformNode,
+  marker: Mesh,
+  desiredMarker: Mesh,
+  point: Vector3,
+): void {
+  state.raidSector.copyFrom(clampSurfacePoint(point));
+  marker.position.x = state.raidSector.x;
+  marker.position.z = state.raidSector.z;
+
+  const target = desiredShipPositionForSector(state.raidSector, root.position);
+  state.desiredPosition.copyFrom(target.desired);
+  if (target.projected) state.projectedTargetCount += 1;
+  desiredMarker.position.set(
+    state.desiredPosition.x,
+    0.34,
+    state.desiredPosition.z,
+  );
+}
+
+function siloAttraction(position: Vector3, phase: NavigationPhase): Vector3 {
+  const distance = horizontalDistance(position);
+  if (distance >= SILO_WARNING_RADIUS || distance < 0.001) return Vector3.Zero();
+
+  const inward = new Vector3(-position.x, 0, -position.z).normalize();
+  const normalized = 1 - distance / SILO_WARNING_RADIUS;
+  const strength =
+    phase === "critical"
+      ? CAPTURE_PULL_STRENGTH * (0.45 + normalized * normalized)
+      : ATTRACTION_STRENGTH * normalized * normalized;
+  return inward.scale(strength);
+}
+
+function movementAcceleration(
+  position: Vector3,
+  velocity: Vector3,
+  desired: Vector3,
+): Vector3 {
+  const error = desired.subtract(position);
+  error.y = 0;
+  const distance = error.length();
+  if (distance < ARRIVAL_RADIUS) {
+    return velocity.scale(-1.2);
+  }
+
+  const desiredDirection = error.normalize();
+  const desiredSpeed = Math.min(MAX_SPEED, Math.max(4, distance * 0.38));
+  const desiredVelocity = desiredDirection.scale(desiredSpeed);
+  const correction = desiredVelocity.subtract(new Vector3(velocity.x, 0, velocity.z));
+  if (correction.length() > MAX_ACCELERATION) correction.normalize().scaleInPlace(MAX_ACCELERATION);
+  return correction;
+}
+
+function updateCamera(
+  camera: ArcRotateCamera,
+  state: NavigationState,
+  root: TransformNode,
+  deltaSeconds: number,
+): void {
+  if (state.cameraMode === "raider") {
+    const followTarget = root.position.add(new Vector3(0, -5, 0));
+    const smoothing = 1 - Math.exp(-deltaSeconds * 4.2);
+    state.cameraAnchor.copyFrom(Vector3.Lerp(state.cameraAnchor, followTarget, smoothing));
+    camera.setTarget(state.cameraAnchor);
+    camera.radius += (64 - camera.radius) * Math.min(1, deltaSeconds * 2.2);
+    camera.beta += (0.93 - camera.beta) * Math.min(1, deltaSeconds * 1.4);
+  } else {
+    camera.setTarget(new Vector3(0, 24, 0));
+  }
+}
+
+async function main(): Promise<void> {
+  const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas");
+  const metrics = document.querySelector<HTMLElement>("#metrics");
+  const resetButton = document.querySelector<HTMLButtonElement>("#reset");
+  const nearButton = document.querySelector<HTMLButtonElement>("#near");
+  const farButton = document.querySelector<HTMLButtonElement>("#far");
+  const cameraButton = document.querySelector<HTMLButtonElement>("#camera");
+  if (!canvas || !metrics || !resetButton || !nearButton || !farButton || !cameraButton) {
+    throw new Error("Navigation lab DOM is incomplete");
+  }
+
+  const engine = new Engine(canvas, true, { adaptToDeviceRatio: true, antialias: true });
+  const scene = new Scene(engine);
+  scene.clearColor.set(0.02, 0.012, 0.034, 1);
+
+  const camera = new ArcRotateCamera(
+    "navigation-camera",
+    -Math.PI / 2.1,
+    0.93,
+    64,
+    START_POSITION,
+    scene,
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 42;
+  camera.upperRadiusLimit = 170;
+  camera.lowerBetaLimit = 0.35;
+  camera.upperBetaLimit = 2.2;
+
+  const ambient = new HemisphericLight("navigation-ambient", new Vector3(0.15, 1, 0.2), scene);
+  ambient.intensity = 0.74;
+
+  const arena = createArena(scene);
+  const mothership = createMothership(scene);
+  const coreLight = new PointLight("navigation-core-light", START_POSITION, scene);
+  coreLight.diffuse = new Color3(0.1, 0.92, 0.88);
+  coreLight.intensity = 0.7;
+  coreLight.range = 62;
+
+  const raidMarkerMaterial = createMaterial(
+    "raid-sector-marker",
+    scene,
+    new Color3(0.06, 0.56, 0.58),
+    new Color3(0.02, 0.28, 0.3),
+    0.86,
+  );
+  const desiredMarkerMaterial = createMaterial(
+    "ship-target-marker",
+    scene,
+    new Color3(0.68, 0.35, 0.09),
+    new Color3(0.18, 0.07, 0.01),
+    0.7,
+  );
+  const raidMarker = createMarker("raid-sector-marker", scene, raidMarkerMaterial, 7);
+  const desiredMarker = createMarker("ship-target-marker", scene, desiredMarkerMaterial, 5);
+
+  const state: NavigationState = {
+    reserve: START_RESERVE,
+    velocity: Vector3.Zero(),
+    desiredPosition: START_POSITION.clone(),
+    raidSector: new Vector3(52, 0.16, 42),
+    cameraAnchor: START_POSITION.clone(),
+    cameraMode: "raider",
+    phase: "stable",
+    projectedTargetCount: 0,
+    totalMovementEnergy: 0,
+    elapsedSeconds: 0,
+  };
+  resetState(state, mothership.root);
+  setTargetSector(state, mothership.root, raidMarker, desiredMarker, state.raidSector);
+
+  let inspectable: { dispose(): void } | undefined;
+  if (new URLSearchParams(location.search).has("inspect")) {
+    const { StartInspectable } = await import("@babylonjs/inspector");
+    inspectable = StartInspectable(scene);
+  }
+
+  const updateCameraButton = () => {
+    cameraButton.textContent = state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
+  };
+
+  const doReset = () => {
+    resetState(state, mothership.root);
+    setTargetSector(state, mothership.root, raidMarker, desiredMarker, state.raidSector);
+    camera.alpha = -Math.PI / 2.1;
+    camera.beta = 0.93;
+    camera.radius = 64;
+    updateCameraButton();
+  };
+
+  const setNearTarget = () => {
+    setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(4, 0, 3));
+  };
+  const setFarTarget = () => {
+    setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(-66, 0, 46));
+  };
+  const toggleCamera = () => {
+    state.cameraMode = state.cameraMode === "raider" ? "defender" : "raider";
+    if (state.cameraMode === "defender") {
+      camera.alpha = -Math.PI / 3.4;
+      camera.beta = 1.34;
+      camera.radius = 138;
+    } else {
+      camera.alpha = -Math.PI / 2.1;
+      camera.beta = 0.93;
+      camera.radius = 64;
+    }
+    updateCameraButton();
+  };
+
+  resetButton.addEventListener("click", doReset);
+  nearButton.addEventListener("click", setNearTarget);
+  farButton.addEventListener("click", setFarTarget);
+  cameraButton.addEventListener("click", toggleCamera);
+
+  scene.onPointerDown = (_event, pickInfo) => {
+    if (pickInfo.hit && pickInfo.pickedPoint && pickInfo.pickedMesh === arena.ground) {
+      setTargetSector(state, mothership.root, raidMarker, desiredMarker, pickInfo.pickedPoint);
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key.toLowerCase() === "r") doReset();
+    if (event.key === "1") setNearTarget();
+    if (event.key === "2") setFarTarget();
+    if (event.key.toLowerCase() === "c") toggleCamera();
+  };
+  window.addEventListener("keydown", onKeyDown);
+
+  let frame = 0;
+  engine.runRenderLoop(() => {
+    const deltaSeconds = Math.min(MAX_FRAME_DELTA_SECONDS, engine.getDeltaTime() / 1000);
+    state.elapsedSeconds += deltaSeconds;
+
+    if (state.phase !== "captured") {
+      state.phase = phaseForPosition(mothership.root.position);
+    }
+
+    const steering = movementAcceleration(
+      mothership.root.position,
+      state.velocity,
+      state.desiredPosition,
+    );
+    const attraction = siloAttraction(mothership.root.position, state.phase);
+    const acceleration = steering.add(attraction);
+
+    if (state.phase === "critical") {
+      const inwardSpeed = -Vector3.Dot(
+        new Vector3(state.velocity.x, 0, state.velocity.z),
+        horizontalDirection(mothership.root.position, new Vector3(1, 0, 0)),
+      );
+      if (horizontalDistance(mothership.root.position) < SILO_CRITICAL_RADIUS * 0.55 && inwardSpeed > 3) {
+        state.phase = "captured";
+      }
+    }
+
+    if (state.phase === "captured") {
+      const inward = new Vector3(-mothership.root.position.x, -10, -mothership.root.position.z);
+      if (inward.lengthSquared() > 0.001) {
+        inward.normalize().scaleInPlace(CAPTURE_PULL_STRENGTH * 1.35);
+        acceleration.copyFrom(inward);
+      }
+    }
+
+    state.velocity.addInPlace(acceleration.scale(deltaSeconds));
+    const damping = Math.exp(-LINEAR_DAMPING * deltaSeconds);
+    state.velocity.x *= damping;
+    state.velocity.z *= damping;
+    state.velocity.y = state.phase === "captured" ? state.velocity.y - 8 * deltaSeconds : 0;
+
+    const horizontalSpeed = Math.sqrt(
+      state.velocity.x * state.velocity.x + state.velocity.z * state.velocity.z,
+    );
+    if (horizontalSpeed > MAX_SPEED * 1.35) {
+      const scale = (MAX_SPEED * 1.35) / horizontalSpeed;
+      state.velocity.x *= scale;
+      state.velocity.z *= scale;
+    }
+
+    mothership.root.position.addInPlace(state.velocity.scale(deltaSeconds));
+    if (state.phase !== "captured") mothership.root.position.y = START_POSITION.y;
+    else mothership.root.position.y = Math.max(15, mothership.root.position.y);
+
+    const movementDrain = acceleration.length() * MOVEMENT_DRAIN_PER_ACCEL * deltaSeconds;
+    state.totalMovementEnergy += movementDrain;
+    state.reserve = Math.max(0, state.reserve - HOVER_DRAIN_PER_SECOND * deltaSeconds - movementDrain);
+
+    const reserveScale = Math.max(0.3, Math.sqrt(state.reserve));
+    mothership.core.scaling.set(reserveScale, reserveScale, reserveScale);
+    mothership.coreMaterial.emissiveColor.set(
+      0.02 * reserveScale,
+      0.52 * reserveScale,
+      0.54 * reserveScale,
+    );
+    coreLight.position.copyFrom(mothership.root.position);
+    coreLight.intensity = 0.2 + state.reserve * 0.62;
+
+    const speed = state.velocity.length();
+    const targetHeading = speed > 0.3 ? Math.atan2(state.velocity.x, state.velocity.z) : mothership.root.rotation.y;
+    mothership.root.rotation.y += (targetHeading - mothership.root.rotation.y) * Math.min(1, deltaSeconds * 1.8);
+    const stress = state.phase === "warning" ? 0.025 : state.phase === "critical" ? 0.06 : state.phase === "captured" ? 0.12 : 0.008;
+    mothership.root.rotation.z = Math.sin(state.elapsedSeconds * 1.8) * stress + state.velocity.x * -0.003;
+    mothership.root.rotation.x = Math.cos(state.elapsedSeconds * 1.4) * stress + state.velocity.z * 0.002;
+
+    const distanceToSilo = horizontalDistance(mothership.root.position);
+    arena.warningRing.scaling.setAll(1 + Math.sin(state.elapsedSeconds * 2.2) * 0.01);
+    arena.criticalRing.scaling.setAll(1 + Math.sin(state.elapsedSeconds * 3.3) * 0.025);
+    arena.siloCore.scaling.y = 1 + Math.max(0, 1 - distanceToSilo / SILO_WARNING_RADIUS) * 0.45;
+
+    updateCamera(camera, state, mothership.root, deltaSeconds);
+    scene.render();
+
+    frame += 1;
+    if (frame % 8 === 0) {
+      const desiredDistance = Vector3.Distance(
+        new Vector3(mothership.root.position.x, 0, mothership.root.position.z),
+        new Vector3(state.desiredPosition.x, 0, state.desiredPosition.z),
+      );
+      metrics.textContent = [
+        "Mothership navigation / silo-attraction PoC",
+        `phase: ${state.phase}`,
+        `reserve: ${(state.reserve * 100).toFixed(1)}%`,
+        `position: ${mothership.root.position.x.toFixed(1)}, ${mothership.root.position.z.toFixed(1)}`,
+        `speed: ${speed.toFixed(2)} u/s`,
+        `distance to silo: ${distanceToSilo.toFixed(1)}`,
+        `desired distance: ${desiredDistance.toFixed(1)}`,
+        `raid sector: ${state.raidSector.x.toFixed(1)}, ${state.raidSector.z.toFixed(1)}`,
+        `movement energy spent: ${(state.totalMovementEnergy * 100).toFixed(2)}%`,
+        `unsafe targets projected: ${state.projectedTargetCount}`,
+        `camera: ${state.cameraMode}`,
+        `fps: ${engine.getFps().toFixed(1)}`,
+        `meshes: ${scene.meshes.length}`,
+        "warning / critical silo radii are lab values",
+        "?inspect=1 enables Babylon Inspector",
+      ].join("\n");
+    }
+  });
+
+  const resize = () => engine.resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("keydown", onKeyDown);
+      inspectable?.dispose();
+      engine.stopRenderLoop();
+      scene.dispose();
+      engine.dispose();
+    },
+    { once: true },
+  );
+
+  (window as unknown as { __defendMothershipNavigation?: unknown }).__defendMothershipNavigation = {
+    state,
+    setSector: (x: number, z: number) =>
+      setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(x, 0, z)),
+  };
+}
+
+void main();

--- a/experiments/hybrid-engine/src/raidPlanPrototype.ts
+++ b/experiments/hybrid-engine/src/raidPlanPrototype.ts
@@ -1,0 +1,242 @@
+type RaiderTier = 1 | 2 | 3;
+
+interface SectorTarget {
+  x: number;
+  z: number;
+}
+
+interface RaidSetPlan {
+  r1: number;
+  r2: number;
+  r3: number;
+  sector: SectorTarget | null;
+}
+
+interface NavigationDebugState {
+  raidSector: { x: number; z: number };
+  reserve: number;
+}
+
+interface NavigationDebugApi {
+  state: NavigationDebugState;
+}
+
+const MAX_PER_TIER = 9;
+const COMMITMENT_WEIGHT: Record<RaiderTier, number> = {
+  1: 1,
+  2: 4,
+  3: 9,
+};
+
+const plans: RaidSetPlan[] = [
+  { r1: 3, r2: 0, r3: 0, sector: null },
+  { r1: 1, r2: 1, r3: 0, sector: null },
+  { r1: 0, r2: 0, r3: 0, sector: null },
+];
+
+function navigationApi(): NavigationDebugApi | null {
+  const scope = window as unknown as {
+    __defendMothershipNavigation?: NavigationDebugApi;
+  };
+  return scope.__defendMothershipNavigation ?? null;
+}
+
+function copyCurrentSector(): SectorTarget | null {
+  const api = navigationApi();
+  if (!api) return null;
+  return {
+    x: api.state.raidSector.x,
+    z: api.state.raidSector.z,
+  };
+}
+
+function commitment(plan: RaidSetPlan): number {
+  return (
+    plan.r1 * COMMITMENT_WEIGHT[1] +
+    plan.r2 * COMMITMENT_WEIGHT[2] +
+    plan.r3 * COMMITMENT_WEIGHT[3]
+  );
+}
+
+function isHold(plan: RaidSetPlan): boolean {
+  return plan.r1 === 0 && plan.r2 === 0 && plan.r3 === 0;
+}
+
+function adjust(index: number, tier: RaiderTier, delta: number): void {
+  const plan = plans[index];
+  const key = tier === 1 ? "r1" : tier === 2 ? "r2" : "r3";
+  plan[key] = Math.max(0, Math.min(MAX_PER_TIER, plan[key] + delta));
+  render();
+}
+
+function setHold(index: number): void {
+  plans[index].r1 = 0;
+  plans[index].r2 = 0;
+  plans[index].r3 = 0;
+  render();
+}
+
+function useCurrentSector(index: number): void {
+  plans[index].sector = copyCurrentSector();
+  render();
+}
+
+function advanceQueue(): void {
+  plans.shift();
+  plans.push({ r1: 0, r2: 0, r3: 0, sector: null });
+  render();
+}
+
+function compositionText(plan: RaidSetPlan): string {
+  if (isHold(plan)) return "HOLD / NO RAID";
+  const parts: string[] = [];
+  if (plan.r1 > 0) parts.push(`R1×${plan.r1}`);
+  if (plan.r2 > 0) parts.push(`R2×${plan.r2}`);
+  if (plan.r3 > 0) parts.push(`R3×${plan.r3}`);
+  return parts.join("  ");
+}
+
+function sectorText(plan: RaidSetPlan): string {
+  if (!plan.sector) return "sector: current at launch / unset";
+  return `sector: ${plan.sector.x.toFixed(1)}, ${plan.sector.z.toFixed(1)}`;
+}
+
+const style = document.createElement("style");
+style.textContent = `
+  #raid-plan-lab {
+    position: fixed;
+    right: 12px;
+    bottom: 48px;
+    z-index: 5;
+    width: min(620px, calc(100vw - 24px));
+    max-height: 52vh;
+    overflow: auto;
+    box-sizing: border-box;
+    padding: 9px;
+    border: 1px solid rgba(66, 216, 210, .32);
+    background: rgba(8, 5, 13, .86);
+    font-size: 11px;
+    line-height: 1.35;
+  }
+  #raid-plan-lab header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 7px;
+  }
+  #raid-plan-lab h2 { margin: 0; font-size: 12px; font-weight: 600; }
+  #raid-plan-lab .queue { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; }
+  #raid-plan-lab .slot { border: 1px solid rgba(214, 145, 76, .24); padding: 6px; background: rgba(18, 10, 27, .6); }
+  #raid-plan-lab .slot.hold { border-style: dashed; opacity: .78; }
+  #raid-plan-lab .slot-title { display: flex; justify-content: space-between; gap: 4px; margin-bottom: 4px; }
+  #raid-plan-lab .composition { min-height: 16px; color: rgb(119, 223, 218); }
+  #raid-plan-lab .sector { opacity: .72; margin: 3px 0 5px; }
+  #raid-plan-lab .tier-row { display: grid; grid-template-columns: 24px 1fr 1fr 24px; gap: 3px; align-items: center; margin-top: 3px; }
+  #raid-plan-lab button { padding: 3px 5px; font-size: 10px; }
+  #raid-plan-lab .slot-actions { display: flex; gap: 3px; flex-wrap: wrap; margin-top: 5px; }
+  #raid-plan-lab .summary { margin-top: 7px; opacity: .84; }
+  @media (max-width: 760px) {
+    #raid-plan-lab { max-height: 44vh; }
+    #raid-plan-lab .queue { grid-template-columns: 1fr; }
+  }
+`;
+document.head.appendChild(style);
+
+const panel = document.createElement("section");
+panel.id = "raid-plan-lab";
+panel.setAttribute("aria-label", "Three-set raid planning prototype");
+document.body.appendChild(panel);
+
+function tierControls(planIndex: number, tier: RaiderTier, value: number): string {
+  return `
+    <div class="tier-row">
+      <span>R${tier}</span>
+      <button type="button" data-action="minus" data-index="${planIndex}" data-tier="${tier}" aria-label="Remove one R${tier} from raid ${planIndex + 1}">−</button>
+      <button type="button" data-action="plus" data-index="${planIndex}" data-tier="${tier}" aria-label="Add one R${tier} to raid ${planIndex + 1}">+</button>
+      <strong>${value}</strong>
+    </div>
+  `;
+}
+
+function render(): void {
+  const api = navigationApi();
+  const currentSector = api
+    ? `${api.state.raidSector.x.toFixed(1)}, ${api.state.raidSector.z.toFixed(1)}`
+    : "navigation initializing";
+  const totalCommitment = plans.reduce((sum, plan) => sum + commitment(plan), 0);
+
+  panel.innerHTML = `
+    <header>
+      <div>
+        <h2>Upcoming three raid sets</h2>
+        <div>current selected sector: ${currentSector}</div>
+      </div>
+      <button type="button" data-action="advance">Advance queue [Q]</button>
+    </header>
+    <div class="queue">
+      ${plans
+        .map(
+          (plan, index) => `
+            <article class="slot ${isHold(plan) ? "hold" : ""}">
+              <div class="slot-title"><strong>Set ${index + 1}</strong><span>weight ${commitment(plan)}</span></div>
+              <div class="composition">${compositionText(plan)}</div>
+              <div class="sector">${sectorText(plan)}</div>
+              ${tierControls(index, 1, plan.r1)}
+              ${tierControls(index, 2, plan.r2)}
+              ${tierControls(index, 3, plan.r3)}
+              <div class="slot-actions">
+                <button type="button" data-action="sector" data-index="${index}">Use current sector</button>
+                <button type="button" data-action="hold" data-index="${index}">Hold / clear</button>
+              </div>
+            </article>
+          `,
+        )
+        .join("")}
+    </div>
+    <div class="summary">
+      total queued commitment weight: ${totalCommitment}. R1/R2/R3 lab weights use 1/4/9 only to visualize relative commitment; they are not production launch costs. Empty sets intentionally mean no raid while mothership hover drain continues in the navigation simulation.
+    </div>
+  `;
+}
+
+panel.addEventListener("click", event => {
+  const target = event.target;
+  if (!(target instanceof HTMLButtonElement)) return;
+  const action = target.dataset.action;
+  if (action === "advance") {
+    advanceQueue();
+    return;
+  }
+  const index = Number(target.dataset.index);
+  if (!Number.isInteger(index) || index < 0 || index >= plans.length) return;
+  if (action === "hold") setHold(index);
+  if (action === "sector") useCurrentSector(index);
+  if (action === "plus" || action === "minus") {
+    const tier = Number(target.dataset.tier) as RaiderTier;
+    if (tier === 1 || tier === 2 || tier === 3) {
+      adjust(index, tier, action === "plus" ? 1 : -1);
+    }
+  }
+});
+
+const onKeyDown = (event: KeyboardEvent) => {
+  if (event.key.toLowerCase() === "q") advanceQueue();
+};
+window.addEventListener("keydown", onKeyDown);
+
+let refreshFrame = 0;
+function refreshCurrentSector(): void {
+  refreshFrame += 1;
+  if (refreshFrame % 20 === 0) render();
+  requestAnimationFrame(refreshCurrentSector);
+}
+
+render();
+requestAnimationFrame(refreshCurrentSector);
+
+(window as unknown as { __defendRaidPlanPrototype?: unknown }).__defendRaidPlanPrototype = {
+  plans,
+  advanceQueue,
+  useCurrentSector,
+};

--- a/experiments/hybrid-engine/vite.config.ts
+++ b/experiments/hybrid-engine/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       input: {
         main: "index.html",
         mothership: "mothership.html",
+        navigation: "navigation.html",
       },
     },
   },


### PR DESCRIPTION
Refs #83, #79, #80
Stacked on #81 (`experiment/mothership-poc`).

## Purpose

Prototype the raider-side rule that the camera belongs to a heavy finite-energy mothership rather than an omniscient RTS view, plus the short three-set planning horizon requested in #83.

## Child scope relative to #81

- tap/click ground-sector targeting;
- bounded mothership acceleration, persistent velocity, overshoot/braking and damping;
- camera following the actual moving ship;
- small movement energy cost from the same reserve;
- continuous silo attraction/instability field;
- unsafe desired-position projection outside the central field;
- inertia carrying the ship into danger despite target projection;
- distinct ground raid-sector marker versus mothership launch-position target;
- three editable upcoming raid-set slots;
- independent R1/R2/R3 counts for each set;
- true HOLD / no-raid sets;
- per-set snapshot of the currently selected ground sector;
- queue advance control demonstrating the rolling three-set horizon.

## Navigation lab

`navigation.html` + `src/mothershipNavigationPrototype.ts` implement the physical movement/silo-field PoC.

Lab values:

- warning radius: 31;
- critical radius: 17;
- desired launch positions projected to at least radius 35;
- max nominal steering acceleration: 7.2 units/s²;
- max target speed: 22 units/s.

These are normalized test values, not campaign balance.

The selected raid sector does not teleport the ship. It produces an offset desired launch position, then the vessel physically accelerates toward it. The camera target uses a damped presentation anchor but authoritative movement belongs to the mothership root.

## Three-set planner

`src/raidPlanPrototype.ts` adds a compact overlay with exactly three upcoming sets.

Each set can:

- add/remove R1/R2/R3 bodies;
- be cleared to HOLD / NO RAID;
- snapshot the currently selected sector;
- remain unset and inherit/currently choose a sector later.

The lab displays relative commitment weights 1/4/9 only to make composition cost/risk legible. Those are not production launch costs. Advancing the queue shifts the remaining two plans forward and appends an empty hold slot.

Hover drain continues while a set is held, so the design supports deliberately waiting without making waiting free.

## Silo attraction

The field is a force curve rather than an invisible kill cylinder. Target projection normally keeps desired positions outside the unsafe region, but existing inertia can carry the ship into warning/critical space. Inner-region inward motion can enter a captured/pull-down state for testing.

## Explicit non-goals

This PR does not yet implement:

- raider physical construction/launch;
- production queue costs;
- final spherical-planet coordinates;
- final crash-on-silo-contact outcome;
- AI planning;
- geothermal simulation.

## Online/static review

Compared with parent #81 head `5ebcb6bf115938b4deb9e958b906a91e9eb1b526`:

- 5 commits ahead / 0 behind;
- 4 child-diff files;
- 929 additions / 0 deletions;
- existing mothership crash prototype remains untouched;
- no production source/dependency changes.

## Local Codex certification required

1. build/typecheck the hybrid lab;
2. confirm existing `index.html` and `mothership.html` remain healthy;
3. open `/navigation.html`;
4. click several surface sectors and verify no teleportation;
5. measure acceleration, overshoot, braking and settle behavior;
6. verify camera follows actual vessel motion and compare raider/defender views;
7. verify movement consumes reserve without a second currency;
8. target near the silo and verify desired position projection;
9. use inertia to enter warning/critical zones and verify continuous attraction/recovery/capture;
10. edit all three raid-set compositions, including an intentional HOLD;
11. assign different sectors to the three plans and advance the queue;
12. confirm queue editing itself does not spend production energy yet and is clearly labeled as a lab planning surface;
13. record FPS/mesh count and camera comfort;
14. capture representative traces/screenshots/video.

Keep draft until browser evidence is posted. Actual raider assembly/deployment is the next slice only after movement and planning are readable.