### PR TITLE
Add Storybook playgrounds for topology, terrain, and spatial audio

### DIFF
--- a/experiments/storybook/.storybook/main.ts
+++ b/experiments/storybook/.storybook/main.ts
@@ -1,9 +1,28 @@
 import type { StorybookConfig } from "@storybook/html-vite";
 
+const repositoryRoot = decodeURIComponent(new URL("../../..", import.meta.url).pathname);
+const defendSourceRoot = decodeURIComponent(new URL("../../../src/js", import.meta.url).pathname);
+
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(js|ts)"],
   addons: ["@storybook/addon-vitest"],
-  framework: "@storybook/html-vite"
+  framework: "@storybook/html-vite",
+  async viteFinal(viteConfig) {
+    const { mergeConfig } = await import("vite");
+    return mergeConfig(viteConfig, {
+      resolve: {
+        alias: {
+          "@defend": defendSourceRoot
+        }
+      },
+      server: {
+        fs: {
+          strict: true,
+          allow: [repositoryRoot]
+        }
+      }
+    });
+  }
 };
 
 export default config;

--- a/experiments/storybook/README.md
+++ b/experiments/storybook/README.md
@@ -57,7 +57,23 @@ The initial capability story intentionally creates no persistent background work
 
 ## Root-source imports
 
-Do not broadly expose the repository filesystem through Vite. When a story needs a pure root module, add the narrowest explicit Vite allow-list/alias required and document it in the PR. Modules coupled to the historical Webpack runtime should instead receive a dedicated adapter or standalone fixture.
+The lab exposes one explicit alias, `@defend/*`, mapped only to the repository's `src/js/` tree. Use it for renderer-independent modules that are already safe foundations on `master`, for example:
+
+```ts
+import { hexToWorld } from "@defend/gameplay/hexGrid";
+import { terrainImpactProfile } from "@defend/gameplay/terrainDeformation";
+import { spatialRenderHints } from "@defend/audio/spatialAudio";
+```
+
+The Vite filesystem allow-list is limited to the repository root so those explicit imports can resolve; do not turn it into an unrestricted filesystem allow-list. A story importing legacy runtime-coupled modules should receive a dedicated adapter or standalone fixture rather than pulling the historical application graph into Storybook.
+
+The current deterministic domain playgrounds deliberately consume the merged source contracts directly:
+
+- `Foundations/Topology/Hex Grid` inspects canonical cells, rings, protected core cells, and six-sector classification;
+- `Foundations/Physics/Terrain Deformation` visualizes bounded impact profiles and recovery;
+- `Audio/Spatial/Voice Budget` visualizes moving emitters, Doppler/priority hints, renderer tiers, and virtualization without creating an AudioContext.
+
+These stories certify presentation and deterministic fixture behavior only after the local Storybook package itself passes install/typecheck/build/browser tests. They do not promote the underlying calibration values to production gameplay/audio constants.
 
 ## Future workspace integration
 

--- a/experiments/storybook/package.json
+++ b/experiments/storybook/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@storybook/addon-vitest": "10.6.0",
     "@storybook/html-vite": "10.6.0",
+    "@types/node": "24.10.0",
     "@vitest/browser-playwright": "4.1.11",
     "playwright": "1.62.1",
     "storybook": "10.6.0",

--- a/experiments/storybook/src/Audio/Spatial/SpatialVoiceBudget.stories.ts
+++ b/experiments/storybook/src/Audio/Spatial/SpatialVoiceBudget.stories.ts
@@ -7,9 +7,9 @@ import type {
 } from "@defend/audio/spatialAudio";
 import {
   planSpatialVoiceBudget,
+  spatialVoiceHistory,
   type SpatialVoiceBudget,
-  type SpatialVoicePlan,
-  spatialVoiceHistory
+  type SpatialVoicePlan
 } from "@defend/audio/spatialVoiceBudget";
 import { createLabShell } from "../../labTheme";
 
@@ -91,7 +91,7 @@ function sources(count: number, timeSeconds: number): SpatialAudioObjectState[] 
     const radialSpeed = index % 4 === 0 ? -5 : 1.5;
     const radial = { x: Math.cos(angle), z: Math.sin(angle) };
     const tangent = { x: -radial.z, z: radial.x };
-    const base: SpatialAudioObjectState = {
+    const source: SpatialAudioObjectState = {
       id: `emitter-${String(index).padStart(3, "0")}`,
       kind: index % 3 === 0 ? "enemy" : index % 3 === 1 ? "impact" : "fragment",
       acousticProfile: index % 3 === 0 ? "enemy" : index % 3 === 1 ? "ground" : "fragment",
@@ -111,28 +111,10 @@ function sources(count: number, timeSeconds: number): SpatialAudioObjectState[] 
       seed: 100 + index,
       sustained: index % 4 === 0
     };
-    generated.push(movingSource(base, timeSeconds));
+    generated.push(movingSource(source, timeSeconds));
   }
 
   return generated;
-}
-
-function tierClass(plan: SpatialVoicePlan): string {
-  return `voice voice--${plan.tier}`;
-}
-
-function stageMarkup(plans: SpatialVoicePlan[]): string {
-  const scale = 1.65;
-  return plans
-    .map(plan => {
-      const source = plan.id === "flyby-projectile"
-        ? null
-        : undefined;
-      void source;
-      const hints = plan.hints;
-      return `<g data-plan-id="${plan.id}" data-tier="${plan.tier}" data-priority="${plan.priority}"></g>`;
-    })
-    .join("");
 }
 
 function sourceMarkup(source: SpatialAudioObjectState, plan: SpatialVoicePlan): string {
@@ -148,14 +130,19 @@ function sourceMarkup(source: SpatialAudioObjectState, plan: SpatialVoicePlan): 
     : "";
 
   return `
-    <g class="${tierClass(plan)}" data-plan-id="${plan.id}" data-tier="${plan.tier}" data-priority="${plan.priority}">
+    <g class="voice voice--${plan.tier}" data-plan-id="${plan.id}" data-tier="${plan.tier}" data-priority="${plan.priority}">
       ${velocityLine}
       <circle cx="${x}" cy="${y}" r="${radius}" />
     </g>
   `;
 }
 
