### PR TITLE
experiment: consolidate mothership, geothermal, and surface-routing labs

### DIFF
--- a/experiments/hybrid-engine/geothermal.html
+++ b/experiments/hybrid-engine/geothermal.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defend Geothermal Planet Lab</title>
+    <style>
+      html, body, #app, canvas { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #08050d; color: #e8d8c0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      canvas { display: block; touch-action: none; }
+      #metrics { position: fixed; top: 12px; left: 12px; z-index: 3; min-width: 300px; padding: 8px 10px; border: 1px solid rgba(66, 216, 210, .35); background: rgba(8, 5, 13, .82); font-size: 12px; line-height: 1.45; pointer-events: none; white-space: pre; }
+      #controls { position: fixed; right: 12px; top: 12px; z-index: 4; display: flex; gap: 6px; flex-wrap: wrap; max-width: 520px; justify-content: flex-end; }
+      button { border: 1px solid rgba(214, 145, 76, .48); background: rgba(18, 10, 27, .9); color: #e8d8c0; padding: 7px 9px; font: inherit; cursor: pointer; }
+      button:hover, button:focus-visible { border-color: rgba(66, 216, 210, .85); outline: none; }
+      #hint { position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%); z-index: 3; max-width: 900px; padding: 6px 9px; background: rgba(8, 5, 13, .72); border: 1px solid rgba(214, 145, 76, .25); font-size: 12px; pointer-events: none; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <div id="app"><canvas id="renderCanvas"></canvas></div>
+    <div id="metrics">initializing…</div>
+    <div id="controls">
+      <button id="reset" type="button">Reset [R]</button>
+      <button id="fire" type="button">Stop tower draw [F]</button>
+      <button id="pressure" type="button">Accelerate pressure [P]</button>
+      <button id="eruption" type="button">Force eruption [E]</button>
+      <button id="layers" type="button">Boost internal layers [L]</button>
+    </div>
+    <div id="hint">Tower proxies draw teal projectile energy through finite-length curved conduits. Sustained shared draw depletes local sources; idle rich sources pressurize and can erupt. Internal planet layers are intentionally translucent.</div>
+    <script type="module" src="/src/geothermalPrototype.ts"></script>
+  </body>
+</html>

--- a/experiments/hybrid-engine/mothership.html
+++ b/experiments/hybrid-engine/mothership.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defend Mothership Lab</title>
+    <style>
+      :root { color-scheme: dark; }
+      html, body, #app, canvas { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #08050d; color: #d9f5f5; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      canvas { display: block; touch-action: none; }
+      #metrics {
+        position: fixed;
+        top: 12px;
+        left: 12px;
+        z-index: 2;
+        min-width: 260px;
+        padding: 9px 11px;
+        border: 1px solid rgba(67, 218, 213, .32);
+        background: rgba(8, 5, 13, .82);
+        font-size: 12px;
+        line-height: 1.5;
+        pointer-events: none;
+        white-space: pre;
+      }
+      #controls {
+        position: fixed;
+        right: 12px;
+        top: 12px;
+        z-index: 3;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 6px;
+        max-width: 420px;
+      }
+      button {
+        border: 1px solid rgba(67, 218, 213, .36);
+        background: rgba(22, 10, 33, .86);
+        color: #d9f5f5;
+        padding: 7px 9px;
+        font: inherit;
+        cursor: pointer;
+      }
+      button:hover, button:focus-visible { border-color: rgba(67, 218, 213, .9); outline: none; }
+      #caption {
+        position: fixed;
+        left: 50%;
+        bottom: 14px;
+        transform: translateX(-50%);
+        z-index: 2;
+        padding: 7px 10px;
+        background: rgba(8, 5, 13, .7);
+        color: rgba(217, 245, 245, .82);
+        font-size: 12px;
+        pointer-events: none;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"><canvas id="renderCanvas"></canvas></div>
+    <div id="metrics">initializing…</div>
+    <div id="controls" aria-label="Mothership prototype controls">
+      <button id="reset" type="button">Reset [R]</button>
+      <button id="pause" type="button">Pause drain [Space]</button>
+      <button id="fast" type="button">Fast drain [F]</button>
+      <button id="camera" type="button">Defender view [C]</button>
+    </div>
+    <div id="caption">Finite teal reserve sustains hover. Depletion weakens suspension until gravity wins.</div>
+    <script type="module" src="/src/mothershipPrototype.ts"></script>
+  </body>
+</html>

--- a/experiments/hybrid-engine/navigation.html
+++ b/experiments/hybrid-engine/navigation.html
@@ -24,7 +24,8 @@
       <button id="far" type="button">Target outer sector [2]</button>
       <button id="camera" type="button">Defender view [C]</button>
     </div>
-    <div id="hint">Tap/click the surface to choose a raid sector. The mothership moves physically toward an offset launch position; unsafe central targets are projected out of the silo field.</div>
+    <div id="hint">Tap/click the surface to choose a raid sector. The mothership moves physically toward an offset launch position; unsafe central targets are projected out of the silo field. The three-set planner can commit a composition or deliberately hold.</div>
     <script type="module" src="/src/mothershipNavigationPrototype.ts"></script>
+    <script type="module" src="/src/raidPlanPrototype.ts"></script>
   </body>
 </html>