-function renderPlans(root: HTMLElement, args: SpatialArgs, timeSeconds: number, previous?: SpatialVoicePlan[]): SpatialVoicePlan[] {
+function renderPlans(
+  root: HTMLElement,
+  args: SpatialArgs,
+  timeSeconds: number,
+  previous?: SpatialVoicePlan[]
+): SpatialVoicePlan[] {
   const currentSources = sources(args.emitterCount, timeSeconds);
   const budget: SpatialVoiceBudget = {
     fullVoices: args.fullVoices,
@@ -165,35 +152,32 @@ function renderPlans(root: HTMLElement, args: SpatialArgs, timeSeconds: number, 
   };
   const history = previous ? spatialVoiceHistory(previous) : undefined;
   const plans = planSpatialVoiceBudget(currentSources, listener, calibration, budget, history);
-  const byId = new Map(currentSources.map(source => [source.id, source]));
+  const byId = new Map<string, SpatialAudioObjectState>(
+    currentSources.map(source => [source.id, source] as const)
+  );
   const hero = plans.find(plan => plan.id === "flyby-projectile");
   const stage = root.querySelector<SVGElement>("[data-spatial-stage]");
   const table = root.querySelector<HTMLElement>("[data-voice-table]");
   const heroDoppler = root.querySelector<HTMLElement>("[data-hero-doppler]");
   const heroPriority = root.querySelector<HTMLElement>("[data-hero-priority]");
-  const rendered = plans.filter(plan => plan.tier !== "virtual").length;
   const renderedMetric = root.querySelector<HTMLElement>("[data-rendered-count]");
+  const rendered = plans.filter(plan => plan.tier !== "virtual").length;
 
   if (stage) {
     stage.innerHTML = `
       <circle class="listener-range" cx="0" cy="0" r="${calibration.referenceDistance * 1.65}" />
       <circle class="listener" cx="0" cy="0" r="6" />
-      ${plans
-        .map(plan => {
-          const source = byId.get(plan.id);
-          return source ? sourceMarkup(source, plan) : "";
-        })
-        .join("")}
+      ${plans.map(plan => {
+        const source = byId.get(plan.id);
+        return source ? sourceMarkup(source, plan) : "";
+      }).join("")}
     `;
   }
 
   if (table) {
-    table.innerHTML = plans
-      .slice(0, 10)
-      .map(
-        plan => `<tr><td>${plan.rank + 1}</td><td>${plan.id}</td><td>${plan.tier}</td><td>${plan.priority.toFixed(3)}</td><td>${plan.hints.distance.toFixed(1)}</td></tr>`
-      )
-      .join("");
+    table.innerHTML = plans.slice(0, 10).map(plan =>
+      `<tr><td>${plan.rank + 1}</td><td>${plan.id}</td><td>${plan.tier}</td><td>${plan.priority.toFixed(3)}</td><td>${plan.hints.distance.toFixed(1)}</td></tr>`
+    ).join("");
   }
 
   if (hero && heroDoppler) heroDoppler.textContent = hero.hints.doppler.ratio.toFixed(3);
@@ -267,8 +251,7 @@ const meta = {
     let plans = renderPlans(shell.root, args, 0);
     const advance = shell.root.querySelector<HTMLButtonElement>("[data-advance]");
     advance?.addEventListener("click", () => {
-      const current = Number(advance.dataset.time || "0");
-      const next = current + 0.25;
+      const next = Number(advance.dataset.time || "0") + 0.25;
       plans = renderPlans(shell.root, args, next, plans);
       advance.dataset.time = String(next);
     });
@@ -284,10 +267,13 @@ export const MovingEmitterBudget: Story = {
   play: async ({ canvasElement }) => {
     const advance = canvasElement.querySelector<HTMLButtonElement>("[data-advance]");
     const hero = canvasElement.querySelector<SVGGElement>("[data-plan-id='flyby-projectile']");
+    const rendered = canvasElement.querySelector<HTMLElement>("[data-rendered-count]");
     await expect(advance).not.toBeNull();
     await expect(hero).not.toBeNull();
-    if (!advance || !hero) return;
+    await expect(rendered).not.toBeNull();
+    if (!advance || !hero || !rendered) return;
     await expect(hero.getAttribute("data-tier")).not.toBe("virtual");
+    await expect(rendered).toHaveTextContent("44");
     await userEvent.click(advance);
     await expect(advance).toHaveAttribute("data-time", "0.25");
   }

--- a/experiments/storybook/src/Audio/Spatial/SpatialVoiceBudget.stories.ts
+++ b/experiments/storybook/src/Audio/Spatial/SpatialVoiceBudget.stories.ts
@@ -1,0 +1,294 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect, userEvent } from "storybook/test";
+import type {
+  SpatialAudioCalibration,
+  SpatialAudioObjectState,
+  SpatialListenerState
+} from "@defend/audio/spatialAudio";
+import {
+  planSpatialVoiceBudget,
+  type SpatialVoiceBudget,
+  type SpatialVoicePlan,
+  spatialVoiceHistory
+} from "@defend/audio/spatialVoiceBudget";
+import { createLabShell } from "../../labTheme";
+
+type SpatialArgs = {
+  emitterCount: number;
+  fullVoices: number;
+  standardVoices: number;
+  cheapVoices: number;
+  retention: number;
+};
+
+const listener: SpatialListenerState = {
+  position: { x: 0, y: 0, z: 0 },
+  velocity: { x: 0, y: 0, z: 0 },
+  forward: { x: 0, y: 0, z: 1 },
+  up: { x: 0, y: 1, z: 0 },
+  focusPosition: { x: 0, y: 0, z: 0 }
+};
+
+const calibration: SpatialAudioCalibration = {
+  speedOfSound: 420,
+  maxRadialFractionOfSoundSpeed: 0.75,
+  minDopplerRatio: 0.5,
+  maxDopplerRatio: 2,
+  referenceDistance: 24,
+  rolloffExponent: 1.35,
+  airAbsorptionPerUnit: 0.008,
+  predictionHorizonSeconds: 1.2,
+  energyReference: 1400,
+  proximityWeight: 1,
+  closestApproachWeight: 1.4,
+  energyWeight: 0.8,
+  threatWeight: 1.2,
+  continuityWeight: 0.35
+};
+
+function movingSource(source: SpatialAudioObjectState, timeSeconds: number): SpatialAudioObjectState {
+  return {
+    ...source,
+    position: {
+      x: source.position.x + source.velocity.x * timeSeconds,
+      y: source.position.y + source.velocity.y * timeSeconds,
+      z: source.position.z + source.velocity.z * timeSeconds
+    }
+  };
+}
+
+function sources(count: number, timeSeconds: number): SpatialAudioObjectState[] {
+  const safeCount = Math.max(8, Math.floor(count));
+  const generated: SpatialAudioObjectState[] = [];
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+
+  generated.push(
+    movingSource(
+      {
+        id: "flyby-projectile",
+        kind: "projectile",
+        acousticProfile: "projectile",
+        position: { x: -96, y: 2, z: 18 },
+        velocity: { x: 148, y: 0, z: -5 },
+        orientation: { x: 1, y: 0, z: 0 },
+        directivity: 0.2,
+        radius: 1.4,
+        baseGain: 1,
+        excitationEnergy: 2600,
+        threat: 0.78,
+        continuity: 0.65,
+        seed: 17,
+        sustained: true
+      },
+      timeSeconds
+    )
+  );
+
+  for (let index = 1; index < safeCount; index += 1) {
+    const angle = index * goldenAngle;
+    const distance = 18 + (index % 9) * 10 + Math.floor(index / 9) * 2;
+    const tangentialSpeed = 4 + (index % 5) * 3;
+    const radialSpeed = index % 4 === 0 ? -5 : 1.5;
+    const radial = { x: Math.cos(angle), z: Math.sin(angle) };
+    const tangent = { x: -radial.z, z: radial.x };
+    const base: SpatialAudioObjectState = {
+      id: `emitter-${String(index).padStart(3, "0")}`,
+      kind: index % 3 === 0 ? "enemy" : index % 3 === 1 ? "impact" : "fragment",
+      acousticProfile: index % 3 === 0 ? "enemy" : index % 3 === 1 ? "ground" : "fragment",
+      position: { x: radial.x * distance, y: 0, z: radial.z * distance },
+      velocity: {
+        x: tangent.x * tangentialSpeed + radial.x * radialSpeed,
+        y: 0,
+        z: tangent.z * tangentialSpeed + radial.z * radialSpeed
+      },
+      orientation: { x: tangent.x, y: 0, z: tangent.z },
+      directivity: 0,
+      radius: 1 + (index % 4) * 0.5,
+      baseGain: 0.75,
+      excitationEnergy: 180 + (index % 11) * 130,
+      threat: index % 13 === 0 ? 0.72 : 0.1 + (index % 5) * 0.08,
+      continuity: index % 6 === 0 ? 0.8 : 0.2,
+      seed: 100 + index,
+      sustained: index % 4 === 0
+    };
+    generated.push(movingSource(base, timeSeconds));
+  }
+
+  return generated;
+}
+
+function tierClass(plan: SpatialVoicePlan): string {
+  return `voice voice--${plan.tier}`;
+}
+
+function stageMarkup(plans: SpatialVoicePlan[]): string {
+  const scale = 1.65;
+  return plans
+    .map(plan => {
+      const source = plan.id === "flyby-projectile"
+        ? null
+        : undefined;
+      void source;
+      const hints = plan.hints;
+      return `<g data-plan-id="${plan.id}" data-tier="${plan.tier}" data-priority="${plan.priority}"></g>`;
+    })
+    .join("");
+}
+
+function sourceMarkup(source: SpatialAudioObjectState, plan: SpatialVoicePlan): string {
+  const scale = 1.65;
+  const x = source.position.x * scale;
+  const y = source.position.z * scale;
+  const velocityScale = 0.12;
+  const vx = source.velocity.x * velocityScale;
+  const vy = source.velocity.z * velocityScale;
+  const radius = source.id === "flyby-projectile" ? 6 : 2.5 + plan.priority * 3.5;
+  const velocityLine = plan.tier === "full" || source.id === "flyby-projectile"
+    ? `<line class="voice__velocity" x1="${x}" y1="${y}" x2="${x + vx}" y2="${y + vy}" />`
+    : "";
+
+  return `
+    <g class="${tierClass(plan)}" data-plan-id="${plan.id}" data-tier="${plan.tier}" data-priority="${plan.priority}">
+      ${velocityLine}
+      <circle cx="${x}" cy="${y}" r="${radius}" />
+    </g>
+  `;
+}
+
+function renderPlans(root: HTMLElement, args: SpatialArgs, timeSeconds: number, previous?: SpatialVoicePlan[]): SpatialVoicePlan[] {
+  const currentSources = sources(args.emitterCount, timeSeconds);
+  const budget: SpatialVoiceBudget = {
+    fullVoices: args.fullVoices,
+    standardVoices: args.standardVoices,
+    cheapVoices: args.cheapVoices,
+    activeVoiceRetention: args.retention
+  };
+  const history = previous ? spatialVoiceHistory(previous) : undefined;
+  const plans = planSpatialVoiceBudget(currentSources, listener, calibration, budget, history);
+  const byId = new Map(currentSources.map(source => [source.id, source]));
+  const hero = plans.find(plan => plan.id === "flyby-projectile");
+  const stage = root.querySelector<SVGElement>("[data-spatial-stage]");
+  const table = root.querySelector<HTMLElement>("[data-voice-table]");
+  const heroDoppler = root.querySelector<HTMLElement>("[data-hero-doppler]");
+  const heroPriority = root.querySelector<HTMLElement>("[data-hero-priority]");
+  const rendered = plans.filter(plan => plan.tier !== "virtual").length;
+  const renderedMetric = root.querySelector<HTMLElement>("[data-rendered-count]");
+
+  if (stage) {
+    stage.innerHTML = `
+      <circle class="listener-range" cx="0" cy="0" r="${calibration.referenceDistance * 1.65}" />
+      <circle class="listener" cx="0" cy="0" r="6" />
+      ${plans
+        .map(plan => {
+          const source = byId.get(plan.id);
+          return source ? sourceMarkup(source, plan) : "";
+        })
+        .join("")}
+    `;
+  }
+
+  if (table) {
+    table.innerHTML = plans
+      .slice(0, 10)
+      .map(
+        plan => `<tr><td>${plan.rank + 1}</td><td>${plan.id}</td><td>${plan.tier}</td><td>${plan.priority.toFixed(3)}</td><td>${plan.hints.distance.toFixed(1)}</td></tr>`
+      )
+      .join("");
+  }
+
+  if (hero && heroDoppler) heroDoppler.textContent = hero.hints.doppler.ratio.toFixed(3);
+  if (hero && heroPriority) heroPriority.textContent = hero.priority.toFixed(3);
+  if (renderedMetric) renderedMetric.textContent = String(rendered);
+  return plans;
+}
+
+const meta = {
+  title: "Audio/Spatial/Voice Budget",
+  tags: ["test", "visual"],
+  args: {
+    emitterCount: 64,
+    fullVoices: 8,
+    standardVoices: 16,
+    cheapVoices: 20,
+    retention: 0.05
+  },
+  argTypes: {
+    emitterCount: { control: { type: "range", min: 16, max: 256, step: 8 } },
+    fullVoices: { control: { type: "range", min: 0, max: 32, step: 1 } },
+    standardVoices: { control: { type: "range", min: 0, max: 64, step: 1 } },
+    cheapVoices: { control: { type: "range", min: 0, max: 128, step: 1 } },
+    retention: { control: { type: "range", min: 0, max: 0.25, step: 0.01 } }
+  },
+  render: (args: SpatialArgs) => {
+    const shell = createLabShell(
+      "Audio / spatial",
+      "World-space voice budget",
+      "Inspect how proximity, predicted closest approach, excitation, threat, and continuity rank moving emitters before any renderer maps semantic tiers to HRTF, equal-power panning, modal complexity, or virtualization."
+    );
+
+    shell.frame.innerHTML = `
+      <style>
+        .spatial-stage { background: radial-gradient(circle at center, rgba(173, 97, 26, 0.09), transparent 38%); }
+        .spatial-stage svg { overflow: visible; }
+        .listener-range { fill: none; stroke: rgba(215, 164, 108, 0.2); stroke-dasharray: 4 5; }
+        .listener { fill: #f4edf7; stroke: #1c0530; stroke-width: 2; }
+        .voice circle { vector-effect: non-scaling-stroke; }
+        .voice--full circle { fill: #e4b980; stroke: #f4edf7; stroke-width: 1.2; }
+        .voice--standard circle { fill: rgba(215, 164, 108, 0.72); stroke: rgba(244, 237, 247, 0.6); }
+        .voice--cheap circle { fill: rgba(173, 97, 26, 0.42); stroke: rgba(215, 164, 108, 0.38); }
+        .voice--virtual circle { fill: rgba(244, 237, 247, 0.05); stroke: rgba(244, 237, 247, 0.14); }
+        .voice__velocity { stroke: rgba(228, 185, 128, 0.45); stroke-width: 1; vector-effect: non-scaling-stroke; }
+        .spatial-actions { display: flex; gap: 8px; margin-top: 14px; }
+      </style>
+      <div class="lab__grid">
+        <section class="lab__panel lab__stage spatial-stage">
+          <svg viewBox="-210 -210 420 420" aria-label="Spatial audio emitter priorities" data-spatial-stage></svg>
+        </section>
+        <aside class="lab__panel lab__panel--padded">
+          <h2 class="lab__section-title">Planner state</h2>
+          <dl class="lab__metrics">
+            <div class="lab__metric"><dt>Emitters</dt><dd>${Math.max(8, Math.floor(args.emitterCount))}</dd></div>
+            <div class="lab__metric"><dt>Rendered voices</dt><dd data-rendered-count>0</dd></div>
+            <div class="lab__metric"><dt>Fly-by Doppler</dt><dd data-hero-doppler>1.000</dd></div>
+            <div class="lab__metric"><dt>Fly-by priority</dt><dd data-hero-priority>0.000</dd></div>
+          </dl>
+          <div class="spatial-actions">
+            <button type="button" data-advance data-time="0">Advance 250 ms</button>
+          </div>
+          <h2 class="lab__section-title" style="margin-top:18px">Top voices</h2>
+          <table>
+            <thead><tr><th>#</th><th>Emitter</th><th>Tier</th><th>Priority</th><th>Distance</th></tr></thead>
+            <tbody data-voice-table></tbody>
+          </table>
+        </aside>
+      </div>
+    `;
+
+    let plans = renderPlans(shell.root, args, 0);
+    const advance = shell.root.querySelector<HTMLButtonElement>("[data-advance]");
+    advance?.addEventListener("click", () => {
+      const current = Number(advance.dataset.time || "0");
+      const next = current + 0.25;
+      plans = renderPlans(shell.root, args, next, plans);
+      advance.dataset.time = String(next);
+    });
+
+    return shell.root;
+  }
+} satisfies Meta<SpatialArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MovingEmitterBudget: Story = {
+  play: async ({ canvasElement }) => {
+    const advance = canvasElement.querySelector<HTMLButtonElement>("[data-advance]");
+    const hero = canvasElement.querySelector<SVGGElement>("[data-plan-id='flyby-projectile']");
+    await expect(advance).not.toBeNull();
+    await expect(hero).not.toBeNull();
+    if (!advance || !hero) return;
+    await expect(hero.getAttribute("data-tier")).not.toBe("virtual");
+    await userEvent.click(advance);
+    await expect(advance).toHaveAttribute("data-time", "0.25");
+  }
+};

--- a/experiments/storybook/src/Foundations/Physics/TerrainDeformation.stories.ts
+++ b/experiments/storybook/src/Foundations/Physics/TerrainDeformation.stories.ts
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+  accumulateDepression,
+  radialDeformationDepth,
+  relaxDepression,
+  terrainImpactProfile,
+  type TerrainDeformationCalibration
+} from "@defend/gameplay/terrainDeformation";
+import { createLabShell } from "../../labTheme";
+
+type TerrainArgs = {
+  effectiveMass: number;
+  normalSpeed: number;
+  bodyRadius: number;
+  compliance: number;
+  stabilization: number;
+  maxDepth: number;
+};
+
+function calibration(args: TerrainArgs): TerrainDeformationCalibration {
+  return {
+    maxDepth: args.maxDepth,
+    minFootprintRadius: 6,
+    maxFootprintRadius: 54,
+    energyForMaxDepth: 520000,
+    energyForMaxRadius: 420000,
+    baseRecoveryHalfLifeMs: 5000,
+    minimumRecoveryHalfLifeMs: 1800,
+    diffusionPerSecond: 0.8,
+    maxSupportSpeed: 8
+  };
+}
+
+function crossSectionPath(radius: number, depthAt: (distance: number) => number, maxDepth: number): string {
+  const width = 420;
+  const centerY = 150;
+  const depthScale = maxDepth > 0 ? 82 / maxDepth : 0;
+  const points: string[] = [];
+  const samples = 96;
+  for (let index = 0; index <= samples; index += 1) {
+    const normalized = index / samples;
+    const worldX = (normalized * 2 - 1) * radius;
+    const x = normalized * width - width / 2;
+    const y = centerY + depthAt(Math.abs(worldX)) * depthScale;
+    points.push(`${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`);
+  }
+  return points.join(" ");
+}
+
+const meta = {
+  title: "Foundations/Physics/Terrain Deformation",
+  tags: ["test", "visual"],
+  args: {
+    effectiveMass: 5400,
+    normalSpeed: 12,
+    bodyRadius: 6,
+    compliance: 0.65,
+    stabilization: 0.12,
+    maxDepth: 8
+  },
+  argTypes: {
+    effectiveMass: { control: { type: "range", min: 100, max: 20000, step: 100 } },
+    normalSpeed: { control: { type: "range", min: 0, max: 40, step: 1 } },
+    bodyRadius: { control: { type: "range", min: 1, max: 16, step: 0.5 } },
+    compliance: { control: { type: "range", min: 0, max: 1.5, step: 0.05 } },
+    stabilization: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
+    maxDepth: { control: { type: "range", min: 1, max: 16, step: 0.5 } }
+  },
+  render: (args: TerrainArgs) => {
+    const config = calibration(args);
+    const profile = terrainImpactProfile(
+      {
+        effectiveMass: args.effectiveMass,
+        normalSpeed: args.normalSpeed,
+        bodyRadius: args.bodyRadius,
+        compliance: args.compliance,
+        stabilization: args.stabilization
+      },
+      config
+    );
+    const radius = Math.max(profile.footprintRadius, 1);
+    const rawPath = crossSectionPath(
+      radius,
+      distance => radialDeformationDepth(distance, profile),
+      config.maxDepth
+    );
+    const recoveredCenter = relaxDepression(
+      profile.depth,
+      config.baseRecoveryHalfLifeMs,
+      args.stabilization,
+      config
+    );
+    const recoveryRatio = profile.depth > 0 ? recoveredCenter / profile.depth : 0;
+    const recoveredPath = crossSectionPath(
+      radius,
+      distance => radialDeformationDepth(distance, profile) * recoveryRatio,
+      config.maxDepth
+    );
+    let repeatedDepth = 0;
+    for (let index = 0; index < 8; index += 1) {
+      repeatedDepth = accumulateDepression(repeatedDepth, profile.depth, config.maxDepth);
+    }
+
+    const shell = createLabShell(
+      "Foundations / physics",
+      "Bounded terrain response",
+      "Explore how impact energy, body scale, material compliance, stabilization, recovery, and the hard depth cap shape a self-leveling support field before any live ground mesh is allowed to move."
+    );
+
+    shell.frame.innerHTML = `
+      <style>
+        .terrain-baseline { stroke: rgba(244, 237, 247, 0.18); stroke-width: 1; vector-effect: non-scaling-stroke; }
+        .terrain-profile { fill: none; stroke: #e4b980; stroke-width: 2; vector-effect: non-scaling-stroke; }
+        .terrain-recovered { fill: none; stroke: rgba(215, 164, 108, 0.44); stroke-width: 1.5; stroke-dasharray: 5 4; vector-effect: non-scaling-stroke; }
+        .terrain-impact { fill: #e4b980; opacity: 0.86; }
+        .terrain-label { fill: rgba(244, 237, 247, 0.52); font-size: 11px; }
+        .terrain-stage { background: linear-gradient(to bottom, rgba(173, 97, 26, 0.03), rgba(10, 2, 18, 0.2)); }
+      </style>
+      <div class="lab__grid">
+        <section class="lab__panel lab__stage terrain-stage">
+          <svg viewBox="-240 0 480 280" aria-label="Terrain deformation cross section">
+            <line class="terrain-baseline" x1="-220" y1="150" x2="220" y2="150" />
+            <path class="terrain-recovered" d="${recoveredPath}" />
+            <path class="terrain-profile" d="${rawPath}" />
+            <circle class="terrain-impact" cx="0" cy="132" r="4" />
+            <text class="terrain-label" x="-214" y="34">impact profile</text>
+            <text class="terrain-label" x="-214" y="52">dashed = one recovery half-life later</text>
+          </svg>
+        </section>
+        <aside class="lab__panel lab__panel--padded">
+          <h2 class="lab__section-title">Impact model</h2>
+          <dl class="lab__metrics">
+            <div class="lab__metric"><dt>Energy</dt><dd>${Math.round(profile.energy).toLocaleString()}</dd></div>
+            <div class="lab__metric"><dt>Peak depth</dt><dd data-depth="${profile.depth}">${profile.depth.toFixed(3)}</dd></div>
+            <div class="lab__metric"><dt>Footprint radius</dt><dd>${profile.footprintRadius.toFixed(2)}</dd></div>
+            <div class="lab__metric"><dt>After 1 half-life</dt><dd>${recoveredCenter.toFixed(3)}</dd></div>
+            <div class="lab__metric"><dt>8 repeated impacts</dt><dd data-repeated-depth="${repeatedDepth}">${repeatedDepth.toFixed(3)}</dd></div>
+            <div class="lab__metric"><dt>Hard cap</dt><dd data-max-depth="${config.maxDepth}">${config.maxDepth.toFixed(2)}</dd></div>
+          </dl>
+        </aside>
+      </div>
+    `;
+
+    return shell.root;
+  }
+} satisfies Meta<TerrainArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ImpactResponse: Story = {
+  play: async ({ canvasElement }) => {
+    const depth = canvasElement.querySelector<HTMLElement>("[data-depth]");
+    const repeated = canvasElement.querySelector<HTMLElement>("[data-repeated-depth]");
+    const maximum = canvasElement.querySelector<HTMLElement>("[data-max-depth]");
+    await expect(depth).not.toBeNull();
+    await expect(repeated).not.toBeNull();
+    await expect(maximum).not.toBeNull();
+    if (!depth || !repeated || !maximum) return;
+    const cap = Number(maximum.dataset.maxDepth);
+    await expect(Number(depth.dataset.depth)).toBeLessThanOrEqual(cap);
+    await expect(Number(repeated.dataset.repeatedDepth)).toBeLessThanOrEqual(cap);
+  }
+};

--- a/experiments/storybook/src/Foundations/Topology/HexTopology.stories.ts
+++ b/experiments/storybook/src/Foundations/Topology/HexTopology.stories.ts
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect, userEvent } from "storybook/test";
+import {
+  hexKey,
+  hexRing,
+  hexSector,
+  hexToWorld,
+  isHexProtected,
+  isHexWithinRadius,
+  type HexCell
+} from "@defend/gameplay/hexGrid";
+import { createLabShell } from "../../labTheme";
+
+type HexArgs = {
+  radius: number;
+  protectedRadius: number;
+  size: number;
+  showSectors: boolean;
+};
+
+function cellsWithin(radius: number): HexCell[] {
+  const cells: HexCell[] = [];
+  for (let q = -radius; q <= radius; q += 1) {
+    for (let r = -radius; r <= radius; r += 1) {
+      const cell = { q, r };
+      if (isHexWithinRadius(cell, radius)) {
+        cells.push(cell);
+      }
+    }
+  }
+  return cells;
+}
+
+function polygonPoints(size: number): string {
+  const points: string[] = [];
+  for (let index = 0; index < 6; index += 1) {
+    const angle = ((-90 + index * 60) * Math.PI) / 180;
+    points.push(`${Math.cos(angle) * size},${Math.sin(angle) * size}`);
+  }
+  return points.join(" ");
+}
+
+function cellMarkup(cell: HexCell, args: HexArgs): string {
+  const world = hexToWorld(cell, args.size);
+  const key = hexKey(cell);
+  const ring = hexRing(cell);
+  const sector = hexSector(cell, args.size);
+  const protectedCell = isHexProtected(cell, args.protectedRadius);
+  const sectorClass = args.showSectors && sector >= 0 ? ` hex--sector-${sector}` : "";
+  const protectedClass = protectedCell ? " hex--protected" : "";
+
+  return `
+    <g
+      class="hex${sectorClass}${protectedClass}"
+      transform="translate(${world.x} ${world.z})"
+      role="button"
+      tabindex="0"
+      data-cell="${key}"
+      data-ring="${ring}"
+      data-sector="${sector}"
+      aria-label="Hex ${key}, ring ${ring}, sector ${sector}"
+    >
+      <polygon points="${polygonPoints(args.size * 0.92)}" />
+      ${ring <= 1 ? `<text y="2">${key}</text>` : ""}
+    </g>
+  `;
+}
+
+const meta = {
+  title: "Foundations/Topology/Hex Grid",
+  tags: ["test", "visual"],
+  args: {
+    radius: 5,
+    protectedRadius: 1,
+    size: 18,
+    showSectors: true
+  },
+  argTypes: {
+    radius: { control: { type: "range", min: 2, max: 9, step: 1 } },
+    protectedRadius: { control: { type: "range", min: 0, max: 3, step: 1 } },
+    size: { control: { type: "range", min: 10, max: 28, step: 1 } },
+    showSectors: { control: "boolean" }
+  },
+  render: (args: HexArgs) => {
+    const safeRadius = Math.max(1, Math.floor(args.radius));
+    const cells = cellsWithin(safeRadius);
+    const shell = createLabShell(
+      "Foundations / topology",
+      "Hex topology playground",
+      "The strategic lattice is discrete while physics remains continuous. Select cells to inspect canonical keys, rings, protected-core membership, and deterministic six-sector classification."
+    );
+
+    shell.frame.innerHTML = `
+      <style>
+        .hex polygon {
+          fill: rgba(215, 164, 108, 0.025);
+          stroke: rgba(215, 164, 108, 0.28);
+          stroke-width: 1;
+          vector-effect: non-scaling-stroke;
+          transition: fill 120ms ease, stroke 120ms ease;
+        }
+        .hex:hover polygon, .hex:focus polygon { fill: rgba(215, 164, 108, 0.12); stroke: #e4b980; }
+        .hex--protected polygon { fill: rgba(173, 97, 26, 0.2); stroke: rgba(228, 185, 128, 0.72); }
+        .hex--sector-1 polygon, .hex--sector-4 polygon { stroke-opacity: 0.72; }
+        .hex--sector-2 polygon, .hex--sector-5 polygon { stroke-dasharray: 2 2; }
+        .hex text { fill: rgba(244, 237, 247, 0.6); font-size: 4px; text-anchor: middle; pointer-events: none; }
+        .hex--selected polygon { fill: rgba(228, 185, 128, 0.2); stroke: #f4edf7; stroke-width: 2; }
+        .hex-stage { background: radial-gradient(circle at center, rgba(173, 97, 26, 0.08), transparent 42%); }
+      </style>
+      <div class="lab__grid">
+        <section class="lab__panel lab__stage hex-stage">
+          <svg viewBox="-190 -170 380 340" aria-label="Interactive hex topology" data-hex-grid>
+            ${cells.map(cell => cellMarkup(cell, { ...args, radius: safeRadius })).join("")}
+          </svg>
+        </section>
+        <aside class="lab__panel lab__panel--padded">
+          <h2 class="lab__section-title">Topology state</h2>
+          <dl class="lab__metrics">
+            <div class="lab__metric"><dt>Cells</dt><dd>${cells.length}</dd></div>
+            <div class="lab__metric"><dt>Arena radius</dt><dd>${safeRadius}</dd></div>
+            <div class="lab__metric"><dt>Protected radius</dt><dd>${Math.max(0, Math.floor(args.protectedRadius))}</dd></div>
+            <div class="lab__metric"><dt>Orientation</dt><dd>pointy</dd></div>
+          </dl>
+          <h2 class="lab__section-title" style="margin-top:18px">Selected cell</h2>
+          <dl class="lab__metrics" data-selection>
+            <div class="lab__metric"><dt>Key</dt><dd data-selected-key>0,0</dd></div>
+            <div class="lab__metric"><dt>Ring</dt><dd data-selected-ring>0</dd></div>
+            <div class="lab__metric"><dt>Sector</dt><dd data-selected-sector>-1</dd></div>
+          </dl>
+        </aside>
+      </div>
+    `;
+
+    const selectionKey = shell.root.querySelector<HTMLElement>("[data-selected-key]");
+    const selectionRing = shell.root.querySelector<HTMLElement>("[data-selected-ring]");
+    const selectionSector = shell.root.querySelector<HTMLElement>("[data-selected-sector]");
+    const hexes = Array.from(shell.root.querySelectorAll<SVGGElement>("[data-cell]"));
+
+    const selectHex = (hex: SVGGElement): void => {
+      hexes.forEach(candidate => candidate.classList.remove("hex--selected"));
+      hex.classList.add("hex--selected");
+      if (selectionKey) selectionKey.textContent = hex.dataset.cell || "";
+      if (selectionRing) selectionRing.textContent = hex.dataset.ring || "";
+      if (selectionSector) selectionSector.textContent = hex.dataset.sector || "";
+    };
+
+    hexes.forEach(hex => {
+      hex.addEventListener("click", () => selectHex(hex));
+      hex.addEventListener("keydown", event => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          selectHex(hex);
+        }
+      });
+    });
+
+    const center = shell.root.querySelector<SVGGElement>("[data-cell='0,0']");
+    if (center) selectHex(center);
+
+    return shell.root;
+  }
+} satisfies Meta<HexArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractiveTopology: Story = {
+  play: async ({ canvasElement }) => {
+    const east = canvasElement.querySelector<SVGGElement>("[data-cell='1,0']");
+    const selected = canvasElement.querySelector<HTMLElement>("[data-selected-key]");
+    await expect(east).not.toBeNull();
+    await expect(selected).not.toBeNull();
+    if (!east || !selected) return;
+    await userEvent.click(east);
+    await expect(selected).toHaveTextContent("1,0");
+    await expect(east).toHaveAttribute("data-sector", "0");
+  }
+};

--- a/experiments/storybook/src/labTheme.ts
+++ b/experiments/storybook/src/labTheme.ts
@@ -1,0 +1,114 @@
+import type { Meta } from "@storybook/html-vite";
+
+export const labBaseCss = `
+  .lab {
+    min-height: 100vh;
+    box-sizing: border-box;
+    padding: clamp(20px, 4vw, 56px);
+    color: #f4edf7;
+    background:
+      radial-gradient(circle at 50% 28%, rgba(173, 97, 26, 0.12), transparent 32%),
+      #1c0530;
+    font: 14px/1.45 system-ui, sans-serif;
+  }
+  .lab * { box-sizing: border-box; }
+  .lab__frame { width: min(1120px, 100%); margin: 0 auto; }
+  .lab__eyebrow {
+    margin: 0 0 8px;
+    color: #d7a46c;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 11px;
+  }
+  .lab h1 {
+    margin: 0;
+    font-size: clamp(26px, 4vw, 48px);
+    font-weight: 560;
+    letter-spacing: -0.035em;
+  }
+  .lab__intro {
+    max-width: 760px;
+    margin: 12px 0 24px;
+    color: rgba(244, 237, 247, 0.68);
+    font-size: 15px;
+  }
+  .lab__grid { display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 18px; }
+  .lab__panel {
+    min-width: 0;
+    border: 1px solid rgba(215, 164, 108, 0.18);
+    background: rgba(10, 2, 18, 0.38);
+  }
+  .lab__panel--padded { padding: 16px; }
+  .lab__stage { min-height: 480px; display: grid; place-items: center; overflow: hidden; }
+  .lab__stage svg { width: 100%; height: min(68vh, 660px); display: block; }
+  .lab__metrics { display: grid; gap: 1px; margin: 0; background: rgba(215, 164, 108, 0.12); }
+  .lab__metric {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 12px;
+    padding: 10px 12px;
+    background: rgba(18, 4, 31, 0.94);
+  }
+  .lab__metric dt { color: rgba(244, 237, 247, 0.58); }
+  .lab__metric dd { margin: 0; color: #e4b980; font-variant-numeric: tabular-nums; }
+  .lab__section-title {
+    margin: 0 0 10px;
+    color: rgba(244, 237, 247, 0.82);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+  }
+  .lab button {
+    appearance: none;
+    border: 1px solid rgba(215, 164, 108, 0.42);
+    border-radius: 0;
+    padding: 9px 12px;
+    color: #f4edf7;
+    background: rgba(173, 97, 26, 0.12);
+    font: inherit;
+    cursor: pointer;
+  }
+  .lab button:hover { background: rgba(173, 97, 26, 0.2); }
+  .lab button:focus-visible,
+  .lab [role="button"]:focus-visible {
+    outline: 2px solid #e4b980;
+    outline-offset: 3px;
+  }
+  .lab table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .lab th, .lab td { padding: 7px 8px; border-bottom: 1px solid rgba(215, 164, 108, 0.1); text-align: left; }
+  .lab th { color: rgba(244, 237, 247, 0.48); font-weight: 500; }
+  .lab td { color: rgba(244, 237, 247, 0.78); font-variant-numeric: tabular-nums; }
+  @media (max-width: 780px) {
+    .lab__grid { grid-template-columns: 1fr; }
+    .lab__stage { min-height: 360px; }
+    .lab__stage svg { height: min(58vh, 520px); }
+  }
+`;
+
+type LabShell = {
+  root: HTMLElement;
+  frame: HTMLElement;
+};
+
+export function createLabShell(eyebrow: string, title: string, intro: string): LabShell {
+  const root = document.createElement("main");
+  root.className = "lab";
+  root.innerHTML = `
+    <style>${labBaseCss}</style>
+    <section class="lab__frame">
+      <p class="lab__eyebrow">${eyebrow}</p>
+      <h1>${title}</h1>
+      <p class="lab__intro">${intro}</p>
+      <div data-lab-content></div>
+    </section>
+  `;
+
+  const frame = root.querySelector<HTMLElement>("[data-lab-content]");
+  if (!frame) {
+    throw new Error("Defend lab shell failed to create its content frame");
+  }
+
+  return { root, frame };
+}
+
+export type LabMeta<TArgs extends Record<string, unknown>> = Meta<TArgs>;