--- a/experiments/hybrid-engine/navigation.html
+++ b/experiments/hybrid-engine/navigation.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defend Mothership Navigation Lab</title>
+    <style>
+      html, body, #app, canvas { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #08050d; color: #e8d8c0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      canvas { display: block; touch-action: none; }
+      #metrics { position: fixed; top: 12px; left: 12px; z-index: 3; min-width: 260px; padding: 8px 10px; border: 1px solid rgba(66, 216, 210, .35); background: rgba(8, 5, 13, .8); font-size: 12px; line-height: 1.45; pointer-events: none; white-space: pre; }
+      #controls { position: fixed; right: 12px; top: 12px; z-index: 4; display: flex; gap: 6px; flex-wrap: wrap; max-width: 440px; justify-content: flex-end; }
+      button { border: 1px solid rgba(214, 145, 76, .48); background: rgba(18, 10, 27, .9); color: #e8d8c0; padding: 7px 9px; font: inherit; cursor: pointer; }
+      button:hover, button:focus-visible { border-color: rgba(66, 216, 210, .85); outline: none; }
+      #hint { position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%); z-index: 3; padding: 6px 9px; background: rgba(8, 5, 13, .72); border: 1px solid rgba(214, 145, 76, .25); font-size: 12px; pointer-events: none; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <div id="app"><canvas id="renderCanvas"></canvas></div>
+    <div id="metrics">initializing…</div>
+    <div id="controls">
+      <button id="reset" type="button">Reset [R]</button>
+      <button id="near" type="button">Target near silo [1]</button>
+      <button id="far" type="button">Target outer sector [2]</button>
+      <button id="camera" type="button">Defender view [C]</button>
+    </div>
+    <div id="hint">Tap/click the surface to choose a raid sector. The mothership moves physically toward an offset launch position; unsafe central targets are projected out of the silo field.</div>
+    <script type="module" src="/src/mothershipNavigationPrototype.ts"></script>
+  </body>
+</html>

--- a/experiments/hybrid-engine/routing.html
+++ b/experiments/hybrid-engine/routing.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Defend Surface Routing Lab</title>
+    <style>
+      html, body, #app, canvas { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body { background: #08050d; color: #e8d8c0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      canvas { display: block; touch-action: none; }
+      #metrics { position: fixed; top: 12px; left: 12px; z-index: 3; min-width: 300px; padding: 8px 10px; border: 1px solid rgba(66, 216, 210, .35); background: rgba(8, 5, 13, .82); font-size: 12px; line-height: 1.45; pointer-events: none; white-space: pre; }
+      #controls { position: fixed; right: 12px; top: 12px; z-index: 4; display: flex; gap: 6px; flex-wrap: wrap; max-width: 460px; justify-content: flex-end; }
+      button { border: 1px solid rgba(214, 145, 76, .48); background: rgba(18, 10, 27, .9); color: #e8d8c0; padding: 7px 9px; font: inherit; cursor: pointer; }
+      button:hover, button:focus-visible { border-color: rgba(66, 216, 210, .85); outline: none; }
+      #hint { position: fixed; left: 50%; bottom: 14px; transform: translateX(-50%); z-index: 3; padding: 6px 9px; background: rgba(8, 5, 13, .72); border: 1px solid rgba(214, 145, 76, .25); font-size: 12px; pointer-events: none; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <div id="app"><canvas id="renderCanvas"></canvas></div>
+    <div id="metrics">initializing…</div>
+    <div id="controls">
+      <button id="reset" type="button">Reset [R]</button>
+      <button id="energy" type="button">Spawn energy [E]</button>
+      <button id="gate" type="button">Open broad gate [G]</button>
+    </div>
+    <div id="hint">Fluid and R1 can use the narrow drain. R2 weighs detour against battering the gate. R3 keeps momentum and accepts major collisions. Open/destroy the gate to change both combat and drainage topology.</div>
+    <script type="module" src="/src/surfaceRoutingPrototype.ts"></script>
+  </body>
+</html>

--- a/experiments/hybrid-engine/src/geothermalPrototype.ts
+++ b/experiments/hybrid-engine/src/geothermalPrototype.ts
@@ -1,0 +1,872 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Engine,
+  HemisphericLight,
+  Mesh,
+  MeshBuilder,
+  PointLight,
+  Scene,
+  StandardMaterial,
+  Vector3,
+} from "@babylonjs/core/pure";
+
+type SourcePhase = "active" | "retreating" | "erupting";
+type TowerTier = 1 | 2 | 3;
+
+const PLANET_CENTER = new Vector3(0, -68, 0);
+const CRUST_RADIUS = 72;
+const MANTLE_RADIUS = 64;
+const CORE_RADIUS = 31;
+const MAX_CONDUIT_LENGTH = 40;
+const DEPLETED_THRESHOLD = 0.075;
+const DEPLETION_RETREAT_SECONDS = 6;
+const RETREAT_SECONDS = 3.2;
+const DEEP_REPLENISH_PER_SECOND = 0.0055;
+const PRESSURE_BUILD_PER_SECOND = 0.018;
+const PRESSURE_ERUPTION_THRESHOLD = 0.96;
+const ERUPTION_SECONDS = 5.5;
+const MAX_FRAME_DELTA_SECONDS = 0.05;
+
+interface GeothermalSource {
+  id: number;
+  position: Vector3;
+  energy: number;
+  pressure: number;
+  drawRate: number;
+  depletedSeconds: number;
+  retreatSeconds: number;
+  eruptionSeconds: number;
+  phase: SourcePhase;
+  vent: Mesh;
+  bulge: Mesh;
+}
+
+interface TowerProxy {
+  id: number;
+  tier: TowerTier;
+  position: Vector3;
+  mesh: Mesh;
+  sourceId: number | null;
+  conduit: Mesh | null;
+  firing: boolean;
+  supported: boolean;
+  melted: boolean;
+  shotPulse: number;
+}
+
+interface RaiderProxy {
+  id: number;
+  mesh: Mesh;
+  velocity: Vector3;
+  releasedEnergy: boolean;
+}
+
+interface EruptionParticle {
+  mesh: Mesh;
+  velocity: Vector3;
+  age: number;
+}
+
+interface CollectedDroplet {
+  mesh: Mesh;
+  age: number;
+  value: number;
+}
+
+function createMaterial(
+  name: string,
+  scene: Scene,
+  diffuse: Color3,
+  emissive: Color3,
+  alpha = 1,
+): StandardMaterial {
+  const material = new StandardMaterial(name, scene);
+  material.diffuseColor = diffuse;
+  material.emissiveColor = emissive;
+  material.specularColor = new Color3(0.08, 0.08, 0.1);
+  material.alpha = alpha;
+  return material;
+}
+
+function surfaceY(x: number, z: number, offset = 0): number {
+  const radialSquared = x * x + z * z;
+  const radiusSquared = CRUST_RADIUS * CRUST_RADIUS;
+  if (radialSquared >= radiusSquared) return PLANET_CENTER.y + offset;
+  return PLANET_CENTER.y + Math.sqrt(radiusSquared - radialSquared) + offset;
+}
+
+function surfacePoint(x: number, z: number, offset = 0): Vector3 {
+  return new Vector3(x, surfaceY(x, z, offset), z);
+}
+
+function horizontalDistance(a: Vector3, b: Vector3): number {
+  const dx = a.x - b.x;
+  const dz = a.z - b.z;
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+function towerDrawRate(tier: TowerTier): number {
+  if (tier === 1) return 0;
+  if (tier === 2) return 0.012;
+  return 0.028;
+}
+
+function createPlanet(scene: Scene) {
+  const crustMaterial = createMaterial(
+    "geothermal-crust",
+    scene,
+    new Color3(0.16, 0.12, 0.2),
+    new Color3(0.018, 0.01, 0.028),
+    0.2,
+  );
+  crustMaterial.backFaceCulling = false;
+  crustMaterial.wireframe = true;
+
+  const mantleMaterial = createMaterial(
+    "geothermal-mantle",
+    scene,
+    new Color3(0.035, 0.46, 0.47),
+    new Color3(0.02, 0.28, 0.3),
+    0.12,
+  );
+  mantleMaterial.backFaceCulling = false;
+
+  const coreMaterial = createMaterial(
+    "geothermal-core",
+    scene,
+    new Color3(0.12, 0.055, 0.18),
+    new Color3(0.035, 0.01, 0.055),
+    0.22,
+  );
+  coreMaterial.backFaceCulling = false;
+
+  const crust = MeshBuilder.CreateSphere(
+    "planet-crust",
+    { diameter: CRUST_RADIUS * 2, segments: 32 },
+    scene,
+  );
+  crust.position.copyFrom(PLANET_CENTER);
+  crust.material = crustMaterial;
+  crust.isPickable = false;
+
+  const mantle = MeshBuilder.CreateSphere(
+    "planet-mantle",
+    { diameter: MANTLE_RADIUS * 2, segments: 28 },
+    scene,
+  );
+  mantle.position.copyFrom(PLANET_CENTER);
+  mantle.material = mantleMaterial;
+  mantle.isPickable = false;
+
+  const core = MeshBuilder.CreateSphere(
+    "planet-core",
+    { diameter: CORE_RADIUS * 2, segments: 20 },
+    scene,
+  );
+  core.position.copyFrom(PLANET_CENTER);
+  core.material = coreMaterial;
+  core.isPickable = false;
+
+  return { crust, mantle, core, crustMaterial, mantleMaterial, coreMaterial };
+}
+
+function createSurfaceReferences(scene: Scene) {
+  const defenderMaterial = createMaterial(
+    "geothermal-defender",
+    scene,
+    new Color3(0.08, 0.31, 0.17),
+    new Color3(0.012, 0.065, 0.025),
+  );
+  const siloEnergyMaterial = createMaterial(
+    "geothermal-silo-energy",
+    scene,
+    new Color3(0.045, 0.52, 0.53),
+    new Color3(0.02, 0.32, 0.34),
+    0.9,
+  );
+  const raiderMaterial = createMaterial(
+    "geothermal-raider",
+    scene,
+    new Color3(0.27, 0.06, 0.39),
+    new Color3(0.055, 0.008, 0.085),
+    0.95,
+  );
+  raiderMaterial.wireframe = true;
+
+  const silo = MeshBuilder.CreateBox(
+    "geothermal-silo",
+    { width: 20, height: 3.5, depth: 20 },
+    scene,
+  );
+  silo.position.copyFrom(surfacePoint(0, 0, 1.75));
+  silo.material = defenderMaterial;
+
+  const siloCore = MeshBuilder.CreateBox(
+    "geothermal-silo-core",
+    { width: 14, height: 1, depth: 14 },
+    scene,
+  );
+  siloCore.position.copyFrom(surfacePoint(0, 0, 4));
+  siloCore.material = siloEnergyMaterial;
+
+  return { defenderMaterial, siloEnergyMaterial, raiderMaterial, silo };
+}
+
+function createSource(
+  scene: Scene,
+  id: number,
+  x: number,
+  z: number,
+  tealMaterial: StandardMaterial,
+  crustMaterial: StandardMaterial,
+): GeothermalSource {
+  const position = surfacePoint(x, z, -0.8);
+  const vent = MeshBuilder.CreateSphere(
+    `geothermal-vent-${id}`,
+    { diameter: 5.2, segments: 7 },
+    scene,
+  );
+  vent.position.copyFrom(position);
+  vent.material = tealMaterial;
+  vent.scaling.y = 0.35;
+  vent.isPickable = false;
+
+  const bulge = MeshBuilder.CreateSphere(
+    `geothermal-bulge-${id}`,
+    { diameter: 11, segments: 8 },
+    scene,
+  );
+  bulge.position.copyFrom(surfacePoint(x, z, -4));
+  bulge.material = crustMaterial;
+  bulge.scaling.set(1, 0.08, 1);
+  bulge.isPickable = false;
+
+  return {
+    id,
+    position,
+    energy: 0.72 + id * 0.09,
+    pressure: 0.25 + id * 0.1,
+    drawRate: 0,
+    depletedSeconds: 0,
+    retreatSeconds: 0,
+    eruptionSeconds: 0,
+    phase: "active",
+    vent,
+    bulge,
+  };
+}
+
+function createSubsurfaceStream(
+  scene: Scene,
+  name: string,
+  from: Vector3,
+  to: Vector3,
+  material: StandardMaterial,
+): Mesh {
+  const midpoint = Vector3.Lerp(from, to, 0.5);
+  midpoint.y -= 5;
+  const path = [
+    from.add(new Vector3(0, -2.5, 0)),
+    Vector3.Lerp(from, midpoint, 0.5).add(new Vector3(0, -1.5, 0)),
+    midpoint,
+    Vector3.Lerp(midpoint, to, 0.5).add(new Vector3(0, -1, 0)),
+    to.add(new Vector3(0, -2.5, 0)),
+  ];
+  const tube = MeshBuilder.CreateTube(
+    name,
+    { path, radius: 0.7, tessellation: 7, cap: Mesh.CAP_ALL },
+    scene,
+  );
+  tube.material = material;
+  tube.isPickable = false;
+  return tube;
+}
+
+function createTower(
+  scene: Scene,
+  id: number,
+  tier: TowerTier,
+  x: number,
+  z: number,
+  material: StandardMaterial,
+): TowerProxy {
+  const height = tier === 1 ? 4 : tier === 2 ? 8 : 11;
+  const mesh = MeshBuilder.CreateBox(
+    `geothermal-tower-${id}`,
+    { width: tier === 1 ? 8 : 6, height, depth: tier === 1 ? 8 : 6 },
+    scene,
+  );
+  const position = surfacePoint(x, z, height / 2 + 0.5);
+  mesh.position.copyFrom(position);
+  mesh.material = material;
+
+  return {
+    id,
+    tier,
+    position,
+    mesh,
+    sourceId: null,
+    conduit: null,
+    firing: tier > 1,
+    supported: tier === 1,
+    melted: false,
+    shotPulse: 0,
+  };
+}
+
+function conduitPath(source: GeothermalSource, tower: TowerProxy): Vector3[] {
+  const start = source.position.add(new Vector3(0, 1.2, 0));
+  const end = tower.mesh.position.add(new Vector3(0, -tower.mesh.getBoundingInfo().boundingBox.extendSizeWorld.y + 0.7, 0));
+  const lateral = end.subtract(start);
+  const side = new Vector3(-lateral.z, 0, lateral.x);
+  if (side.lengthSquared() > 0.001) side.normalize().scaleInPlace(Math.min(5, lateral.length() * 0.12));
+  const p1 = Vector3.Lerp(start, end, 0.32).add(side).add(new Vector3(0, 1.4, 0));
+  const p2 = Vector3.Lerp(start, end, 0.68).subtract(side.scale(0.45)).add(new Vector3(0, 1.1, 0));
+  return [start, p1, p2, end];
+}
+
+function connectTowers(
+  scene: Scene,
+  towers: TowerProxy[],
+  sources: GeothermalSource[],
+  conduitMaterial: StandardMaterial,
+): void {
+  towers.forEach(tower => {
+    tower.conduit?.dispose();
+    tower.conduit = null;
+    tower.sourceId = null;
+    tower.supported = tower.tier === 1;
+
+    if (tower.tier === 1) return;
+
+    let best: GeothermalSource | null = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (const source of sources) {
+      if (source.phase === "retreating") continue;
+      const distance = horizontalDistance(tower.mesh.position, source.position);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = source;
+      }
+    }
+
+    if (!best || bestDistance > MAX_CONDUIT_LENGTH) return;
+
+    tower.sourceId = best.id;
+    tower.supported = true;
+    tower.conduit = MeshBuilder.CreateTube(
+      `tower-conduit-${tower.id}`,
+      { path: conduitPath(best, tower), radius: 0.42, tessellation: 6, cap: Mesh.CAP_ALL },
+      scene,
+    );
+    tower.conduit.material = conduitMaterial;
+    tower.conduit.isPickable = false;
+  });
+}
+
+function relocateSource(source: GeothermalSource, relocationIndex: number): void {
+  const relocationPoints = [
+    new Vector3(-52, 0, 28),
+    new Vector3(16, 0, 48),
+    new Vector3(50, 0, -4),
+    new Vector3(-8, 0, -52),
+  ];
+  const point = relocationPoints[(source.id + relocationIndex) % relocationPoints.length];
+  source.position.copyFrom(surfacePoint(point.x, point.z, -0.8));
+  source.vent.position.copyFrom(source.position);
+  source.bulge.position.copyFrom(surfacePoint(point.x, point.z, -4));
+  source.energy = 0.62;
+  source.pressure = 0.18;
+  source.drawRate = 0;
+  source.depletedSeconds = 0;
+  source.retreatSeconds = 0;
+  source.phase = "active";
+  source.vent.setEnabled(true);
+}
+
+function createEruptionParticles(
+  scene: Scene,
+  source: GeothermalSource,
+  material: StandardMaterial,
+): EruptionParticle[] {
+  const particles: EruptionParticle[] = [];
+  for (let index = 0; index < 24; index += 1) {
+    const mesh = MeshBuilder.CreateSphere(
+      `eruption-${source.id}-${index}`,
+      { diameter: 0.8 + (index % 4) * 0.25, segments: 4 },
+      scene,
+    );
+    mesh.position.copyFrom(source.position.add(new Vector3(0, 1.3, 0)));
+    mesh.material = material;
+    mesh.isPickable = false;
+
+    const angle = (index / 24) * Math.PI * 2;
+    const speed = 5 + (index % 6) * 1.2;
+    particles.push({
+      mesh,
+      velocity: new Vector3(Math.cos(angle) * speed, 10 + (index % 5) * 2.2, Math.sin(angle) * speed),
+      age: 0,
+    });
+  }
+  return particles;
+}
+
+function spawnCollectedDroplet(
+  scene: Scene,
+  origin: Vector3,
+  material: StandardMaterial,
+  index: number,
+): CollectedDroplet {
+  const mesh = MeshBuilder.CreateSphere(
+    `eruption-liberated-energy-${index}`,
+    { diameter: 1.15, segments: 5 },
+    scene,
+  );
+  mesh.position.copyFrom(origin);
+  mesh.material = material;
+  mesh.isPickable = false;
+  return { mesh, age: 0, value: 1 };
+}
+
+async function main(): Promise<void> {
+  const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas");
+  const metrics = document.querySelector<HTMLElement>("#metrics");
+  const resetButton = document.querySelector<HTMLButtonElement>("#reset");
+  const fireButton = document.querySelector<HTMLButtonElement>("#fire");
+  const pressureButton = document.querySelector<HTMLButtonElement>("#pressure");
+  const eruptionButton = document.querySelector<HTMLButtonElement>("#eruption");
+  const layersButton = document.querySelector<HTMLButtonElement>("#layers");
+  if (!canvas || !metrics || !resetButton || !fireButton || !pressureButton || !eruptionButton || !layersButton) {
+    throw new Error("Geothermal lab DOM is incomplete");
+  }
+
+  const engine = new Engine(canvas, true, { adaptToDeviceRatio: true, antialias: true });
+  const scene = new Scene(engine);
+  scene.clearColor.set(0.02, 0.012, 0.034, 1);
+
+  const camera = new ArcRotateCamera(
+    "geothermal-camera",
+    -Math.PI / 2.35,
+    1.08,
+    154,
+    new Vector3(0, -12, 0),
+    scene,
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 90;
+  camera.upperRadiusLimit = 220;
+  camera.lowerBetaLimit = 0.38;
+  camera.upperBetaLimit = 2.5;
+
+  const ambient = new HemisphericLight("geothermal-ambient", new Vector3(0.25, 1, 0.15), scene);
+  ambient.intensity = 0.7;
+
+  const planet = createPlanet(scene);
+  const refs = createSurfaceReferences(scene);
+  const tealMaterial = createMaterial(
+    "geothermal-energy",
+    scene,
+    new Color3(0.03, 0.62, 0.61),
+    new Color3(0.015, 0.48, 0.48),
+    0.9,
+  );
+  tealMaterial.specularColor = new Color3(0.18, 0.94, 0.9);
+  const conduitMaterial = createMaterial(
+    "geothermal-conduit",
+    scene,
+    new Color3(0.035, 0.38, 0.4),
+    new Color3(0.012, 0.21, 0.23),
+    0.84,
+  );
+  const invalidMaterial = createMaterial(
+    "unsupported-tower",
+    scene,
+    new Color3(0.25, 0.08, 0.1),
+    new Color3(0.05, 0.01, 0.015),
+  );
+
+  const sources = [
+    createSource(scene, 0, -36, -18, tealMaterial, planet.crustMaterial),
+    createSource(scene, 1, 3, 34, tealMaterial, planet.crustMaterial),
+    createSource(scene, 2, 39, -20, tealMaterial, planet.crustMaterial),
+  ];
+
+  const deepStreams = [
+    createSubsurfaceStream(scene, "deep-stream-0", sources[0].position, sources[1].position, tealMaterial),
+    createSubsurfaceStream(scene, "deep-stream-1", sources[1].position, sources[2].position, tealMaterial),
+  ];
+  deepStreams.forEach(stream => {
+    stream.visibility = 0.55;
+  });
+
+  const towers = [
+    createTower(scene, 0, 2, -24, -31, refs.defenderMaterial),
+    createTower(scene, 1, 3, -9, -22, refs.defenderMaterial),
+    createTower(scene, 2, 2, 27, -29, refs.defenderMaterial),
+    createTower(scene, 3, 3, 51, 22, refs.defenderMaterial),
+    createTower(scene, 4, 1, 17, 30, refs.defenderMaterial),
+  ];
+
+  const raiders: RaiderProxy[] = [6, 9, 14].map((diameter, index) => {
+    const mesh = MeshBuilder.CreateSphere(
+      `geothermal-raider-${index}`,
+      { diameter, segments: 5 + index },
+      scene,
+    );
+    mesh.position.copyFrom(surfacePoint(-46 + index * 34, 12 + index * 9, diameter / 2 + 0.4));
+    mesh.material = refs.raiderMaterial;
+    return { id: index, mesh, velocity: Vector3.Zero(), releasedEnergy: false };
+  });
+
+  connectTowers(scene, towers, sources, conduitMaterial);
+  towers.forEach(tower => {
+    if (!tower.supported && tower.tier > 1) tower.mesh.material = invalidMaterial;
+  });
+
+  const ventLight = new PointLight("geothermal-vent-light", sources[1].position, scene);
+  ventLight.diffuse = new Color3(0.08, 0.92, 0.88);
+  ventLight.intensity = 0.35;
+  ventLight.range = 44;
+
+  let globalFiring = true;
+  let acceleratedPressure = false;
+  let boostedLayers = false;
+  let relocationIndex = 0;
+  let collectedFromEruptions = 0;
+  let eruptionParticles: EruptionParticle[] = [];
+  let collectedDroplets: CollectedDroplet[] = [];
+  let eruptionSourceId: number | null = null;
+
+  let inspectable: { dispose(): void } | undefined;
+  if (new URLSearchParams(location.search).has("inspect")) {
+    const { StartInspectable } = await import("@babylonjs/inspector");
+    inspectable = StartInspectable(scene);
+  }
+
+  const updateButtons = () => {
+    fireButton.textContent = globalFiring ? "Stop tower draw [F]" : "Resume tower draw [F]";
+    pressureButton.textContent = acceleratedPressure ? "Normal pressure [P]" : "Accelerate pressure [P]";
+    layersButton.textContent = boostedLayers ? "Dim internal layers [L]" : "Boost internal layers [L]";
+  };
+
+  const startEruption = (source: GeothermalSource) => {
+    if (eruptionSourceId !== null) return;
+    source.phase = "erupting";
+    source.eruptionSeconds = 0;
+    source.pressure = 1;
+    eruptionSourceId = source.id;
+    eruptionParticles = createEruptionParticles(scene, source, tealMaterial);
+
+    for (const tower of towers) {
+      if (horizontalDistance(tower.mesh.position, source.position) < 25 && !tower.melted) {
+        tower.melted = true;
+        tower.firing = false;
+      }
+    }
+
+    for (const raider of raiders) {
+      const distance = horizontalDistance(raider.mesh.position, source.position);
+      if (distance < 31) {
+        const outward = raider.mesh.position.subtract(source.position);
+        outward.y = 0;
+        if (outward.lengthSquared() < 0.001) outward.set(1, 0, 0);
+        outward.normalize();
+        raider.velocity.addInPlace(outward.scale(10 + (31 - distance) * 0.35));
+        raider.velocity.y += 9;
+        if (!raider.releasedEnergy) {
+          raider.releasedEnergy = true;
+          collectedDroplets.push(
+            spawnCollectedDroplet(scene, raider.mesh.position, tealMaterial, collectedDroplets.length),
+          );
+        }
+      }
+    }
+  };
+
+  const reset = () => {
+    globalFiring = true;
+    acceleratedPressure = false;
+    boostedLayers = false;
+    relocationIndex = 0;
+    collectedFromEruptions = 0;
+    eruptionSourceId = null;
+    eruptionParticles.forEach(particle => particle.mesh.dispose());
+    collectedDroplets.forEach(droplet => droplet.mesh.dispose());
+    eruptionParticles = [];
+    collectedDroplets = [];
+
+    const resetPoints = [new Vector3(-36, 0, -18), new Vector3(3, 0, 34), new Vector3(39, 0, -20)];
+    sources.forEach((source, index) => {
+      source.position.copyFrom(surfacePoint(resetPoints[index].x, resetPoints[index].z, -0.8));
+      source.vent.position.copyFrom(source.position);
+      source.vent.setEnabled(true);
+      source.bulge.position.copyFrom(surfacePoint(resetPoints[index].x, resetPoints[index].z, -4));
+      source.bulge.scaling.set(1, 0.08, 1);
+      source.energy = 0.72 + index * 0.09;
+      source.pressure = 0.25 + index * 0.1;
+      source.drawRate = 0;
+      source.depletedSeconds = 0;
+      source.retreatSeconds = 0;
+      source.eruptionSeconds = 0;
+      source.phase = "active";
+    });
+
+    towers.forEach(tower => {
+      tower.firing = tower.tier > 1;
+      tower.melted = false;
+      tower.mesh.scaling.set(1, 1, 1);
+      tower.mesh.rotation.set(0, 0, 0);
+      tower.mesh.material = refs.defenderMaterial;
+    });
+    raiders.forEach((raider, index) => {
+      const diameter = [6, 9, 14][index];
+      raider.mesh.position.copyFrom(surfacePoint(-46 + index * 34, 12 + index * 9, diameter / 2 + 0.4));
+      raider.velocity.set(0, 0, 0);
+      raider.releasedEnergy = false;
+    });
+
+    planet.crustMaterial.alpha = 0.2;
+    planet.mantleMaterial.alpha = 0.12;
+    planet.coreMaterial.alpha = 0.22;
+    connectTowers(scene, towers, sources, conduitMaterial);
+    towers.forEach(tower => {
+      if (!tower.supported && tower.tier > 1) tower.mesh.material = invalidMaterial;
+    });
+    updateButtons();
+  };
+
+  const toggleFire = () => {
+    globalFiring = !globalFiring;
+    updateButtons();
+  };
+  const togglePressure = () => {
+    acceleratedPressure = !acceleratedPressure;
+    updateButtons();
+  };
+  const toggleLayers = () => {
+    boostedLayers = !boostedLayers;
+    planet.crustMaterial.alpha = boostedLayers ? 0.32 : 0.2;
+    planet.mantleMaterial.alpha = boostedLayers ? 0.28 : 0.12;
+    planet.coreMaterial.alpha = boostedLayers ? 0.42 : 0.22;
+    updateButtons();
+  };
+  const forceEruption = () => {
+    const candidate = sources.reduce((best, source) =>
+      source.pressure > best.pressure ? source : best,
+    );
+    startEruption(candidate);
+  };
+
+  resetButton.addEventListener("click", reset);
+  fireButton.addEventListener("click", toggleFire);
+  pressureButton.addEventListener("click", togglePressure);
+  eruptionButton.addEventListener("click", forceEruption);
+  layersButton.addEventListener("click", toggleLayers);
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    const key = event.key.toLowerCase();
+    if (key === "r") reset();
+    if (key === "f") toggleFire();
+    if (key === "p") togglePressure();
+    if (key === "e") forceEruption();
+    if (key === "l") toggleLayers();
+  };
+  window.addEventListener("keydown", onKeyDown);
+
+  let frame = 0;
+  engine.runRenderLoop(() => {
+    const deltaSeconds = Math.min(MAX_FRAME_DELTA_SECONDS, engine.getDeltaTime() / 1000);
+
+    sources.forEach(source => {
+      source.drawRate = 0;
+    });
+
+    towers.forEach(tower => {
+      if (tower.melted) {
+        tower.mesh.scaling.y += (0.22 - tower.mesh.scaling.y) * Math.min(1, deltaSeconds * 0.75);
+        tower.mesh.rotation.z += deltaSeconds * 0.09;
+        return;
+      }
+      if (!globalFiring || !tower.firing || !tower.supported || tower.sourceId === null) return;
+      const source = sources.find(candidate => candidate.id === tower.sourceId);
+      if (!source || source.phase !== "active" || source.energy <= 0) return;
+      const requested = towerDrawRate(tower.tier) * deltaSeconds;
+      const actual = Math.min(source.energy, requested);
+      source.energy -= actual;
+      source.drawRate += actual / Math.max(deltaSeconds, 0.0001);
+      tower.shotPulse += deltaSeconds * (tower.tier === 3 ? 2.2 : 4.8);
+      if (tower.conduit) {
+        const pulse = 0.72 + Math.sin(tower.shotPulse * Math.PI * 2) * 0.2;
+        tower.conduit.visibility = pulse;
+        tower.conduit.scaling.y = 0.92 + source.energy * 0.12;
+      }
+    });
+
+    sources.forEach(source => {
+      if (source.phase === "active") {
+        source.energy = Math.min(1, source.energy + DEEP_REPLENISH_PER_SECOND * deltaSeconds);
+        if (source.energy < DEPLETED_THRESHOLD) source.depletedSeconds += deltaSeconds;
+        else source.depletedSeconds = Math.max(0, source.depletedSeconds - deltaSeconds * 0.5);
+
+        const quietRich = source.energy > 0.78 && source.drawRate < 0.003;
+        if (quietRich) {
+          const multiplier = acceleratedPressure ? 7 : 1;
+          source.pressure = Math.min(
+            1,
+            source.pressure + PRESSURE_BUILD_PER_SECOND * multiplier * deltaSeconds,
+          );
+        } else if (source.drawRate > 0.008) {
+          source.pressure = Math.max(0.08, source.pressure - source.drawRate * 0.3 * deltaSeconds);
+        }
+
+        if (source.depletedSeconds >= DEPLETION_RETREAT_SECONDS) {
+          source.phase = "retreating";
+          source.retreatSeconds = 0;
+          source.vent.setEnabled(true);
+          connectTowers(scene, towers, sources, conduitMaterial);
+        }
+        if (source.pressure >= PRESSURE_ERUPTION_THRESHOLD && eruptionSourceId === null) {
+          startEruption(source);
+        }
+      } else if (source.phase === "retreating") {
+        source.retreatSeconds += deltaSeconds;
+        source.vent.scaling.x = Math.max(0.05, 1 - source.retreatSeconds / RETREAT_SECONDS);
+        source.vent.scaling.z = source.vent.scaling.x;
+        source.vent.position.y -= deltaSeconds * 1.6;
+        if (source.retreatSeconds >= RETREAT_SECONDS) {
+          relocationIndex += 1;
+          source.vent.scaling.set(1, 0.35, 1);
+          relocateSource(source, relocationIndex);
+          connectTowers(scene, towers, sources, conduitMaterial);
+          towers.forEach(tower => {
+            tower.mesh.material = !tower.supported && tower.tier > 1 ? invalidMaterial : refs.defenderMaterial;
+          });
+        }
+      } else if (source.phase === "erupting") {
+        source.eruptionSeconds += deltaSeconds;
+        source.energy = Math.max(0.08, source.energy - 0.055 * deltaSeconds);
+        source.pressure = Math.max(0.08, source.pressure - 0.16 * deltaSeconds);
+        source.bulge.position.y += deltaSeconds * (source.eruptionSeconds < 1.4 ? 1.2 : -0.18);
+        source.bulge.scaling.y = Math.min(0.8, 0.15 + source.eruptionSeconds * 0.12);
+        if (source.eruptionSeconds >= ERUPTION_SECONDS) {
+          source.phase = "retreating";
+          source.retreatSeconds = 0;
+          source.depletedSeconds = DEPLETION_RETREAT_SECONDS;
+          source.bulge.scaling.set(1, 0.12, 1);
+          eruptionSourceId = null;
+          connectTowers(scene, towers, sources, conduitMaterial);
+        }
+      }
+
+      const visibleEnergy = Math.max(0.12, source.energy);
+      source.vent.scaling.x = source.phase === "retreating" ? source.vent.scaling.x : 0.55 + visibleEnergy * 0.65;
+      source.vent.scaling.z = source.vent.scaling.x;
+      source.vent.scaling.y = source.phase === "erupting" ? 0.65 + source.pressure * 0.8 : 0.22 + source.pressure * 0.35;
+      const bulgePressure = Math.max(0, source.pressure - 0.58);
+      if (source.phase === "active") {
+        source.bulge.scaling.y = 0.08 + bulgePressure * 0.42;
+        source.bulge.position.y = surfaceY(source.position.x, source.position.z, -4 + bulgePressure * 2.2);
+      }
+    });
+
+    for (let index = eruptionParticles.length - 1; index >= 0; index -= 1) {
+      const particle = eruptionParticles[index];
+      particle.age += deltaSeconds;
+      particle.velocity.y -= 8.5 * deltaSeconds;
+      particle.mesh.position.addInPlace(particle.velocity.scale(deltaSeconds));
+      const floor = surfaceY(particle.mesh.position.x, particle.mesh.position.z, 0.25);
+      if (particle.mesh.position.y <= floor || particle.age > 4.2) {
+        particle.mesh.dispose();
+        eruptionParticles.splice(index, 1);
+      }
+    }
+
+    raiders.forEach(raider => {
+      if (raider.velocity.lengthSquared() < 0.001) return;
+      raider.velocity.y -= 7.5 * deltaSeconds;
+      raider.mesh.position.addInPlace(raider.velocity.scale(deltaSeconds));
+      const radius = raider.mesh.getBoundingInfo().boundingSphere.radiusWorld;
+      const floor = surfaceY(raider.mesh.position.x, raider.mesh.position.z, radius + 0.2);
+      if (raider.mesh.position.y < floor) {
+        raider.mesh.position.y = floor;
+        raider.velocity.y *= -0.3;
+        raider.velocity.x *= 0.92;
+        raider.velocity.z *= 0.92;
+      }
+    });
+
+    const siloTarget = refs.silo.position.add(new Vector3(0, 2.5, 0));
+    for (let index = collectedDroplets.length - 1; index >= 0; index -= 1) {
+      const droplet = collectedDroplets[index];
+      droplet.age += deltaSeconds;
+      const toSilo = siloTarget.subtract(droplet.mesh.position);
+      const horizontal = new Vector3(toSilo.x, 0, toSilo.z);
+      if (horizontal.length() < 3) {
+        collectedFromEruptions += droplet.value;
+        droplet.mesh.dispose();
+        collectedDroplets.splice(index, 1);
+        continue;
+      }
+      horizontal.normalize();
+      const speed = 8 + Math.min(8, toSilo.length() * 0.08);
+      droplet.mesh.position.x += horizontal.x * speed * deltaSeconds;
+      droplet.mesh.position.z += horizontal.z * speed * deltaSeconds;
+      droplet.mesh.position.y = surfaceY(droplet.mesh.position.x, droplet.mesh.position.z, 0.55);
+    }
+
+    const highlighted = eruptionSourceId === null ? sources[1] : sources.find(source => source.id === eruptionSourceId) ?? sources[1];
+    ventLight.position.copyFrom(highlighted.position.add(new Vector3(0, 3, 0)));
+    ventLight.intensity = 0.18 + highlighted.pressure * 0.8;
+
+    scene.render();
+    frame += 1;
+    if (frame % 10 === 0) {
+      const sourceLines = sources.map(
+        source =>
+          `S${source.id + 1} ${source.phase.padEnd(10)} energy ${(source.energy * 100).toFixed(0).padStart(3)}% pressure ${(source.pressure * 100).toFixed(0).padStart(3)}% draw ${source.drawRate.toFixed(3)}`,
+      );
+      const supported = towers.filter(tower => tower.tier === 1 || tower.supported).length;
+      const firing = towers.filter(tower => tower.tier > 1 && tower.supported && !tower.melted && globalFiring).length;
+      metrics.textContent = [
+        "Planetary geothermal / tower-power PoC",
+        ...sourceLines,
+        `supported towers: ${supported}/${towers.length}`,
+        `active firing towers: ${firing}`,
+        `max conduit length: ${MAX_CONDUIT_LENGTH}`,
+        `eruption particles: ${eruptionParticles.length}`,
+        `liberated raider droplets in transit: ${collectedDroplets.length}`,
+        `eruption-liberated energy collected: ${collectedFromEruptions.toFixed(0)} lab units`,
+        `internal layers: ${boostedLayers ? "boosted" : "subtle"}`,
+        `fps: ${engine.getFps().toFixed(1)}`,
+        `meshes: ${scene.meshes.length}`,
+        "all rates/thresholds are lab values",
+        "?inspect=1 enables Babylon Inspector",
+      ].join("\n");
+    }
+  });
+
+  const resize = () => engine.resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("keydown", onKeyDown);
+      inspectable?.dispose();
+      engine.stopRenderLoop();
+      scene.dispose();
+      engine.dispose();
+    },
+    { once: true },
+  );
+
+  (window as unknown as { __defendGeothermalPrototype?: unknown }).__defendGeothermalPrototype = {
+    sources,
+    towers,
+    raiders,
+    forceEruption,
+  };
+}
+
+void main();