--- a/experiments/storybook/tsconfig.json
+++ b/experiments/storybook/tsconfig.json
@@ -4,6 +4,10 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "baseUrl": ".",
+    "paths": {
+      "@defend/*": ["../../src/js/*"]
+    },
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true

--- a/experiments/storybook/tsconfig.json
+++ b/experiments/storybook/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
     "baseUrl": ".",
     "paths": {
       "@defend/*": ["../../src/js/*"]

--- a/experiments/storybook/vite.config.ts
+++ b/experiments/storybook/vite.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from "vite";
 
+const repositoryRoot = decodeURIComponent(new URL("../..", import.meta.url).pathname);
+const defendSourceRoot = decodeURIComponent(new URL("../../src/js", import.meta.url).pathname);
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@defend": defendSourceRoot
+    }
+  },
   server: {
     fs: {
-      strict: true
+      strict: true,
+      allow: [repositoryRoot]
     }
   }
 });


### PR DESCRIPTION
Refs #64
Related: #56, #58, #60, #63, #66

## Scope

Extend the already-isolated `experiments/storybook/` lab with deterministic playgrounds that consume the merged pure contracts on `master`. No production imports, gameplay wiring, Web Audio runtime, physics engine, or legacy root build changes.

## Added playgrounds

- `Foundations/Topology/Hex Grid`
  - renders the actual `hexGrid.ts` pointy-top axial topology;
  - exposes radius, protected-core radius, scale, and sector visibility controls;
  - supports pointer + keyboard cell selection;
  - displays canonical key/ring/sector state;
  - includes a deterministic interaction assertion for the east cell / sector 0 contract.