--- a/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
@@ -1,0 +1,655 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Engine,
+  HemisphericLight,
+  Mesh,
+  MeshBuilder,
+  PointLight,
+  Scene,
+  StandardMaterial,
+  TransformNode,
+  Vector3,
+} from "@babylonjs/core/pure";
+
+type CameraMode = "raider" | "defender";
+type NavigationPhase = "stable" | "warning" | "critical" | "captured";
+
+const START_POSITION = new Vector3(48, 46, 30);
+const START_RESERVE = 1;
+const HOVER_DRAIN_PER_SECOND = 0.0025;
+const MOVEMENT_DRAIN_PER_ACCEL = 0.00028;
+const MAX_ACCELERATION = 7.2;
+const MAX_SPEED = 22;
+const LINEAR_DAMPING = 0.42;
+const ARRIVAL_RADIUS = 4;
+const SURFACE_HALF_EXTENT = 86;
+const SILO_WARNING_RADIUS = 31;
+const SILO_CRITICAL_RADIUS = 17;
+const SAFE_TARGET_RADIUS = 35;
+const TARGET_LAUNCH_OFFSET = 24;
+const ATTRACTION_STRENGTH = 19;
+const CAPTURE_PULL_STRENGTH = 34;
+const MAX_FRAME_DELTA_SECONDS = 0.05;
+
+interface NavigationState {
+  reserve: number;
+  velocity: Vector3;
+  desiredPosition: Vector3;
+  raidSector: Vector3;
+  cameraAnchor: Vector3;
+  cameraMode: CameraMode;
+  phase: NavigationPhase;
+  projectedTargetCount: number;
+  totalMovementEnergy: number;
+  elapsedSeconds: number;
+}
+
+function createMaterial(
+  name: string,
+  scene: Scene,
+  diffuse: Color3,
+  emissive: Color3,
+  alpha = 1,
+): StandardMaterial {
+  const material = new StandardMaterial(name, scene);
+  material.diffuseColor = diffuse;
+  material.emissiveColor = emissive;
+  material.specularColor = new Color3(0.08, 0.08, 0.1);
+  material.alpha = alpha;
+  return material;
+}
+
+function horizontalDistance(position: Vector3): number {
+  return Math.sqrt(position.x * position.x + position.z * position.z);
+}
+
+function horizontalDirection(position: Vector3, fallback: Vector3): Vector3 {
+  const direction = new Vector3(position.x, 0, position.z);
+  if (direction.lengthSquared() < 0.0001) {
+    direction.copyFrom(fallback);
+    direction.y = 0;
+  }
+  if (direction.lengthSquared() < 0.0001) {
+    direction.set(1, 0, 0);
+  }
+  return direction.normalize();
+}
+
+function clampSurfacePoint(point: Vector3): Vector3 {
+  return new Vector3(
+    Math.max(-SURFACE_HALF_EXTENT, Math.min(SURFACE_HALF_EXTENT, point.x)),
+    0.16,
+    Math.max(-SURFACE_HALF_EXTENT, Math.min(SURFACE_HALF_EXTENT, point.z)),
+  );
+}
+
+function desiredShipPositionForSector(
+  sector: Vector3,
+  currentPosition: Vector3,
+): { desired: Vector3; projected: boolean } {
+  const outward = horizontalDirection(sector, currentPosition);
+  const desired = new Vector3(
+    sector.x + outward.x * TARGET_LAUNCH_OFFSET,
+    START_POSITION.y,
+    sector.z + outward.z * TARGET_LAUNCH_OFFSET,
+  );
+
+  const distance = horizontalDistance(desired);
+  if (distance >= SAFE_TARGET_RADIUS) {
+    return { desired, projected: false };
+  }
+
+  desired.x = outward.x * SAFE_TARGET_RADIUS;
+  desired.z = outward.z * SAFE_TARGET_RADIUS;
+  return { desired, projected: true };
+}
+
+function phaseForPosition(position: Vector3): NavigationPhase {
+  const distance = horizontalDistance(position);
+  if (distance <= SILO_CRITICAL_RADIUS) return "critical";
+  if (distance <= SILO_WARNING_RADIUS) return "warning";
+  return "stable";
+}
+
+function createArena(scene: Scene) {
+  const groundMaterial = createMaterial(
+    "navigation-ground",
+    scene,
+    new Color3(0.028, 0.019, 0.038),
+    new Color3(0.008, 0.005, 0.014),
+  );
+  const ground = MeshBuilder.CreateGround(
+    "navigation-ground",
+    { width: 180, height: 180, subdivisions: 1 },
+    scene,
+  );
+  ground.material = groundMaterial;
+
+  const towerMaterial = createMaterial(
+    "navigation-defender",
+    scene,
+    new Color3(0.08, 0.31, 0.17),
+    new Color3(0.012, 0.06, 0.025),
+  );
+  const tealMaterial = createMaterial(
+    "navigation-silo-core",
+    scene,
+    new Color3(0.05, 0.54, 0.55),
+    new Color3(0.025, 0.36, 0.37),
+    0.9,
+  );
+  const warningMaterial = createMaterial(
+    "navigation-warning",
+    scene,
+    new Color3(0.48, 0.26, 0.08),
+    new Color3(0.16, 0.065, 0.01),
+    0.45,
+  );
+  const criticalMaterial = createMaterial(
+    "navigation-critical",
+    scene,
+    new Color3(0.55, 0.08, 0.2),
+    new Color3(0.24, 0.015, 0.05),
+    0.5,
+  );
+
+  const silo = MeshBuilder.CreateBox(
+    "navigation-silo",
+    { width: 24, height: 4, depth: 24 },
+    scene,
+  );
+  silo.position.y = 2;
+  silo.material = towerMaterial;
+
+  const siloCore = MeshBuilder.CreateBox(
+    "navigation-silo-core",
+    { width: 17, height: 1.1, depth: 17 },
+    scene,
+  );
+  siloCore.position.y = 4.6;
+  siloCore.material = tealMaterial;
+
+  const warningRing = MeshBuilder.CreateTorus(
+    "silo-warning-ring",
+    { diameter: SILO_WARNING_RADIUS * 2, thickness: 0.45, tessellation: 48 },
+    scene,
+  );
+  warningRing.rotation.x = Math.PI / 2;
+  warningRing.position.y = 0.28;
+  warningRing.material = warningMaterial;
+  warningRing.isPickable = false;
+
+  const criticalRing = MeshBuilder.CreateTorus(
+    "silo-critical-ring",
+    { diameter: SILO_CRITICAL_RADIUS * 2, thickness: 0.7, tessellation: 40 },
+    scene,
+  );
+  criticalRing.rotation.x = Math.PI / 2;
+  criticalRing.position.y = 0.32;
+  criticalRing.material = criticalMaterial;
+  criticalRing.isPickable = false;
+
+  const barrierPositions = [
+    new Vector3(-30, 2, -24),
+    new Vector3(28, 2, -25),
+    new Vector3(-28, 2, 26),
+    new Vector3(31, 2, 25),
+    new Vector3(-52, 2, 8),
+    new Vector3(52, 2, -5),
+  ];
+  barrierPositions.forEach((position, index) => {
+    const barrier = MeshBuilder.CreateBox(
+      `navigation-barrier-${index}`,
+      { width: 10, height: 4, depth: 10 },
+      scene,
+    );
+    barrier.position.copyFrom(position);
+    barrier.material = towerMaterial;
+  });
+
+  return { ground, siloCore, warningRing, criticalRing };
+}
+
+function createMothership(scene: Scene) {
+  const root = new TransformNode("navigation-mothership-root", scene);
+  root.position.copyFrom(START_POSITION);
+
+  const shellMaterial = createMaterial(
+    "navigation-mothership-shell",
+    scene,
+    new Color3(0.23, 0.055, 0.35),
+    new Color3(0.075, 0.012, 0.105),
+    0.92,
+  );
+  shellMaterial.wireframe = true;
+  const structureMaterial = createMaterial(
+    "navigation-mothership-structure",
+    scene,
+    new Color3(0.15, 0.035, 0.24),
+    new Color3(0.035, 0.006, 0.055),
+    0.96,
+  );
+  const coreMaterial = createMaterial(
+    "navigation-mothership-core",
+    scene,
+    new Color3(0.04, 0.58, 0.58),
+    new Color3(0.02, 0.52, 0.54),
+    0.93,
+  );
+
+  const shell = MeshBuilder.CreateSphere(
+    "navigation-mothership-shell",
+    { diameter: 32, segments: 8 },
+    scene,
+  );
+  shell.parent = root;
+  shell.material = shellMaterial;
+  shell.isPickable = false;
+
+  const core = MeshBuilder.CreateSphere(
+    "navigation-mothership-core",
+    { diameter: 12, segments: 10 },
+    scene,
+  );
+  core.parent = root;
+  core.material = coreMaterial;
+  core.isPickable = false;
+
+  for (const axis of ["equator", "x", "z"] as const) {
+    const ring = MeshBuilder.CreateTorus(
+      `navigation-ring-${axis}`,
+      { diameter: 29, thickness: 0.9, tessellation: 18 },
+      scene,
+    );
+    ring.parent = root;
+    if (axis === "x") ring.rotation.x = Math.PI / 2;
+    if (axis === "z") ring.rotation.z = Math.PI / 2;
+    ring.material = structureMaterial;
+    ring.isPickable = false;
+  }
+
+  const strutX = MeshBuilder.CreateBox(
+    "navigation-strut-x",
+    { width: 25, height: 0.75, depth: 0.75 },
+    scene,
+  );
+  strutX.parent = root;
+  strutX.material = structureMaterial;
+  const strutZ = MeshBuilder.CreateBox(
+    "navigation-strut-z",
+    { width: 0.75, height: 0.75, depth: 25 },
+    scene,
+  );
+  strutZ.parent = root;
+  strutZ.material = structureMaterial;
+
+  return { root, core, coreMaterial, shellMaterial };
+}
+
+function createMarker(
+  name: string,
+  scene: Scene,
+  material: StandardMaterial,
+  diameter: number,
+): Mesh {
+  const marker = MeshBuilder.CreateTorus(
+    name,
+    { diameter, thickness: 0.55, tessellation: 28 },
+    scene,
+  );
+  marker.rotation.x = Math.PI / 2;
+  marker.position.y = 0.3;
+  marker.material = material;
+  marker.isPickable = false;
+  return marker;
+}
+
+function resetState(state: NavigationState, root: TransformNode): void {
+  state.reserve = START_RESERVE;
+  state.velocity.set(0, 0, 0);
+  state.raidSector.set(52, 0.16, 42);
+  const initialTarget = desiredShipPositionForSector(state.raidSector, START_POSITION);
+  state.desiredPosition.copyFrom(initialTarget.desired);
+  state.cameraAnchor.copyFrom(START_POSITION);
+  state.phase = "stable";
+  state.projectedTargetCount = 0;
+  state.totalMovementEnergy = 0;
+  state.elapsedSeconds = 0;
+  root.position.copyFrom(START_POSITION);
+  root.rotation.set(0, 0, 0);
+}
+
+function setTargetSector(
+  state: NavigationState,
+  root: TransformNode,
+  marker: Mesh,
+  desiredMarker: Mesh,
+  point: Vector3,
+): void {
+  state.raidSector.copyFrom(clampSurfacePoint(point));
+  marker.position.x = state.raidSector.x;
+  marker.position.z = state.raidSector.z;
+
+  const target = desiredShipPositionForSector(state.raidSector, root.position);
+  state.desiredPosition.copyFrom(target.desired);
+  if (target.projected) state.projectedTargetCount += 1;
+  desiredMarker.position.set(
+    state.desiredPosition.x,
+    0.34,
+    state.desiredPosition.z,
+  );
+}
+
+function siloAttraction(position: Vector3, phase: NavigationPhase): Vector3 {
+  const distance = horizontalDistance(position);
+  if (distance >= SILO_WARNING_RADIUS || distance < 0.001) return Vector3.Zero();
+
+  const inward = new Vector3(-position.x, 0, -position.z).normalize();
+  const normalized = 1 - distance / SILO_WARNING_RADIUS;
+  const strength =
+    phase === "critical"
+      ? CAPTURE_PULL_STRENGTH * (0.45 + normalized * normalized)
+      : ATTRACTION_STRENGTH * normalized * normalized;
+  return inward.scale(strength);
+}
+
+function movementAcceleration(
+  position: Vector3,
+  velocity: Vector3,
+  desired: Vector3,
+): Vector3 {
+  const error = desired.subtract(position);
+  error.y = 0;
+  const distance = error.length();
+  if (distance < ARRIVAL_RADIUS) {
+    return velocity.scale(-1.2);
+  }
+
+  const desiredDirection = error.normalize();
+  const desiredSpeed = Math.min(MAX_SPEED, Math.max(4, distance * 0.38));
+  const desiredVelocity = desiredDirection.scale(desiredSpeed);
+  const correction = desiredVelocity.subtract(new Vector3(velocity.x, 0, velocity.z));
+  if (correction.length() > MAX_ACCELERATION) correction.normalize().scaleInPlace(MAX_ACCELERATION);
+  return correction;
+}
+
+function updateCamera(
+  camera: ArcRotateCamera,
+  state: NavigationState,
+  root: TransformNode,
+  deltaSeconds: number,
+): void {
+  if (state.cameraMode === "raider") {
+    const followTarget = root.position.add(new Vector3(0, -5, 0));
+    const smoothing = 1 - Math.exp(-deltaSeconds * 4.2);
+    state.cameraAnchor.copyFrom(Vector3.Lerp(state.cameraAnchor, followTarget, smoothing));
+    camera.setTarget(state.cameraAnchor);
+    camera.radius += (64 - camera.radius) * Math.min(1, deltaSeconds * 2.2);
+    camera.beta += (0.93 - camera.beta) * Math.min(1, deltaSeconds * 1.4);
+  } else {
+    camera.setTarget(new Vector3(0, 24, 0));
+  }
+}
+
+async function main(): Promise<void> {
+  const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas");
+  const metrics = document.querySelector<HTMLElement>("#metrics");
+  const resetButton = document.querySelector<HTMLButtonElement>("#reset");
+  const nearButton = document.querySelector<HTMLButtonElement>("#near");
+  const farButton = document.querySelector<HTMLButtonElement>("#far");
+  const cameraButton = document.querySelector<HTMLButtonElement>("#camera");
+  if (!canvas || !metrics || !resetButton || !nearButton || !farButton || !cameraButton) {
+    throw new Error("Navigation lab DOM is incomplete");
+  }
+
+  const engine = new Engine(canvas, true, { adaptToDeviceRatio: true, antialias: true });
+  const scene = new Scene(engine);
+  scene.clearColor.set(0.02, 0.012, 0.034, 1);
+
+  const camera = new ArcRotateCamera(
+    "navigation-camera",
+    -Math.PI / 2.1,
+    0.93,
+    64,
+    START_POSITION,
+    scene,
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 42;
+  camera.upperRadiusLimit = 170;
+  camera.lowerBetaLimit = 0.35;
+  camera.upperBetaLimit = 2.2;
+
+  const ambient = new HemisphericLight("navigation-ambient", new Vector3(0.15, 1, 0.2), scene);
+  ambient.intensity = 0.74;
+
+  const arena = createArena(scene);
+  const mothership = createMothership(scene);
+  const coreLight = new PointLight("navigation-core-light", START_POSITION, scene);
+  coreLight.diffuse = new Color3(0.1, 0.92, 0.88);
+  coreLight.intensity = 0.7;
+  coreLight.range = 62;
+
+  const raidMarkerMaterial = createMaterial(
+    "raid-sector-marker",
+    scene,
+    new Color3(0.06, 0.56, 0.58),
+    new Color3(0.02, 0.28, 0.3),
+    0.86,
+  );
+  const desiredMarkerMaterial = createMaterial(
+    "ship-target-marker",
+    scene,
+    new Color3(0.68, 0.35, 0.09),
+    new Color3(0.18, 0.07, 0.01),
+    0.7,
+  );
+  const raidMarker = createMarker("raid-sector-marker", scene, raidMarkerMaterial, 7);
+  const desiredMarker = createMarker("ship-target-marker", scene, desiredMarkerMaterial, 5);
+
+  const state: NavigationState = {
+    reserve: START_RESERVE,
+    velocity: Vector3.Zero(),
+    desiredPosition: START_POSITION.clone(),
+    raidSector: new Vector3(52, 0.16, 42),
+    cameraAnchor: START_POSITION.clone(),
+    cameraMode: "raider",
+    phase: "stable",
+    projectedTargetCount: 0,
+    totalMovementEnergy: 0,
+    elapsedSeconds: 0,
+  };
+  resetState(state, mothership.root);
+  setTargetSector(state, mothership.root, raidMarker, desiredMarker, state.raidSector);
+
+  let inspectable: { dispose(): void } | undefined;
+  if (new URLSearchParams(location.search).has("inspect")) {
+    const { StartInspectable } = await import("@babylonjs/inspector");
+    inspectable = StartInspectable(scene);
+  }
+
+  const updateCameraButton = () => {
+    cameraButton.textContent = state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
+  };
+
+  const doReset = () => {
+    resetState(state, mothership.root);
+    setTargetSector(state, mothership.root, raidMarker, desiredMarker, state.raidSector);
+    camera.alpha = -Math.PI / 2.1;
+    camera.beta = 0.93;
+    camera.radius = 64;
+    updateCameraButton();
+  };
+
+  const setNearTarget = () => {
+    setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(4, 0, 3));
+  };
+  const setFarTarget = () => {
+    setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(-66, 0, 46));
+  };
+  const toggleCamera = () => {
+    state.cameraMode = state.cameraMode === "raider" ? "defender" : "raider";
+    if (state.cameraMode === "defender") {
+      camera.alpha = -Math.PI / 3.4;
+      camera.beta = 1.34;
+      camera.radius = 138;
+    } else {
+      camera.alpha = -Math.PI / 2.1;
+      camera.beta = 0.93;
+      camera.radius = 64;
+    }
+    updateCameraButton();
+  };
+
+  resetButton.addEventListener("click", doReset);
+  nearButton.addEventListener("click", setNearTarget);
+  farButton.addEventListener("click", setFarTarget);
+  cameraButton.addEventListener("click", toggleCamera);
+
+  scene.onPointerDown = (_event, pickInfo) => {
+    if (pickInfo.hit && pickInfo.pickedPoint && pickInfo.pickedMesh === arena.ground) {
+      setTargetSector(state, mothership.root, raidMarker, desiredMarker, pickInfo.pickedPoint);
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key.toLowerCase() === "r") doReset();
+    if (event.key === "1") setNearTarget();
+    if (event.key === "2") setFarTarget();
+    if (event.key.toLowerCase() === "c") toggleCamera();
+  };
+  window.addEventListener("keydown", onKeyDown);
+
+  let frame = 0;
+  engine.runRenderLoop(() => {
+    const deltaSeconds = Math.min(MAX_FRAME_DELTA_SECONDS, engine.getDeltaTime() / 1000);
+    state.elapsedSeconds += deltaSeconds;
+
+    if (state.phase !== "captured") {
+      state.phase = phaseForPosition(mothership.root.position);
+    }
+
+    const steering = movementAcceleration(
+      mothership.root.position,
+      state.velocity,
+      state.desiredPosition,
+    );
+    const attraction = siloAttraction(mothership.root.position, state.phase);
+    const acceleration = steering.add(attraction);
+
+    if (state.phase === "critical") {
+      const inwardSpeed = -Vector3.Dot(
+        new Vector3(state.velocity.x, 0, state.velocity.z),
+        horizontalDirection(mothership.root.position, new Vector3(1, 0, 0)),
+      );
+      if (horizontalDistance(mothership.root.position) < SILO_CRITICAL_RADIUS * 0.55 && inwardSpeed > 3) {
+        state.phase = "captured";
+      }
+    }
+
+    if (state.phase === "captured") {
+      const inward = new Vector3(-mothership.root.position.x, -10, -mothership.root.position.z);
+      if (inward.lengthSquared() > 0.001) {
+        inward.normalize().scaleInPlace(CAPTURE_PULL_STRENGTH * 1.35);
+        acceleration.copyFrom(inward);
+      }
+    }
+
+    state.velocity.addInPlace(acceleration.scale(deltaSeconds));
+    const damping = Math.exp(-LINEAR_DAMPING * deltaSeconds);
+    state.velocity.x *= damping;
+    state.velocity.z *= damping;
+    state.velocity.y = state.phase === "captured" ? state.velocity.y - 8 * deltaSeconds : 0;
+
+    const horizontalSpeed = Math.sqrt(
+      state.velocity.x * state.velocity.x + state.velocity.z * state.velocity.z,
+    );
+    if (horizontalSpeed > MAX_SPEED * 1.35) {
+      const scale = (MAX_SPEED * 1.35) / horizontalSpeed;
+      state.velocity.x *= scale;
+      state.velocity.z *= scale;
+    }
+
+    mothership.root.position.addInPlace(state.velocity.scale(deltaSeconds));
+    if (state.phase !== "captured") mothership.root.position.y = START_POSITION.y;
+    else mothership.root.position.y = Math.max(15, mothership.root.position.y);
+
+    const movementDrain = acceleration.length() * MOVEMENT_DRAIN_PER_ACCEL * deltaSeconds;
+    state.totalMovementEnergy += movementDrain;
+    state.reserve = Math.max(0, state.reserve - HOVER_DRAIN_PER_SECOND * deltaSeconds - movementDrain);
+
+    const reserveScale = Math.max(0.3, Math.sqrt(state.reserve));
+    mothership.core.scaling.set(reserveScale, reserveScale, reserveScale);
+    mothership.coreMaterial.emissiveColor.set(
+      0.02 * reserveScale,
+      0.52 * reserveScale,
+      0.54 * reserveScale,
+    );
+    coreLight.position.copyFrom(mothership.root.position);
+    coreLight.intensity = 0.2 + state.reserve * 0.62;
+
+    const speed = state.velocity.length();
+    const targetHeading = speed > 0.3 ? Math.atan2(state.velocity.x, state.velocity.z) : mothership.root.rotation.y;
+    mothership.root.rotation.y += (targetHeading - mothership.root.rotation.y) * Math.min(1, deltaSeconds * 1.8);
+    const stress = state.phase === "warning" ? 0.025 : state.phase === "critical" ? 0.06 : state.phase === "captured" ? 0.12 : 0.008;
+    mothership.root.rotation.z = Math.sin(state.elapsedSeconds * 1.8) * stress + state.velocity.x * -0.003;
+    mothership.root.rotation.x = Math.cos(state.elapsedSeconds * 1.4) * stress + state.velocity.z * 0.002;
+
+    const distanceToSilo = horizontalDistance(mothership.root.position);
+    arena.warningRing.scaling.setAll(1 + Math.sin(state.elapsedSeconds * 2.2) * 0.01);
+    arena.criticalRing.scaling.setAll(1 + Math.sin(state.elapsedSeconds * 3.3) * 0.025);
+    arena.siloCore.scaling.y = 1 + Math.max(0, 1 - distanceToSilo / SILO_WARNING_RADIUS) * 0.45;
+
+    updateCamera(camera, state, mothership.root, deltaSeconds);
+    scene.render();
+
+    frame += 1;
+    if (frame % 8 === 0) {
+      const desiredDistance = Vector3.Distance(
+        new Vector3(mothership.root.position.x, 0, mothership.root.position.z),
+        new Vector3(state.desiredPosition.x, 0, state.desiredPosition.z),
+      );
+      metrics.textContent = [
+        "Mothership navigation / silo-attraction PoC",
+        `phase: ${state.phase}`,
+        `reserve: ${(state.reserve * 100).toFixed(1)}%`,
+        `position: ${mothership.root.position.x.toFixed(1)}, ${mothership.root.position.z.toFixed(1)}`,
+        `speed: ${speed.toFixed(2)} u/s`,
+        `distance to silo: ${distanceToSilo.toFixed(1)}`,
+        `desired distance: ${desiredDistance.toFixed(1)}`,
+        `raid sector: ${state.raidSector.x.toFixed(1)}, ${state.raidSector.z.toFixed(1)}`,
+        `movement energy spent: ${(state.totalMovementEnergy * 100).toFixed(2)}%`,
+        `unsafe targets projected: ${state.projectedTargetCount}`,
+        `camera: ${state.cameraMode}`,
+        `fps: ${engine.getFps().toFixed(1)}`,
+        `meshes: ${scene.meshes.length}`,
+        "warning / critical silo radii are lab values",
+        "?inspect=1 enables Babylon Inspector",
+      ].join("\n");
+    }
+  });
+
+  const resize = () => engine.resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("keydown", onKeyDown);
+      inspectable?.dispose();
+      engine.stopRenderLoop();
+      scene.dispose();
+      engine.dispose();
+    },
+    { once: true },
+  );
+
+  (window as unknown as { __defendMothershipNavigation?: unknown }).__defendMothershipNavigation = {
+    state,
+    setSector: (x: number, z: number) =>
+      setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(x, 0, z)),
+  };
+}
+
+void main();

--- a/experiments/hybrid-engine/src/mothershipPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipPrototype.ts
@@ -1,0 +1,616 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Engine,
+  HemisphericLight,
+  MeshBuilder,
+  PointLight,
+  Scene,
+  StandardMaterial,
+  TransformNode,
+  Vector3,
+} from "@babylonjs/core/pure";
+
+type MothershipPhase = "stable" | "low-reserve" | "critical" | "falling" | "hulk";
+type CameraMode = "raider" | "defender";
+
+const START_RESERVE = 1;
+const LOW_RESERVE = 0.38;
+const CRITICAL_RESERVE = 0.2;
+const FALL_RESERVE = 0.1;
+const HOVER_DRAIN_PER_SECOND = 0.0065;
+const FALL_DRAIN_PER_SECOND = 0.002;
+const FAST_DRAIN_MULTIPLIER = 8;
+const START_ALTITUDE = 56;
+const HULK_CENTER_Y = 18;
+const GRAVITY = 9.81;
+const MAX_FRAME_DELTA_SECONDS = 0.05;
+
+interface MothershipState {
+  reserve: number;
+  phase: MothershipPhase;
+  verticalVelocity: number;
+  angularVelocity: Vector3;
+  elapsedSeconds: number;
+  impactCount: number;
+  paused: boolean;
+  fastDrain: boolean;
+  cameraMode: CameraMode;
+}
+
+function phaseForReserve(reserve: number): MothershipPhase {
+  if (reserve <= FALL_RESERVE) return "falling";
+  if (reserve <= CRITICAL_RESERVE) return "critical";
+  if (reserve <= LOW_RESERVE) return "low-reserve";
+  return "stable";
+}
+
+function createMaterial(
+  name: string,
+  scene: Scene,
+  diffuse: Color3,
+  emissive: Color3,
+  alpha = 1,
+): StandardMaterial {
+  const material = new StandardMaterial(name, scene);
+  material.diffuseColor = diffuse;
+  material.emissiveColor = emissive;
+  material.specularColor = new Color3(0.08, 0.08, 0.1);
+  material.alpha = alpha;
+  return material;
+}
+
+function createMothership(scene: Scene) {
+  const root = new TransformNode("mothership-root", scene);
+  root.position.set(0, START_ALTITUDE, 0);
+
+  const shellMaterial = createMaterial(
+    "mothership-shell",
+    scene,
+    new Color3(0.22, 0.055, 0.34),
+    new Color3(0.07, 0.012, 0.1),
+    0.92,
+  );
+  shellMaterial.wireframe = true;
+
+  const structureMaterial = createMaterial(
+    "mothership-structure",
+    scene,
+    new Color3(0.16, 0.035, 0.24),
+    new Color3(0.035, 0.006, 0.055),
+    0.96,
+  );
+
+  const activeStructureMaterial = createMaterial(
+    "mothership-active-structure",
+    scene,
+    new Color3(0.08, 0.24, 0.27),
+    new Color3(0.025, 0.18, 0.2),
+    0.9,
+  );
+
+  const coreMaterial = createMaterial(
+    "mothership-energy-core",
+    scene,
+    new Color3(0.04, 0.58, 0.58),
+    new Color3(0.02, 0.52, 0.54),
+    0.92,
+  );
+  coreMaterial.specularColor = new Color3(0.2, 0.95, 0.92);
+
+  const shell = MeshBuilder.CreateSphere(
+    "mothership-shell-cage",
+    { diameter: 38, segments: 8 },
+    scene,
+  );
+  shell.parent = root;
+  shell.material = shellMaterial;
+  shell.isPickable = false;
+
+  const core = MeshBuilder.CreateSphere(
+    "mothership-core",
+    { diameter: 15, segments: 12 },
+    scene,
+  );
+  core.parent = root;
+  core.material = coreMaterial;
+  core.isPickable = false;
+
+  const equator = MeshBuilder.CreateTorus(
+    "mothership-equator",
+    { diameter: 35, thickness: 1.25, tessellation: 16 },
+    scene,
+  );
+  equator.parent = root;
+  equator.material = structureMaterial;
+
+  const meridianX = MeshBuilder.CreateTorus(
+    "mothership-meridian-x",
+    { diameter: 35, thickness: 1.05, tessellation: 16 },
+    scene,
+  );
+  meridianX.parent = root;
+  meridianX.rotation.x = Math.PI / 2;
+  meridianX.material = structureMaterial;
+
+  const meridianZ = MeshBuilder.CreateTorus(
+    "mothership-meridian-z",
+    { diameter: 35, thickness: 1.05, tessellation: 16 },
+    scene,
+  );
+  meridianZ.parent = root;
+  meridianZ.rotation.z = Math.PI / 2;
+  meridianZ.material = structureMaterial;
+
+  const launchRing = MeshBuilder.CreateTorus(
+    "mothership-launch-ring",
+    { diameter: 21, thickness: 0.75, tessellation: 14 },
+    scene,
+  );
+  launchRing.parent = root;
+  launchRing.position.y = -6.2;
+  launchRing.material = activeStructureMaterial;
+
+  const strutX = MeshBuilder.CreateBox(
+    "mothership-strut-x",
+    { width: 30, height: 0.85, depth: 0.85 },
+    scene,
+  );
+  strutX.parent = root;
+  strutX.material = structureMaterial;
+
+  const strutY = MeshBuilder.CreateBox(
+    "mothership-strut-y",
+    { width: 0.85, height: 30, depth: 0.85 },
+    scene,
+  );
+  strutY.parent = root;
+  strutY.material = structureMaterial;
+
+  const strutZ = MeshBuilder.CreateBox(
+    "mothership-strut-z",
+    { width: 0.85, height: 0.85, depth: 30 },
+    scene,
+  );
+  strutZ.parent = root;
+  strutZ.material = structureMaterial;
+
+  const nodePositions = [
+    new Vector3(17, 0, 0),
+    new Vector3(-17, 0, 0),
+    new Vector3(0, 17, 0),
+    new Vector3(0, -17, 0),
+    new Vector3(0, 0, 17),
+    new Vector3(0, 0, -17),
+    new Vector3(11.5, 11.5, 0),
+    new Vector3(-11.5, 11.5, 0),
+    new Vector3(0, 11.5, 11.5),
+    new Vector3(0, 11.5, -11.5),
+  ];
+
+  const fieldNodes = nodePositions.map((position, index) => {
+    const node = MeshBuilder.CreateSphere(
+      `mothership-field-node-${index}`,
+      { diameter: index < 6 ? 3.2 : 2.5, segments: 5 },
+      scene,
+    );
+    node.parent = root;
+    node.position.copyFrom(position);
+    node.material = index % 3 === 0 ? activeStructureMaterial : structureMaterial;
+    return node;
+  });
+
+  return {
+    root,
+    core,
+    coreMaterial,
+    shellMaterial,
+    structureMaterial,
+    activeStructureMaterial,
+    launchRing,
+    fieldNodes,
+  };
+}
+
+function createArena(scene: Scene) {
+  const groundMaterial = createMaterial(
+    "arena-ground",
+    scene,
+    new Color3(0.025, 0.018, 0.035),
+    new Color3(0.008, 0.005, 0.012),
+  );
+
+  const ground = MeshBuilder.CreateGround(
+    "arena-ground",
+    { width: 180, height: 180, subdivisions: 1 },
+    scene,
+  );
+  ground.material = groundMaterial;
+  ground.position.y = 0;
+
+  const towerMaterial = createMaterial(
+    "defender-structure",
+    scene,
+    new Color3(0.09, 0.31, 0.17),
+    new Color3(0.015, 0.07, 0.03),
+  );
+  const siloEnergyMaterial = createMaterial(
+    "defender-silo-energy",
+    scene,
+    new Color3(0.05, 0.5, 0.52),
+    new Color3(0.02, 0.3, 0.32),
+    0.82,
+  );
+
+  const silo = MeshBuilder.CreateBox(
+    "defender-silo",
+    { width: 24, height: 3.5, depth: 24 },
+    scene,
+  );
+  silo.position.y = 1.75;
+  silo.material = towerMaterial;
+
+  const siloCore = MeshBuilder.CreateBox(
+    "defender-silo-core",
+    { width: 17, height: 1.2, depth: 17 },
+    scene,
+  );
+  siloCore.position.y = 4.1;
+  siloCore.material = siloEnergyMaterial;
+
+  const barrierPositions = [
+    new Vector3(-22, 2, -18),
+    new Vector3(22, 2, -18),
+    new Vector3(-22, 2, 18),
+    new Vector3(22, 2, 18),
+  ];
+  barrierPositions.forEach((position, index) => {
+    const barrier = MeshBuilder.CreateBox(
+      `defender-barrier-${index}`,
+      { width: 10, height: 4, depth: 10 },
+      scene,
+    );
+    barrier.position.copyFrom(position);
+    barrier.material = towerMaterial;
+  });
+
+  const raiderShellMaterial = createMaterial(
+    "raider-reference-shell",
+    scene,
+    new Color3(0.28, 0.06, 0.4),
+    new Color3(0.06, 0.01, 0.09),
+  );
+  raiderShellMaterial.wireframe = true;
+  const raiderCoreMaterial = createMaterial(
+    "raider-reference-core",
+    scene,
+    new Color3(0.04, 0.5, 0.52),
+    new Color3(0.015, 0.24, 0.27),
+    0.8,
+  );
+
+  [6, 9, 14].forEach((diameter, index) => {
+    const x = -34 + index * 17;
+    const shell = MeshBuilder.CreateSphere(
+      `raider-reference-shell-${index + 1}`,
+      { diameter, segments: 5 + index },
+      scene,
+    );
+    shell.position.set(x, diameter / 2, 48);
+    shell.material = raiderShellMaterial;
+
+    const core = MeshBuilder.CreateSphere(
+      `raider-reference-core-${index + 1}`,
+      { diameter: diameter * 0.42, segments: 6 },
+      scene,
+    );
+    core.position.copyFrom(shell.position);
+    core.material = raiderCoreMaterial;
+  });
+}
+
+function setCameraMode(camera: ArcRotateCamera, mode: CameraMode, target: Vector3): void {
+  if (mode === "raider") {
+    camera.alpha = -Math.PI / 2.2;
+    camera.beta = 0.9;
+    camera.radius = 58;
+    camera.setTarget(target);
+  } else {
+    camera.alpha = -Math.PI / 3.5;
+    camera.beta = 1.92;
+    camera.radius = 126;
+    camera.setTarget(new Vector3(0, 30, 0));
+  }
+}
+
+function resetState(state: MothershipState, root: TransformNode): void {
+  state.reserve = START_RESERVE;
+  state.phase = "stable";
+  state.verticalVelocity = 0;
+  state.angularVelocity.set(0, 0, 0);
+  state.elapsedSeconds = 0;
+  state.impactCount = 0;
+  state.paused = false;
+  state.fastDrain = false;
+
+  root.position.set(0, START_ALTITUDE, 0);
+  root.rotation.set(0, 0, 0);
+}
+
+async function main(): Promise<void> {
+  const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas");
+  const metrics = document.querySelector<HTMLElement>("#metrics");
+  const resetButton = document.querySelector<HTMLButtonElement>("#reset");
+  const pauseButton = document.querySelector<HTMLButtonElement>("#pause");
+  const fastButton = document.querySelector<HTMLButtonElement>("#fast");
+  const cameraButton = document.querySelector<HTMLButtonElement>("#camera");
+
+  if (!canvas || !metrics || !resetButton || !pauseButton || !fastButton || !cameraButton) {
+    throw new Error("Mothership lab DOM is incomplete");
+  }
+
+  const engine = new Engine(canvas, true, {
+    adaptToDeviceRatio: true,
+    antialias: true,
+  });
+  const scene = new Scene(engine);
+  scene.clearColor.set(0.02, 0.012, 0.034, 1);
+
+  const camera = new ArcRotateCamera(
+    "mothership-camera",
+    -Math.PI / 2.2,
+    0.9,
+    58,
+    new Vector3(0, START_ALTITUDE - 8, 0),
+    scene,
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 36;
+  camera.upperRadiusLimit = 180;
+  camera.lowerBetaLimit = 0.3;
+  camera.upperBetaLimit = 2.35;
+
+  const ambient = new HemisphericLight(
+    "ambient",
+    new Vector3(0.15, 1, 0.2),
+    scene,
+  );
+  ambient.intensity = 0.72;
+
+  const coreLight = new PointLight("core-light", new Vector3(0, START_ALTITUDE, 0), scene);
+  coreLight.diffuse = new Color3(0.12, 0.9, 0.88);
+  coreLight.intensity = 0.65;
+  coreLight.range = 62;
+
+  createArena(scene);
+  const mothership = createMothership(scene);
+
+  const state: MothershipState = {
+    reserve: START_RESERVE,
+    phase: "stable",
+    verticalVelocity: 0,
+    angularVelocity: Vector3.Zero(),
+    elapsedSeconds: 0,
+    impactCount: 0,
+    paused: false,
+    fastDrain: false,
+    cameraMode: "raider",
+  };
+
+  setCameraMode(camera, state.cameraMode, mothership.root.position);
+
+  let inspectable: { dispose(): void } | undefined;
+  if (new URLSearchParams(location.search).has("inspect")) {
+    const { StartInspectable } = await import("@babylonjs/inspector");
+    inspectable = StartInspectable(scene);
+  }
+
+  const updateButtons = () => {
+    pauseButton.textContent = state.paused ? "Resume drain [Space]" : "Pause drain [Space]";
+    fastButton.textContent = state.fastDrain ? "Normal drain [F]" : "Fast drain [F]";
+    cameraButton.textContent = state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
+  };
+
+  const doReset = () => {
+    resetState(state, mothership.root);
+    setCameraMode(camera, state.cameraMode, mothership.root.position);
+    updateButtons();
+  };
+
+  const togglePause = () => {
+    state.paused = !state.paused;
+    updateButtons();
+  };
+
+  const toggleFast = () => {
+    state.fastDrain = !state.fastDrain;
+    updateButtons();
+  };
+
+  const toggleCamera = () => {
+    state.cameraMode = state.cameraMode === "raider" ? "defender" : "raider";
+    setCameraMode(camera, state.cameraMode, mothership.root.position);
+    updateButtons();
+  };
+
+  resetButton.addEventListener("click", doReset);
+  pauseButton.addEventListener("click", togglePause);
+  fastButton.addEventListener("click", toggleFast);
+  cameraButton.addEventListener("click", toggleCamera);
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.repeat) return;
+    if (event.code === "KeyR") doReset();
+    if (event.code === "Space") {
+      event.preventDefault();
+      togglePause();
+    }
+    if (event.code === "KeyF") toggleFast();
+    if (event.code === "KeyC") toggleCamera();
+  };
+  window.addEventListener("keydown", onKeyDown);
+
+  let frame = 0;
+
+  engine.runRenderLoop(() => {
+    const deltaSeconds = Math.min(
+      MAX_FRAME_DELTA_SECONDS,
+      engine.getDeltaTime() / 1000,
+    );
+    state.elapsedSeconds += deltaSeconds;
+
+    if (!state.paused && state.phase !== "hulk") {
+      const drainMultiplier = state.fastDrain ? FAST_DRAIN_MULTIPLIER : 1;
+      const drainRate =
+        state.phase === "falling" ? FALL_DRAIN_PER_SECOND : HOVER_DRAIN_PER_SECOND;
+      state.reserve = Math.max(
+        0,
+        state.reserve - drainRate * drainMultiplier * deltaSeconds,
+      );
+    }
+
+    if (state.phase !== "falling" && state.phase !== "hulk") {
+      state.phase = phaseForReserve(state.reserve);
+    }
+
+    if (state.phase === "falling") {
+      state.verticalVelocity -= GRAVITY * deltaSeconds;
+      mothership.root.position.y += state.verticalVelocity * deltaSeconds;
+      mothership.root.rotation.x += state.angularVelocity.x * deltaSeconds;
+      mothership.root.rotation.y += state.angularVelocity.y * deltaSeconds;
+      mothership.root.rotation.z += state.angularVelocity.z * deltaSeconds;
+
+      if (state.angularVelocity.lengthSquared() < 0.0001) {
+        state.angularVelocity.set(0.22, 0.08, -0.16);
+      }
+
+      if (mothership.root.position.y <= HULK_CENTER_Y) {
+        mothership.root.position.y = HULK_CENTER_Y;
+        state.impactCount += 1;
+        if (state.impactCount === 1 && Math.abs(state.verticalVelocity) > 4) {
+          state.verticalVelocity = Math.abs(state.verticalVelocity) * 0.12;
+          state.angularVelocity.scaleInPlace(0.72);
+        } else {
+          state.verticalVelocity = 0;
+          state.angularVelocity.set(0, 0, 0);
+          state.phase = "hulk";
+        }
+      }
+    } else if (state.phase !== "hulk") {
+      const liftFraction = Math.max(
+        0,
+        Math.min(1, (state.reserve - FALL_RESERVE) / (START_RESERVE - FALL_RESERVE)),
+      );
+      const depletion = 1 - liftFraction;
+      const targetAltitude = START_ALTITUDE - depletion * 12;
+      const stiffness = 4.4 * (0.32 + liftFraction * 0.68);
+      const damping = 1.1 + liftFraction * 3.1;
+      const wobbleAmplitude = 0.08 + depletion * depletion * 1.5;
+      const wobble =
+        Math.sin(state.elapsedSeconds * (1.2 + depletion * 1.8)) * wobbleAmplitude;
+      const acceleration =
+        (targetAltitude - mothership.root.position.y) * stiffness -
+        state.verticalVelocity * damping +
+        wobble;
+
+      state.verticalVelocity += acceleration * deltaSeconds;
+      mothership.root.position.y += state.verticalVelocity * deltaSeconds;
+
+      const orientationAmplitude = depletion * depletion * 0.14;
+      const targetPitch = Math.sin(state.elapsedSeconds * 0.72) * orientationAmplitude;
+      const targetRoll = Math.cos(state.elapsedSeconds * 0.58) * orientationAmplitude;
+      const correction = Math.max(0.35, 2.6 * liftFraction) * deltaSeconds;
+      mothership.root.rotation.x +=
+        (targetPitch - mothership.root.rotation.x) * correction;
+      mothership.root.rotation.z +=
+        (targetRoll - mothership.root.rotation.z) * correction;
+      mothership.root.rotation.y += deltaSeconds * (0.035 + depletion * 0.025);
+    }
+
+    if (state.phase !== "hulk" && state.reserve <= FALL_RESERVE) {
+      state.phase = "falling";
+      state.angularVelocity.set(0.22, 0.08, -0.16);
+    }
+
+    const visibleReserve = state.phase === "hulk" ? Math.min(state.reserve, 0.025) : state.reserve;
+    const coreScale = 0.26 + Math.cbrt(Math.max(0, visibleReserve)) * 0.74;
+    mothership.core.scaling.set(coreScale, coreScale, coreScale);
+
+    mothership.coreMaterial.emissiveColor.set(
+      0.015 + visibleReserve * 0.05,
+      0.07 + visibleReserve * 0.48,
+      0.08 + visibleReserve * 0.5,
+    );
+    mothership.coreMaterial.diffuseColor.set(
+      0.025 + visibleReserve * 0.04,
+      0.16 + visibleReserve * 0.42,
+      0.17 + visibleReserve * 0.41,
+    );
+
+    const structureEnergy = state.phase === "hulk" ? 0.02 : Math.max(0.03, state.reserve);
+    mothership.activeStructureMaterial.emissiveColor.set(
+      0.01,
+      0.04 + structureEnergy * 0.15,
+      0.05 + structureEnergy * 0.16,
+    );
+    mothership.shellMaterial.emissiveColor.set(
+      0.018 + structureEnergy * 0.045,
+      0.003 + structureEnergy * 0.012,
+      0.03 + structureEnergy * 0.07,
+    );
+
+    coreLight.position.copyFrom(mothership.root.position);
+    coreLight.intensity = state.phase === "hulk" ? 0.05 : 0.12 + state.reserve * 0.72;
+
+    if (state.cameraMode === "raider") {
+      const target = mothership.root.position.clone();
+      target.y -= 8;
+      camera.setTarget(target);
+    }
+
+    scene.render();
+
+    frame += 1;
+    if (frame % 8 === 0) {
+      const drainMultiplier = state.fastDrain ? FAST_DRAIN_MULTIPLIER : 1;
+      metrics.textContent = [
+        "Defend mothership PoC — issue #80",
+        `phase: ${state.phase}`,
+        `reserve: ${(state.reserve * 100).toFixed(1)}%`,
+        `altitude: ${mothership.root.position.y.toFixed(2)}`,
+        `vertical velocity: ${state.verticalVelocity.toFixed(2)}`,
+        `hover drain: x${drainMultiplier}${state.paused ? " (paused)" : ""}`,
+        `camera: ${state.cameraMode}`,
+        `impacts: ${state.impactCount}`,
+        `meshes: ${scene.meshes.length}`,
+        `fps: ${engine.getFps().toFixed(1)}`,
+        "",
+        "R reset · Space pause · F fast drain · C camera",
+        "?inspect=1 enables Babylon Inspector",
+      ].join("\n");
+    }
+  });
+
+  updateButtons();
+
+  const resize = () => engine.resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("keydown", onKeyDown);
+      resetButton.removeEventListener("click", doReset);
+      pauseButton.removeEventListener("click", togglePause);
+      fastButton.removeEventListener("click", toggleFast);
+      cameraButton.removeEventListener("click", toggleCamera);
+      inspectable?.dispose();
+      engine.stopRenderLoop();
+      scene.dispose();
+      engine.dispose();
+    },
+    { once: true },
+  );
+}
+
+void main();