- `Foundations/Physics/Terrain Deformation`
  - renders the actual `terrainDeformation.ts` impact profile as a cross-section;
  - exposes mass, normal speed, body radius, compliance, stabilization, and hard depth cap;
  - compares the immediate profile with one recovery half-life later;
  - displays repeated-impact saturation;
  - asserts immediate and repeated depths remain within the configured hard cap.

- `Audio/Spatial/Voice Budget`
  - consumes `spatialAudio.ts` + `spatialVoiceBudget.ts` directly;
  - renders deterministic world-space emitters around a static listener;
  - includes a fast projectile fly-by with velocity visualization;
  - displays semantic `full / standard / cheap / virtual` tiers, Doppler and priority hints;
  - exposes emitter count and tier budgets up to a 256-emitter fixture;
  - advances the scene in explicit 250 ms steps with bounded history/hysteresis and no RAF/audio context.

## Root-source boundary

The lab now has an explicit `@defend/*` alias to `src/js/*`, represented in both Vite and TypeScript configuration. Storybook's `viteFinal` also reinforces the repository-root filesystem allow-list because Storybook's Vite builder sets a strict config-directory root.

This remains a narrow source boundary, not an unrestricted filesystem allowance.

`@types/node@24.10.0` is added directly because the Storybook/Vitest configuration already imports `node:path` / `node:url` and the lab targets Node 24.20 LTS.