--- a/experiments/hybrid-engine/src/raidPlanPrototype.ts
+++ b/experiments/hybrid-engine/src/raidPlanPrototype.ts
@@ -1,0 +1,242 @@
+type RaiderTier = 1 | 2 | 3;
+
+interface SectorTarget {
+  x: number;
+  z: number;
+}
+
+interface RaidSetPlan {
+  r1: number;
+  r2: number;
+  r3: number;
+  sector: SectorTarget | null;
+}
+
+interface NavigationDebugState {
+  raidSector: { x: number; z: number };
+  reserve: number;
+}
+
+interface NavigationDebugApi {
+  state: NavigationDebugState;
+}
+
+const MAX_PER_TIER = 9;
+const COMMITMENT_WEIGHT: Record<RaiderTier, number> = {
+  1: 1,
+  2: 4,
+  3: 9,
+};
+
+const plans: RaidSetPlan[] = [
+  { r1: 3, r2: 0, r3: 0, sector: null },
+  { r1: 1, r2: 1, r3: 0, sector: null },
+  { r1: 0, r2: 0, r3: 0, sector: null },
+];
+
+function navigationApi(): NavigationDebugApi | null {
+  const scope = window as unknown as {
+    __defendMothershipNavigation?: NavigationDebugApi;
+  };
+  return scope.__defendMothershipNavigation ?? null;
+}
+
+function copyCurrentSector(): SectorTarget | null {
+  const api = navigationApi();
+  if (!api) return null;
+  return {
+    x: api.state.raidSector.x,
+    z: api.state.raidSector.z,
+  };
+}
+
+function commitment(plan: RaidSetPlan): number {
+  return (
+    plan.r1 * COMMITMENT_WEIGHT[1] +
+    plan.r2 * COMMITMENT_WEIGHT[2] +
+    plan.r3 * COMMITMENT_WEIGHT[3]
+  );
+}
+
+function isHold(plan: RaidSetPlan): boolean {
+  return plan.r1 === 0 && plan.r2 === 0 && plan.r3 === 0;
+}
+
+function adjust(index: number, tier: RaiderTier, delta: number): void {
+  const plan = plans[index];
+  const key = tier === 1 ? "r1" : tier === 2 ? "r2" : "r3";
+  plan[key] = Math.max(0, Math.min(MAX_PER_TIER, plan[key] + delta));
+  render();
+}
+
+function setHold(index: number): void {
+  plans[index].r1 = 0;
+  plans[index].r2 = 0;
+  plans[index].r3 = 0;
+  render();
+}
+
+function useCurrentSector(index: number): void {
+  plans[index].sector = copyCurrentSector();
+  render();
+}
+
+function advanceQueue(): void {
+  plans.shift();
+  plans.push({ r1: 0, r2: 0, r3: 0, sector: null });
+  render();
+}
+
+function compositionText(plan: RaidSetPlan): string {
+  if (isHold(plan)) return "HOLD / NO RAID";
+  const parts: string[] = [];
+  if (plan.r1 > 0) parts.push(`R1×${plan.r1}`);
+  if (plan.r2 > 0) parts.push(`R2×${plan.r2}`);
+  if (plan.r3 > 0) parts.push(`R3×${plan.r3}`);
+  return parts.join("  ");
+}
+
+function sectorText(plan: RaidSetPlan): string {
+  if (!plan.sector) return "sector: current at launch / unset";
+  return `sector: ${plan.sector.x.toFixed(1)}, ${plan.sector.z.toFixed(1)}`;
+}
+
+const style = document.createElement("style");
+style.textContent = `
+  #raid-plan-lab {
+    position: fixed;
+    right: 12px;
+    bottom: 48px;
+    z-index: 5;
+    width: min(620px, calc(100vw - 24px));
+    max-height: 52vh;
+    overflow: auto;
+    box-sizing: border-box;
+    padding: 9px;
+    border: 1px solid rgba(66, 216, 210, .32);
+    background: rgba(8, 5, 13, .86);
+    font-size: 11px;
+    line-height: 1.35;
+  }
+  #raid-plan-lab header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 7px;
+  }
+  #raid-plan-lab h2 { margin: 0; font-size: 12px; font-weight: 600; }
+  #raid-plan-lab .queue { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; }
+  #raid-plan-lab .slot { border: 1px solid rgba(214, 145, 76, .24); padding: 6px; background: rgba(18, 10, 27, .6); }
+  #raid-plan-lab .slot.hold { border-style: dashed; opacity: .78; }
+  #raid-plan-lab .slot-title { display: flex; justify-content: space-between; gap: 4px; margin-bottom: 4px; }
+  #raid-plan-lab .composition { min-height: 16px; color: rgb(119, 223, 218); }
+  #raid-plan-lab .sector { opacity: .72; margin: 3px 0 5px; }
+  #raid-plan-lab .tier-row { display: grid; grid-template-columns: 24px 1fr 1fr 24px; gap: 3px; align-items: center; margin-top: 3px; }
+  #raid-plan-lab button { padding: 3px 5px; font-size: 10px; }
+  #raid-plan-lab .slot-actions { display: flex; gap: 3px; flex-wrap: wrap; margin-top: 5px; }
+  #raid-plan-lab .summary { margin-top: 7px; opacity: .84; }
+  @media (max-width: 760px) {
+    #raid-plan-lab { max-height: 44vh; }
+    #raid-plan-lab .queue { grid-template-columns: 1fr; }
+  }
+`;
+document.head.appendChild(style);
+
+const panel = document.createElement("section");
+panel.id = "raid-plan-lab";
+panel.setAttribute("aria-label", "Three-set raid planning prototype");
+document.body.appendChild(panel);
+
+function tierControls(planIndex: number, tier: RaiderTier, value: number): string {
+  return `
+    <div class="tier-row">
+      <span>R${tier}</span>
+      <button type="button" data-action="minus" data-index="${planIndex}" data-tier="${tier}" aria-label="Remove one R${tier} from raid ${planIndex + 1}">−</button>
+      <button type="button" data-action="plus" data-index="${planIndex}" data-tier="${tier}" aria-label="Add one R${tier} to raid ${planIndex + 1}">+</button>
+      <strong>${value}</strong>
+    </div>
+  `;
+}
+
+function render(): void {
+  const api = navigationApi();
+  const currentSector = api
+    ? `${api.state.raidSector.x.toFixed(1)}, ${api.state.raidSector.z.toFixed(1)}`
+    : "navigation initializing";
+  const totalCommitment = plans.reduce((sum, plan) => sum + commitment(plan), 0);
+
+  panel.innerHTML = `
+    <header>
+      <div>
+        <h2>Upcoming three raid sets</h2>
+        <div>current selected sector: ${currentSector}</div>
+      </div>
+      <button type="button" data-action="advance">Advance queue [Q]</button>
+    </header>
+    <div class="queue">
+      ${plans
+        .map(
+          (plan, index) => `
+            <article class="slot ${isHold(plan) ? "hold" : ""}">
+              <div class="slot-title"><strong>Set ${index + 1}</strong><span>weight ${commitment(plan)}</span></div>
+              <div class="composition">${compositionText(plan)}</div>
+              <div class="sector">${sectorText(plan)}</div>
+              ${tierControls(index, 1, plan.r1)}
+              ${tierControls(index, 2, plan.r2)}
+              ${tierControls(index, 3, plan.r3)}
+              <div class="slot-actions">
+                <button type="button" data-action="sector" data-index="${index}">Use current sector</button>
+                <button type="button" data-action="hold" data-index="${index}">Hold / clear</button>
+              </div>
+            </article>
+          `,
+        )
+        .join("")}
+    </div>
+    <div class="summary">
+      total queued commitment weight: ${totalCommitment}. R1/R2/R3 lab weights use 1/4/9 only to visualize relative commitment; they are not production launch costs. Empty sets intentionally mean no raid while mothership hover drain continues in the navigation simulation.
+    </div>
+  `;
+}
+
+panel.addEventListener("click", event => {
+  const target = event.target;
+  if (!(target instanceof HTMLButtonElement)) return;
+  const action = target.dataset.action;
+  if (action === "advance") {
+    advanceQueue();
+    return;
+  }
+  const index = Number(target.dataset.index);
+  if (!Number.isInteger(index) || index < 0 || index >= plans.length) return;
+  if (action === "hold") setHold(index);
+  if (action === "sector") useCurrentSector(index);
+  if (action === "plus" || action === "minus") {
+    const tier = Number(target.dataset.tier) as RaiderTier;
+    if (tier === 1 || tier === 2 || tier === 3) {
+      adjust(index, tier, action === "plus" ? 1 : -1);
+    }
+  }
+});
+
+const onKeyDown = (event: KeyboardEvent) => {
+  if (event.key.toLowerCase() === "q") advanceQueue();
+};
+window.addEventListener("keydown", onKeyDown);
+
+let refreshFrame = 0;
+function refreshCurrentSector(): void {
+  refreshFrame += 1;
+  if (refreshFrame % 20 === 0) render();
+  requestAnimationFrame(refreshCurrentSector);
+}
+
+render();
+requestAnimationFrame(refreshCurrentSector);
+
+(window as unknown as { __defendRaidPlanPrototype?: unknown }).__defendRaidPlanPrototype = {
+  plans,
+  advanceQueue,
+  useCurrentSector,
+};

--- a/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
+++ b/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
@@ -1,0 +1,605 @@
+import {
+  ArcRotateCamera,
+  Color3,
+  Engine,
+  HemisphericLight,
+  Mesh,
+  MeshBuilder,
+  Scene,
+  StandardMaterial,
+  Vector3,
+} from "@babylonjs/core/pure";
+
+type RaiderTier = 1 | 2 | 3;
+type RaiderState = "moving" | "blocked" | "reached";
+type EnergyState = "streaming" | "pooling" | "collected";
+
+interface Obstacle {
+  id: string;
+  mesh: Mesh;
+  x: number;
+  z: number;
+  halfX: number;
+  halfZ: number;
+  health: number;
+  maxHealth: number;
+  breakable: boolean;
+}
+
+interface RaiderBody {
+  tier: RaiderTier;
+  mesh: Mesh;
+  radius: number;
+  velocity: Vector3;
+  desired: Vector3;
+  state: RaiderState;
+  decisionTimer: number;
+  collisions: number;
+  distanceTravelled: number;
+}
+
+interface EnergyPacket {
+  mesh: Mesh;
+  value: number;
+  state: EnergyState;
+  blockedSeconds: number;
+  distanceTravelled: number;
+}
+
+const SILO = new Vector3(48, 0, 0);
+const START_X = -56;
+const MAX_DT = 0.05;
+const DRAIN_RADIUS = 1.1;
+const SILO_RADIUS = 7;
+const WALL_X = 18;
+const NARROW_DRAIN_Z = -30;
+const BROAD_GATE_Z = 12;
+const TERRAIN_VALLEY_Z = -24;
+
+function material(
+  name: string,
+  scene: Scene,
+  diffuse: Color3,
+  emissive: Color3,
+  alpha = 1,
+): StandardMaterial {
+  const result = new StandardMaterial(name, scene);
+  result.diffuseColor = diffuse;
+  result.emissiveColor = emissive;
+  result.specularColor = new Color3(0.08, 0.08, 0.1);
+  result.alpha = alpha;
+  return result;
+}
+
+function terrainHeight(z: number): number {
+  const normalized = (z - TERRAIN_VALLEY_Z) / 14;
+  return -1.4 * Math.exp(-(normalized * normalized));
+}
+
+function terrainPreference(z: number): number {
+  return terrainHeight(z) * 2.5;
+}
+
+function createObstacle(
+  scene: Scene,
+  id: string,
+  x: number,
+  z: number,
+  width: number,
+  depth: number,
+  height: number,
+  obstacleMaterial: StandardMaterial,
+  health: number,
+  breakable: boolean,
+): Obstacle {
+  const mesh = MeshBuilder.CreateBox(
+    id,
+    { width, depth, height },
+    scene,
+  );
+  mesh.position.set(x, height / 2 + terrainHeight(z), z);
+  mesh.material = obstacleMaterial;
+  return {
+    id,
+    mesh,
+    x,
+    z,
+    halfX: width / 2,
+    halfZ: depth / 2,
+    health,
+    maxHealth: health,
+    breakable,
+  };
+}
+
+function pointBlocked(
+  x: number,
+  z: number,
+  radius: number,
+  obstacles: Obstacle[],
+): Obstacle | undefined {
+  return obstacles.find(
+    (obstacle) =>
+      obstacle.health > 0 &&
+      Math.abs(x - obstacle.x) <= obstacle.halfX + radius &&
+      Math.abs(z - obstacle.z) <= obstacle.halfZ + radius,
+  );
+}
+
+function normalize2(x: number, z: number): Vector3 {
+  const length = Math.hypot(x, z);
+  if (length < 0.0001) return Vector3.Zero();
+  return new Vector3(x / length, 0, z / length);
+}
+
+function rotate2(direction: Vector3, radians: number): Vector3 {
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+  return new Vector3(
+    direction.x * cosine - direction.z * sine,
+    0,
+    direction.x * sine + direction.z * cosine,
+  );
+}
+
+function candidateDirections(direct: Vector3): Vector3[] {
+  return [
+    direct,
+    rotate2(direct, Math.PI / 6),
+    rotate2(direct, -Math.PI / 6),
+    rotate2(direct, Math.PI / 3),
+    rotate2(direct, -Math.PI / 3),
+    rotate2(direct, Math.PI / 2),
+    rotate2(direct, -Math.PI / 2),
+  ];
+}
+
+function scoreCandidate(
+  position: Vector3,
+  direction: Vector3,
+  step: number,
+  target: Vector3,
+): number {
+  const x = position.x + direction.x * step;
+  const z = position.z + direction.z * step;
+  return Math.hypot(target.x - x, target.z - z) + terrainPreference(z);
+}
+
+function bestOpenDirection(
+  position: Vector3,
+  radius: number,
+  target: Vector3,
+  obstacles: Obstacle[],
+  probe = 4,
+): Vector3 | undefined {
+  const direct = normalize2(target.x - position.x, target.z - position.z);
+  const candidates = candidateDirections(direct)
+    .filter((candidate) => {
+      const x = position.x + candidate.x * probe;
+      const z = position.z + candidate.z * probe;
+      return pointBlocked(x, z, radius, obstacles) === undefined;
+    })
+    .sort(
+      (a, b) =>
+        scoreCandidate(position, a, probe, target) -
+        scoreCandidate(position, b, probe, target),
+    );
+  return candidates[0];
+}
+
+function createArena(scene: Scene) {
+  const groundMaterial = material(
+    "routing-ground",
+    scene,
+    new Color3(0.026, 0.018, 0.038),
+    new Color3(0.008, 0.005, 0.012),
+  );
+  const ground = MeshBuilder.CreateGround(
+    "routing-ground",
+    { width: 130, height: 110, subdivisions: 1 },
+    scene,
+  );
+  ground.material = groundMaterial;
+  ground.position.y = -1.45;
+
+  const valleyMaterial = material(
+    "valley-guide",
+    scene,
+    new Color3(0.02, 0.08, 0.085),
+    new Color3(0.01, 0.08, 0.09),
+    0.5,
+  );
+  const valley = MeshBuilder.CreateBox(
+    "valley-guide",
+    { width: 125, depth: 10, height: 0.15 },
+    scene,
+  );
+  valley.position.set(0, terrainHeight(TERRAIN_VALLEY_Z) - 0.15, TERRAIN_VALLEY_Z);
+  valley.material = valleyMaterial;
+
+  const siloMaterial = material(
+    "routing-silo",
+    scene,
+    new Color3(0.09, 0.31, 0.17),
+    new Color3(0.015, 0.07, 0.03),
+  );
+  const siloCoreMaterial = material(
+    "routing-silo-core",
+    scene,
+    new Color3(0.04, 0.52, 0.54),
+    new Color3(0.02, 0.34, 0.36),
+    0.9,
+  );
+  const silo = MeshBuilder.CreateBox(
+    "routing-silo",
+    { width: 16, depth: 16, height: 4 },
+    scene,
+  );
+  silo.position.set(SILO.x, 2 + terrainHeight(SILO.z), SILO.z);
+  silo.material = siloMaterial;
+  const core = MeshBuilder.CreateBox(
+    "routing-silo-core",
+    { width: 10, depth: 10, height: 1.4 },
+    scene,
+  );
+  core.position.set(SILO.x, 4.6 + terrainHeight(SILO.z), SILO.z);
+  core.material = siloCoreMaterial;
+
+  return { ground };
+}
+
+function createFortress(scene: Scene) {
+  const wallMaterial = material(
+    "routing-wall",
+    scene,
+    new Color3(0.08, 0.3, 0.16),
+    new Color3(0.012, 0.06, 0.025),
+  );
+  const gateMaterial = material(
+    "routing-gate",
+    scene,
+    new Color3(0.16, 0.38, 0.2),
+    new Color3(0.025, 0.085, 0.035),
+  );
+
+  const obstacles: Obstacle[] = [
+    createObstacle(scene, "wall-south", WALL_X, -43, 6, 18, 8, wallMaterial, 9999, false),
+    createObstacle(scene, "wall-mid", WALL_X, -12, 6, 28, 8, wallMaterial, 9999, false),
+    createObstacle(scene, "wall-north", WALL_X, 37, 6, 30, 8, wallMaterial, 9999, false),
+    createObstacle(scene, "broad-gate", WALL_X, BROAD_GATE_Z, 6, 20, 8, gateMaterial, 900, true),
+  ];
+
+  const sideWalls = [
+    createObstacle(scene, "north-return", 38, 52, 46, 5, 7, wallMaterial, 9999, false),
+    createObstacle(scene, "south-return", 38, -52, 46, 5, 7, wallMaterial, 9999, false),
+    createObstacle(scene, "east-return", 61, 0, 5, 104, 7, wallMaterial, 9999, false),
+  ];
+  obstacles.push(...sideWalls);
+
+  return obstacles;
+}
+
+function createRaiderMaterial(scene: Scene, tier: RaiderTier): StandardMaterial {
+  const diffuse = [
+    new Color3(0.22, 0.05, 0.34),
+    new Color3(0.27, 0.055, 0.4),
+    new Color3(0.32, 0.06, 0.45),
+  ][tier - 1];
+  return material(
+    `routing-raider-${tier}`,
+    scene,
+    diffuse,
+    new Color3(diffuse.r * 0.22, diffuse.g * 0.22, diffuse.b * 0.22),
+  );
+}
+
+function spawnRaiders(scene: Scene): RaiderBody[] {
+  const radii: Record<RaiderTier, number> = { 1: 3, 2: 4.5, 3: 7 };
+  const starts: Record<RaiderTier, number> = { 1: -30, 2: 8, 3: 27 };
+  return ([1, 2, 3] as RaiderTier[]).map((tier) => {
+    const radius = radii[tier];
+    const mesh = MeshBuilder.CreateIcoSphere(
+      `routing-raider-${tier}`,
+      { radius, subdivisions: tier },
+      scene,
+    );
+    const z = starts[tier];
+    mesh.position.set(START_X, radius + terrainHeight(z), z);
+    mesh.material = createRaiderMaterial(scene, tier);
+    return {
+      tier,
+      mesh,
+      radius,
+      velocity: Vector3.Zero(),
+      desired: normalize2(SILO.x - START_X, SILO.z - z),
+      state: "moving" as RaiderState,
+      decisionTimer: 0,
+      collisions: 0,
+      distanceTravelled: 0,
+    };
+  });
+}
+
+function raiderDecision(body: RaiderBody, obstacles: Obstacle[]): Vector3 {
+  const direct = normalize2(SILO.x - body.mesh.position.x, SILO.z - body.mesh.position.z);
+
+  if (body.tier === 1) {
+    return bestOpenDirection(body.mesh.position, body.radius + 0.25, SILO, obstacles, 4.4) ?? direct;
+  }
+
+  if (body.tier === 2) {
+    const blocker = pointBlocked(
+      body.mesh.position.x + direct.x * 5,
+      body.mesh.position.z + direct.z * 5,
+      body.radius,
+      obstacles,
+    );
+    if (blocker?.breakable) return direct;
+    return bestOpenDirection(body.mesh.position, body.radius + 0.35, SILO, obstacles, 5.2) ?? direct;
+  }
+
+  const downhillBias = normalize2(0, (TERRAIN_VALLEY_Z - body.mesh.position.z) * 0.28);
+  return normalize2(direct.x + downhillBias.x * 0.3, direct.z + downhillBias.z * 0.3);
+}
+
+function applyObstacleImpact(body: RaiderBody, obstacle: Obstacle): void {
+  body.collisions += 1;
+  if (obstacle.breakable) {
+    const speed = Math.hypot(body.velocity.x, body.velocity.z);
+    const tierImpulse = body.tier === 1 ? 6 : body.tier === 2 ? 26 : 68;
+    obstacle.health = Math.max(0, obstacle.health - tierImpulse * Math.max(0.5, speed));
+    const remaining = obstacle.health / obstacle.maxHealth;
+    obstacle.mesh.scaling.y = Math.max(0.15, remaining);
+    obstacle.mesh.position.y =
+      terrainHeight(obstacle.z) + 4 * obstacle.mesh.scaling.y;
+    if (obstacle.health <= 0) {
+      obstacle.mesh.setEnabled(false);
+    }
+  }
+
+  const retention = body.tier === 1 ? 0.15 : body.tier === 2 ? 0.42 : 0.66;
+  body.velocity.scaleInPlace(retention);
+  if (body.tier === 1) body.decisionTimer = 0;
+  body.state = "blocked";
+}
+
+function updateRaider(body: RaiderBody, obstacles: Obstacle[], deltaSeconds: number): void {
+  if (body.state === "reached") return;
+
+  const cadence = body.tier === 1 ? 0.16 : body.tier === 2 ? 0.42 : 0.9;
+  body.decisionTimer -= deltaSeconds;
+  if (body.decisionTimer <= 0) {
+    body.desired = raiderDecision(body, obstacles);
+    body.decisionTimer = cadence;
+  }
+
+  const acceleration = body.tier === 1 ? 13 : body.tier === 2 ? 8.5 : 4.4;
+  const maxSpeed = body.tier === 1 ? 15 : body.tier === 2 ? 12 : 9.5;
+  body.velocity.x += body.desired.x * acceleration * deltaSeconds;
+  body.velocity.z += body.desired.z * acceleration * deltaSeconds;
+
+  const damping = Math.max(0, 1 - (body.tier === 1 ? 1.8 : body.tier === 2 ? 0.9 : 0.35) * deltaSeconds);
+  body.velocity.scaleInPlace(damping);
+  const speed = Math.hypot(body.velocity.x, body.velocity.z);
+  if (speed > maxSpeed) {
+    const scale = maxSpeed / speed;
+    body.velocity.x *= scale;
+    body.velocity.z *= scale;
+  }
+
+  const nextX = body.mesh.position.x + body.velocity.x * deltaSeconds;
+  const nextZ = body.mesh.position.z + body.velocity.z * deltaSeconds;
+  const obstacle = pointBlocked(nextX, nextZ, body.radius, obstacles);
+  if (obstacle) {
+    applyObstacleImpact(body, obstacle);
+  } else {
+    const dx = nextX - body.mesh.position.x;
+    const dz = nextZ - body.mesh.position.z;
+    body.distanceTravelled += Math.hypot(dx, dz);
+    body.mesh.position.x = nextX;
+    body.mesh.position.z = nextZ;
+    body.mesh.position.y = body.radius + terrainHeight(nextZ);
+    body.state = "moving";
+  }
+
+  const siloDistance = Math.hypot(
+    SILO.x - body.mesh.position.x,
+    SILO.z - body.mesh.position.z,
+  );
+  if (siloDistance <= SILO_RADIUS + body.radius * 0.45) {
+    body.state = "reached";
+    body.velocity.set(0, 0, 0);
+  }
+}
+
+function createEnergyMaterial(scene: Scene): StandardMaterial {
+  const result = material(
+    "routing-energy",
+    scene,
+    new Color3(0.04, 0.62, 0.62),
+    new Color3(0.02, 0.48, 0.5),
+    0.92,
+  );
+  result.specularColor = new Color3(0.2, 0.95, 0.92);
+  return result;
+}
+
+function spawnEnergy(scene: Scene, packets: EnergyPacket[], energyMaterial: StandardMaterial): void {
+  const offsets = [-4, -2, 0, 2, 4];
+  offsets.forEach((offset, index) => {
+    const mesh = MeshBuilder.CreateSphere(
+      `routing-energy-${performance.now()}-${index}`,
+      { diameter: 1.8, segments: 5 },
+      scene,
+    );
+    mesh.position.set(
+      START_X + 8 + index * 0.8,
+      0.7 + terrainHeight(NARROW_DRAIN_Z + offset),
+      NARROW_DRAIN_Z + offset,
+    );
+    mesh.scaling.y = 0.45;
+    mesh.material = energyMaterial;
+    packets.push({
+      mesh,
+      value: 100,
+      state: "streaming",
+      blockedSeconds: 0,
+      distanceTravelled: 0,
+    });
+  });
+}
+
+function energyDirection(packet: EnergyPacket, obstacles: Obstacle[]): Vector3 | undefined {
+  const direct = normalize2(SILO.x - packet.mesh.position.x, SILO.z - packet.mesh.position.z);
+  const candidates = candidateDirections(direct)
+    .filter((candidate) => {
+      const x = packet.mesh.position.x + candidate.x * 3.2;
+      const z = packet.mesh.position.z + candidate.z * 3.2;
+      return pointBlocked(x, z, DRAIN_RADIUS, obstacles) === undefined;
+    })
+    .sort((a, b) => {
+      const aScore = scoreCandidate(packet.mesh.position, a, 3.2, SILO);
+      const bScore = scoreCandidate(packet.mesh.position, b, 3.2, SILO);
+      return aScore - bScore;
+    });
+  return candidates[0];
+}
+
+function updateEnergy(packet: EnergyPacket, obstacles: Obstacle[], deltaSeconds: number): void {
+  if (packet.state === "collected") return;
+
+  const distance = Math.hypot(
+    SILO.x - packet.mesh.position.x,
+    SILO.z - packet.mesh.position.z,
+  );
+  if (distance <= SILO_RADIUS) {
+    packet.state = "collected";
+    packet.mesh.setEnabled(false);
+    return;
+  }
+
+  const direction = energyDirection(packet, obstacles);
+  if (!direction) {
+    packet.blockedSeconds += deltaSeconds;
+    packet.state = "pooling";
+    packet.mesh.scaling.set(1.5, 0.25, 1.5);
+    return;
+  }
+
+  packet.state = "streaming";
+  packet.blockedSeconds = 0;
+  packet.mesh.scaling.set(1.05, 0.42, 1.05);
+  const speed = 8.5;
+  const nextX = packet.mesh.position.x + direction.x * speed * deltaSeconds;
+  const nextZ = packet.mesh.position.z + direction.z * speed * deltaSeconds;
+  if (!pointBlocked(nextX, nextZ, DRAIN_RADIUS, obstacles)) {
+    packet.distanceTravelled += Math.hypot(
+      nextX - packet.mesh.position.x,
+      nextZ - packet.mesh.position.z,
+    );
+    packet.mesh.position.x = nextX;
+    packet.mesh.position.z = nextZ;
+    packet.mesh.position.y = 0.5 + terrainHeight(nextZ);
+  }
+}
+
+function openBroadGate(obstacles: Obstacle[]): void {
+  const gate = obstacles.find((obstacle) => obstacle.id === "broad-gate");
+  if (!gate || gate.health <= 0) return;
+  gate.health = 0;
+  gate.mesh.setEnabled(false);
+}
+
+async function main(): Promise<void> {
+  const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas");
+  const metrics = document.querySelector<HTMLElement>("#metrics");
+  const resetButton = document.querySelector<HTMLButtonElement>("#reset");
+  const energyButton = document.querySelector<HTMLButtonElement>("#energy");
+  const gateButton = document.querySelector<HTMLButtonElement>("#gate");
+  if (!canvas || !metrics || !resetButton || !energyButton || !gateButton) {
+    throw new Error("Surface routing lab DOM is incomplete");
+  }
+
+  const engine = new Engine(canvas, true, { adaptToDeviceRatio: true, antialias: true });
+  const scene = new Scene(engine);
+  scene.clearColor.set(0.02, 0.012, 0.034, 1);
+  const camera = new ArcRotateCamera(
+    "routing-camera",
+    -Math.PI / 2,
+    0.78,
+    132,
+    new Vector3(5, 0, 0),
+    scene,
+  );
+  camera.attachControl(canvas, true);
+  camera.lowerRadiusLimit = 70;
+  camera.upperRadiusLimit = 190;
+
+  const light = new HemisphericLight("routing-light", new Vector3(0.2, 1, 0.1), scene);
+  light.intensity = 0.82;
+
+  createArena(scene);
+  let obstacles = createFortress(scene);
+  let raiders = spawnRaiders(scene);
+  const energyMaterial = createEnergyMaterial(scene);
+  let energyPackets: EnergyPacket[] = [];
+  spawnEnergy(scene, energyPackets, energyMaterial);
+
+  const reset = () => {
+    obstacles.forEach((obstacle) => obstacle.mesh.dispose());
+    raiders.forEach((raider) => raider.mesh.dispose());
+    energyPackets.forEach((packet) => packet.mesh.dispose());
+    obstacles = createFortress(scene);
+    raiders = spawnRaiders(scene);
+    energyPackets = [];
+    spawnEnergy(scene, energyPackets, energyMaterial);
+  };
+
+  resetButton.addEventListener("click", reset);
+  energyButton.addEventListener("click", () => spawnEnergy(scene, energyPackets, energyMaterial));
+  gateButton.addEventListener("click", () => openBroadGate(obstacles));
+  window.addEventListener("keydown", (event) => {
+    if (event.key.toLowerCase() === "r") reset();
+    if (event.key.toLowerCase() === "e") spawnEnergy(scene, energyPackets, energyMaterial);
+    if (event.key.toLowerCase() === "g") openBroadGate(obstacles);
+  });
+
+  engine.runRenderLoop(() => {
+    const deltaSeconds = Math.min(MAX_DT, engine.getDeltaTime() / 1000);
+    raiders.forEach((raider) => updateRaider(raider, obstacles, deltaSeconds));
+    energyPackets.forEach((packet) => updateEnergy(packet, obstacles, deltaSeconds));
+
+    const gate = obstacles.find((obstacle) => obstacle.id === "broad-gate");
+    const pooled = energyPackets.filter((packet) => packet.state === "pooling");
+    const collected = energyPackets.filter((packet) => packet.state === "collected");
+    metrics.textContent = [
+      "Shared surface topology proof of concept",
+      `R1 navigator: ${raiders[0].state} | collisions ${raiders[0].collisions} | path ${raiders[0].distanceTravelled.toFixed(1)}`,
+      `R2 breaker:   ${raiders[1].state} | collisions ${raiders[1].collisions} | path ${raiders[1].distanceTravelled.toFixed(1)}`,
+      `R3 titan:     ${raiders[2].state} | collisions ${raiders[2].collisions} | path ${raiders[2].distanceTravelled.toFixed(1)}`,
+      `broad gate: ${gate && gate.health > 0 ? `${gate.health.toFixed(0)} / ${gate.maxHealth}` : "OPEN / DESTROYED"}`,
+      `energy packets: ${energyPackets.length} | pooled ${pooled.length} | collected ${collected.length}`,
+      `fps: ${engine.getFps().toFixed(1)} | meshes: ${scene.meshes.length}`,
+      "narrow west gap: fluid + R1 only",
+      "R2 may batter breakable gate; R3 favors momentum/direct pressure",
+      "terrain valley biases free flow and raider movement toward lower surface",
+    ].join("\n");
+
+    scene.render();
+  });
+
+  const resize = () => engine.resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener(
+    "beforeunload",
+    () => {
+      window.removeEventListener("resize", resize);
+      engine.stopRenderLoop();
+      scene.dispose();
+      engine.dispose();
+    },
+    { once: true },
+  );
+}
+
+void main();