## Shared presentation

A small `labTheme.ts` provides the common dark-violet / copper Defend presentation shell, metrics, focus behavior, tables and responsive layout so later playgrounds do not copy large style blocks.

The visual language stays restrained and semantic: opacity, stroke treatment, and the existing copper/brass family distinguish states rather than rainbow frequency/category coloring.

## Research check

Current Storybook Vite guidance says project Vite configuration is automatically merged, but specifically recommends `viteFinal` when overriding strict filesystem/root behavior. This PR uses both the ordinary Vite config (also consumed by Vitest) and `viteFinal` (Storybook builder) so they agree on the same alias/allow-list.

Reference: https://storybook.js.org/docs/builders/vite

## Required local certification before treating the lab as operational

From `experiments/storybook/`:

1. `pnpm install` and inspect/commit the generated `pnpm-lock.yaml` if coherent;
2. `pnpm exec playwright install chromium` if needed;
3. `pnpm typecheck`;
4. `pnpm build`;
5. `pnpm test` and confirm the capability + three new deterministic stories pass;
6. open each story and exercise Storybook controls;
7. confirm source imports resolve only through the explicit `@defend/*` boundary;
8. confirm the hex story remains interactive by pointer and keyboard;
9. confirm terrain metrics remain finite at control extremes;
10. confirm the 256-emitter spatial fixture remains responsive and does not create audio/worker/background resources;
11. inspect browser console for Vite/Storybook warnings and root-source resolution problems;
12. verify install/build/test leaves the legacy root dependency graph untouched.

## Production impact

None. This is an isolated experimental/browser-test surface. Story results may inform later production PRs, but no calibration or presentation behavior is promoted merely by merging this lab.