--- a/experiments/hybrid-engine/vite.config.ts
+++ b/experiments/hybrid-engine/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       input: {
         main: "index.html",
         mothership: "mothership.html",
+        navigation: "navigation.html",
       },
     },
   },

--- a/experiments/hybrid-engine/vite.config.ts
+++ b/experiments/hybrid-engine/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         main: "index.html",
         mothership: "mothership.html",
         navigation: "navigation.html",
+        geothermal: "geothermal.html",
       },
     },
   },

--- a/experiments/hybrid-engine/vite.config.ts
+++ b/experiments/hybrid-engine/vite.config.ts
@@ -8,5 +8,11 @@ export default defineConfig({
   },
   build: {
     target: "es2022",
+    rollupOptions: {
+      input: {
+        main: "index.html",
+        mothership: "mothership.html",
+      },
+    },
   },
 });

--- a/experiments/hybrid-engine/vite.config.ts
+++ b/experiments/hybrid-engine/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         mothership: "mothership.html",
         navigation: "navigation.html",
         geothermal: "geothermal.html",
+        routing: "routing.html",
       },
     },
   },


### PR DESCRIPTION
Refs #86, #76, #82, #72, #80, #83
Supersedes the isolated lab implementation stack #81 → #84 → #85 for integration purposes.

## Consolidation purpose

The local executor runs infrequently. This PR is now intentionally retargeted to `master` so the complete raider/mothership/geothermal/routing laboratory can live in one isolated package and be certified in one install/build/browser campaign.

All changes remain under `experiments/hybrid-engine`; production gameplay and dependencies are untouched.

## Included lab pages

This branch contains the complete inherited experiment stack:

- `mothership.html` — finite mothership reserve, visible degradation, loss of lift, physical fall and persistent hulk;
- `navigation.html` — inertial mothership movement, camera follow, silo attraction/exclusion and three-set R1/R2/R3 raid planner;
- `geothermal.html` — defender geothermal source draw, conduit limits, depletion/migration, pressure and faction-neutral eruption behavior;
- `routing.html` — shared obstacle topology for defender energy drainage and tier-distinct R1/R2/R3 locomotion;
- the existing default Babylon/Bevy hybrid fixture remains unchanged and must continue to work.

## Shared routing child scope

The newest routing slice adds:

- one blocky fortress topology;
- a narrow drainage gap intended for loose energy and R1-sized bodies;
- a broader breakable gate;
- shallow low-terrain/valley preference;
- central silo;
- loose teal-energy aggregates using local obstacle-aware surface steering;
- R1 navigator behavior;
- R2 breaker behavior;
- R3 inertia/direct-pressure behavior;
- live obstacle/gate health and routing diagnostics;
- controls to spawn more energy, open the broad gate, and reset.

Loose teal energy remains obstacle-bound, pools when locally blocked, resumes when topology opens, and never receives obstacle immunity. R1 navigates smaller openings, R2 pressures breakable structure, and R3 preserves the strongest inertia/body-size constraint.

## Scope boundary

This is an **experimental browser laboratory**, not production implementation. It does not change production pathfinding, collision damage, terrain authority, spherical gravity, campaign balance, final fluid rendering, production tower rules, or AI.

## Static integration review

Compared directly with current `master` before retargeting, the full stack changes only ten files under `experiments/hybrid-engine`:

- four new HTML lab entries;
- five new TypeScript prototype modules;
- one additive `vite.config.ts` build-entry update.

No root package/dependency or production `src/js` file changes are present.

## Local certification campaign

Use #92 / `docs/LOCAL_CERTIFICATION.md`. Test this consolidated head once rather than installing/building #81, #84 and #85 separately.

From `experiments/hybrid-engine`:

1. install/use the declared Node/pnpm/Rust/wasm-pack environment;
2. run the full hybrid package typecheck/test/build path;
3. confirm the default `index.html` fixture remains healthy;
4. exercise `mothership.html`: reserve drain, degradation, falling, impact/hulk, both viewpoints;
5. exercise `navigation.html`: inertial targeting, braking/overshoot, silo field, camera comfort, three-set planner including HOLD;
6. exercise `geothermal.html`: T1/T2/T3 proxy draw, conduit reach, local depletion/retreat/re-emergence, pressure/eruption, tower melt and raider displacement;
7. exercise `routing.html`: obstacle-bound energy flow/pooling/release, R1 narrow routing, R2 breakable-gate pressure and R3 inertia/clearance;
8. record console warnings, FPS/frame time, mesh/particle peaks and screenshots/video for representative states;
9. confirm design distinctions remain readable without relying exclusively on debug overlays.

Merging this PR only makes the isolated experiments available on `master`; it does not certify their runtime behavior or promote their calibration values into production design.