### PR TITLE
certification: batch behavior-preserving gameplay seams

### DIFF
--- a/src/js/enemy/Enemy.ts
+++ b/src/js/enemy/Enemy.ts
@@ -16,6 +16,7 @@ import {
 	economyGlobals
 } from "../main/globalVariables";
 import positionGenerator from "../utility/positionGenerator";
+import { enemyDiameter } from "../gameplay/enemyScaling";
 
 interface Position2D {
 	x: number;
@@ -26,7 +27,7 @@ class Enemy {
 	constructor(level: number, position: Position2D, scene: Scene) {
 		const name = `enemyLevel${level}Index${enemyGlobals.index}` as string;
 		enemyGlobals.index += 1;
-		const diameter = (level * level + 5) as number;
+		const diameter = enemyDiameter(level);
 		const sphereMesh = MeshBuilder.CreateIcoSphere(
 			name,
 			{

--- a/src/js/enemy/checkHitPoints.ts
+++ b/src/js/enemy/checkHitPoints.ts
@@ -3,6 +3,10 @@ import { enemyGlobals } from "../main/globalVariables";
 import { fragment } from "./Enemy";
 import { destroyEnemy } from "./destroyEnemy";
 import { EnemySphere } from "./enemyBorn";
+import {
+	decayEnemyHitPoints,
+	enemyHealthMeterScale
+} from "../gameplay/enemyLifecycle";
 
 function checkHitPoints(
 	scene: Scene,
@@ -30,9 +34,15 @@ function checkHitPoints(
 
 		destroyEnemy(sphereMesh, scene, level);
 	} else {
-		sphereMesh.hitPoints -= enemyGlobals.decayRate;
-		const scaleRate =
-      1 / ((level * level * enemyGlobals.baseHitPoints) / (sphereMesh.hitPoints));
+		sphereMesh.hitPoints = decayEnemyHitPoints(
+			sphereMesh.hitPoints,
+			enemyGlobals.decayRate
+		);
+		const scaleRate = enemyHealthMeterScale(
+			sphereMesh.hitPoints,
+			enemyGlobals.baseHitPoints,
+			level
+		);
 
 		hitPointsMeter.scaling = new BABYLON.Vector3(
 			scaleRate,

--- a/src/js/enemy/currencyCollide.ts
+++ b/src/js/enemy/currencyCollide.ts
@@ -2,6 +2,7 @@ import { currencyMeshColor } from "./currencyMeshColor";
 
 import { economyGlobals } from "../main/globalVariables";
 import { damageCurrency } from "../main/sound";
+import { applyEnemyBankDamage } from "../gameplay/economy";
 import { EnemySphere } from "./enemyBorn";
 import { Vector3, Scene } from "babylonjs";
 import { fragment } from "./Enemy";
@@ -24,7 +25,10 @@ function currencyCollide(enemy: EnemySphere, scene: Scene, level: number) {
 				) {
 					// color
 					currencyMeshColor();
-					economyGlobals.currentBalance -= enemy.hitPoints / 2;
+					economyGlobals.currentBalance = applyEnemyBankDamage(
+						economyGlobals.currentBalance,
+						enemy.hitPoints
+					);
 
 					if (
 						enemy.physicsImpostor !== null

--- a/src/js/enemy/enemyAi.ts
+++ b/src/js/enemy/enemyAi.ts
@@ -2,11 +2,15 @@ import { Vector3 } from "babylonjs";
 import randomNumberRange from "../utility/randomNumberRange";
 import { enemyGlobals } from "../main/globalVariables";
 import { EnemySphere } from "./enemyBorn";
+import {
+	enemyDiameter,
+	enemyMoveImpulse
+} from "../gameplay/enemyScaling";
 
 function vector(enemy: EnemySphere, direction: string = "", level: number) {
 	if (enemy.physicsImpostor !== null) {
-		const speed = enemyGlobals.speed * level * level;
-		const radius = (level * level + 5) / 2;
+		const speed = enemyMoveImpulse(enemyGlobals.speed, level);
+		const radius = enemyDiameter(level) / 2;
 
 		switch (direction) {
 			case "down":

--- a/src/js/enemy/enemyBorn.ts
+++ b/src/js/enemy/enemyBorn.ts
@@ -10,6 +10,11 @@ import { Position2D } from "./Enemy";
 import { decide } from "./decide";
 import { checkHitPoints } from "./checkHitPoints";
 import randomNumberRange from "../utility/randomNumberRange";
+import {
+	enemyHitPoints,
+	enemyMass,
+	enemyRestitution
+} from "../gameplay/enemyScaling";
 
 interface EnemySphere extends Mesh {
 	hitPoints: number;
@@ -22,9 +27,9 @@ function enemyBorn (
 	diameter: number,
 	level: number = 1 | 2 | 3
 ) {
-	const enemyMass = (enemyGlobals.mass * level * level) as number;
+	const mass = enemyMass(enemyGlobals.mass, level);
 
-	sphereMesh.hitPoints = level * level * enemyGlobals.baseHitPoints + level * 440;
+	sphereMesh.hitPoints = enemyHitPoints(enemyGlobals.baseHitPoints, level);
 
 	const hitPointsMeter = MeshBuilder.CreateIcoSphere(
 		name + "hitPointMeter",
@@ -46,8 +51,8 @@ function enemyBorn (
 		sphereMesh,
 		PhysicsImpostor.SphereImpostor,
 		{
-			mass: enemyMass,
-			restitution: enemyGlobals.restitution - (level * level) / 10,
+			mass,
+			restitution: enemyRestitution(enemyGlobals.restitution, level),
 			friction: enemyGlobals.friction
 		},
 		scene

--- a/src/js/gameplay/economy.ts
+++ b/src/js/gameplay/economy.ts
@@ -1,0 +1,37 @@
+function projectileEnergyRecovery(
+	projectileHitPoints: number,
+	energyRecoveryRatio: number
+): number {
+	return projectileHitPoints * energyRecoveryRatio;
+}
+
+function applyProjectileEnergyRecovery(
+	currentBalance: number,
+	projectileHitPoints: number,
+	energyRecoveryRatio: number,
+	maxBalance: number
+): number {
+	const recoveredBalance =
+		currentBalance +
+		projectileEnergyRecovery(projectileHitPoints, energyRecoveryRatio);
+
+	return recoveredBalance > maxBalance ? maxBalance : recoveredBalance;
+}
+
+function enemyBankDamage(enemyHitPoints: number): number {
+	return enemyHitPoints / 2;
+}
+
+function applyEnemyBankDamage(
+	currentBalance: number,
+	enemyHitPoints: number
+): number {
+	return currentBalance - enemyBankDamage(enemyHitPoints);
+}
+
+export {
+	projectileEnergyRecovery,
+	applyProjectileEnergyRecovery,
+	enemyBankDamage,
+	applyEnemyBankDamage
+};

--- a/src/js/gameplay/enemyLifecycle.ts
+++ b/src/js/gameplay/enemyLifecycle.ts
@@ -1,0 +1,17 @@
+// Pure finite-lifetime calculations extracted from the legacy enemy loop.
+// Preserve the current arithmetic exactly so runtime modernization can compare
+// behavior without depending on Babylon meshes or render callbacks.
+
+function decayEnemyHitPoints(hitPoints: number, decayRate: number): number {
+	return hitPoints - decayRate;
+}
+
+function enemyHealthMeterScale(
+	hitPoints: number,
+	baseHitPoints: number,
+	level: number
+): number {
+	return 1 / ((level * level * baseHitPoints) / hitPoints);
+}
+
+export { decayEnemyHitPoints, enemyHealthMeterScale };

--- a/src/js/gameplay/enemyScaling.ts
+++ b/src/js/gameplay/enemyScaling.ts
@@ -1,0 +1,35 @@
+// Pure enemy tier-scaling rules extracted from the legacy Babylon/Cannon call sites.
+// These intentionally preserve the current arithmetic, including restitution values
+// that can become negative, so physics migration can compare behavior explicitly.
+
+function levelSquared(level: number): number {
+	return level * level;
+}
+
+function enemyDiameter(level: number): number {
+	return levelSquared(level) + 5;
+}
+
+function enemyHitPoints(baseHitPoints: number, level: number): number {
+	return levelSquared(level) * baseHitPoints + level * 440;
+}
+
+function enemyMass(baseMass: number, level: number): number {
+	return baseMass * levelSquared(level);
+}
+
+function enemyMoveImpulse(baseSpeed: number, level: number): number {
+	return baseSpeed * levelSquared(level);
+}
+
+function enemyRestitution(baseRestitution: number, level: number): number {
+	return baseRestitution - levelSquared(level) / 10;
+}
+
+export {
+	enemyDiameter,
+	enemyHitPoints,
+	enemyMass,
+	enemyMoveImpulse,
+	enemyRestitution
+};

--- a/src/js/gameplay/tierScaling.ts
+++ b/src/js/gameplay/tierScaling.ts
@@ -1,0 +1,34 @@
+// Pure tier-scaling rules extracted from the legacy Babylon/Cannon call sites.
+// Keep these calculations engine-independent so modernization can certify balance
+// without coupling tests to rendering or physics APIs.
+
+function levelSquared(level: number): number {
+	return level * level;
+}
+
+function levelCubed(level: number): number {
+	return level * level * level;
+}
+
+function projectileHitPoints(baseHitPoints: number, level: number): number {
+	return baseHitPoints * levelCubed(level);
+}
+
+function projectileImpulse(baseSpeed: number, level: number): number {
+	return baseSpeed * levelCubed(level);
+}
+
+function projectileMass(baseMass: number, level: number): number {
+	return baseMass * levelSquared(level);
+}
+
+function towerShotInterval(baseRateOfFire: number, level: number): number {
+	return baseRateOfFire * levelCubed(level);
+}
+
+export {
+	projectileHitPoints,
+	projectileImpulse,
+	projectileMass,
+	towerShotInterval
+};

--- a/src/js/projectile/Projectile.ts
+++ b/src/js/projectile/Projectile.ts
@@ -4,6 +4,10 @@ import { Scene, Vector3, PhysicsEngine } from "babylonjs";
 import { projectileGlobals } from "../main/globalVariables";
 import { EnemySphere } from "../enemy/enemyBorn";
 import { TowerTurret } from "../tower/towerBorn";
+import {
+	projectileHitPoints,
+	projectileImpulse
+} from "../gameplay/tierScaling";
 
 class Projectile {
 	constructor(
@@ -34,7 +38,10 @@ class Projectile {
 		}
 		if (projectile !== undefined) {
 
-			projectile.hitPoints = level * level * level * projectileGlobals.baseHitPoints;
+			projectile.hitPoints = projectileHitPoints(
+				projectileGlobals.baseHitPoints,
+				level
+			);
 
 			startLife(
 				scene,
@@ -58,7 +65,7 @@ export function impulsePhys (
 	const forwardLocal = new Vector3(
 		0,
 		0,
-		projectileGlobals.speed * (level * level * level) * -1
+		projectileImpulse(projectileGlobals.speed, level) * -1
 	) as Vector3;
 	const speed = originMesh.getDirection(forwardLocal) as Vector3;
 		if (projectile.physicsImpostor !== null) {

--- a/src/js/projectile/hitEffect.ts
+++ b/src/js/projectile/hitEffect.ts
@@ -1,6 +1,7 @@
 import { economyGlobals, materialGlobals } from "../main/globalVariables";
 import { damage } from "../main/sound";
 import { EnemySphere } from "../enemy/enemyBorn";
+import { applyProjectileEnergyRecovery } from "../gameplay/economy";
 import { LiveProjectileInstance } from "./startLife";
 
 export function hitEffect(
@@ -28,12 +29,12 @@ export function hitEffect(
 				) {
 					// hitpoints
 					enemy.hitPoints -= projectile.hitPoints;
-					economyGlobals.currentBalance +=
-						projectile.hitPoints * economyGlobals.energyRecoveryRatio;
-
-					if (economyGlobals.currentBalance > economyGlobals.maxBalance) {
-						economyGlobals.currentBalance = economyGlobals.maxBalance;
-					}
+					economyGlobals.currentBalance = applyProjectileEnergyRecovery(
+						economyGlobals.currentBalance,
+						projectile.hitPoints,
+						economyGlobals.energyRecoveryRatio,
+						economyGlobals.maxBalance
+					);
 				}
 				if (enemy.material === materialGlobals.hitMaterial) {
 					// color

--- a/src/js/projectile/startLife.ts
+++ b/src/js/projectile/startLife.ts
@@ -13,6 +13,7 @@ import { impulsePhys } from "./Projectile";
 import { destroyOnCollide } from "./destroyOnCollide";
 import { EnemySphere } from "../enemy/enemyBorn";
 import { TowerTurret } from "../tower/towerBorn";
+import { projectileMass } from "../gameplay/tierScaling";
 
 interface LiveProjectile extends Mesh {
 	hitPoints: number;
@@ -41,7 +42,7 @@ export function startLife (
 		projectile,
 		PhysicsImpostor.BoxImpostor,
 		{
-			mass: projectileGlobals.mass * (level * level),
+			mass: projectileMass(projectileGlobals.mass, level),
 			restitution: 0.3,
 			friction: 0.4
 		},

--- a/src/js/tower/Tower.ts
+++ b/src/js/tower/Tower.ts
@@ -13,6 +13,10 @@ import { towerGlobals, projectileGlobals } from "../main/globalVariables";
 import { Position2D } from "../enemy/Enemy";
 import { EnemySphere } from "../enemy/enemyBorn";
 
+interface TowerMetadata {
+	level: number;
+}
+
 class Tower {
 	constructor(
 		level: number = 1 | 2 | 3,
@@ -25,6 +29,7 @@ class Tower {
 		let tower = towerGlobals.towerBaseMesh.clone(
 			name, undefined, true, false
 		) as Mesh;
+		tower.metadata = { level } as TowerMetadata;
 
 		tower.physicsImpostor = new PhysicsImpostor(
 			tower,
@@ -39,6 +44,10 @@ class Tower {
 		addTower(tower, level);
 		towerGlobals.allPositions = towerBasePositions(scene);
 	}
+}
+
+function towerLevel(tower: Mesh): number {
+	return (tower.metadata as TowerMetadata).level;
 }
 
 function towerBasePositions(scene: Scene) {
@@ -146,6 +155,7 @@ export {
 	Tower,
 	destroyTower,
 	towerBasePositions,
+	towerLevel,
 	shotClearsTower,
 	rotateTurret
 };

--- a/src/js/tower/trackSpheres.ts
+++ b/src/js/tower/trackSpheres.ts
@@ -5,6 +5,7 @@ import { rotateTurret } from "./Tower";
 import { shoot } from "../main/sound";
 import { TowerTurret } from "./towerBorn";
 import { EnemySphere } from "../enemy/enemyBorn";
+import { towerShotInterval } from "../gameplay/tierScaling";
 
 function trackSpheres (
 	scene: Scene,
@@ -47,7 +48,7 @@ function trackSpheres (
 					level
 				) as Vector3; // track the enemy spheres
 				if (
-					now - deltaTime > towerGlobals.rateOfFire * level * level * level &&
+					now - deltaTime > towerShotInterval(towerGlobals.rateOfFire, level) &&
 					towerGlobals.shoot
 					//  &&           shotClearsTower(scene, ray, nearestEnemy)
 				) {

--- a/src/js/tower/upgradeTower.ts
+++ b/src/js/tower/upgradeTower.ts
@@ -11,7 +11,7 @@ import {
 	towerGlobals,
 	economyGlobals,
 } from "../main/globalVariables";
-import { towerBasePositions, Tower } from "./Tower";
+import { towerBasePositions, towerLevel, Tower } from "./Tower";
 import { removeTower } from "../main/sound";
 import { currencyMeshColor } from "../enemy/currencyMeshColor";
 import { createBaseInstance } from "./indicatorInstance";
@@ -19,17 +19,14 @@ import { createBaseInstance } from "./indicatorInstance";
 function upgradeTower(scene: Scene, physicsEngine: PhysicsEngine) {
 	//When pointer tap event is raised
 	scene.onPointerObservable.add(function (evt: PointerInfo) {
-		let currentLevel = 0;
 		const pickResult = evt.pickInfo as PickingInfo;
-		if (pickResult.pickedMesh !== null) {
-			currentLevel = parseInt(pickResult.pickedMesh.name[10]);
-		}
 		if (
 			pickResult.hit &&
 			pickResult.pickedMesh !== null &&
 			Tags.MatchesQuery(pickResult.pickedMesh, "towerBase") &&
 			pickResult.pickedMesh.name !== "ground"
 		) {
+			const currentLevel = towerLevel(pickResult.pickedMesh);
 			const samePosition = {
 				x: pickResult.pickedMesh.position.x,
 				z: pickResult.pickedMesh.position.z


### PR DESCRIPTION
Refs #30, #32, #92
Supersedes #36, #43, #45, #46 and #51 **for local certification only**. Keep those original PRs open as provenance until this batch is certified/merged or abandoned.

## Why this batch exists

The local executor runs infrequently. The five remaining behavior-preserving gameplay PRs are mechanically independent but each otherwise requires a separate checkout/build/browser session. This PR assembles their exact reviewed file blobs on top of current `master` so one exact SHA can certify all five ownership boundaries and their interactions in one runtime campaign.

This is intentionally a certification/integration candidate, not a new design change.

## Base and provenance

Base at assembly: `master` `9c5eaa9d93a7037b55e858f4ea14f8eace67f2fa`.

Source heads:

- #36 economy parity: `557dba7285d4d5152f3837db9ad11db2f0f295ba`;
- #43 tower metadata: `4040113d45e8070e36c81dcaee088fc9d400df27`;
- #45 projectile/turret scaling: `01beca0489f4c68a671794d36ab55bd6c43a5b8e`;
- #46 enemy scaling: `afc93016c70d64491729934b3dbef096bbb75a4b`;
- #51 enemy lifecycle/health meter: `22719a31fdaa156862dc4a3defc274da4fe5a6d9`.

Before assembly, GitHub commit comparisons confirmed that none of the 15 target files had independently changed on `master` since the corresponding source PR baseline. The five PR file sets are mutually disjoint. The batch therefore uses the exact source-branch blobs without hand-written conflict resolution.

## Included ownership boundaries

### Economy — from #36

- `src/js/gameplay/economy.ts`;
- projectile hit recovery routed through the pure recovery/cap formula;
- bank collision damage routed through remaining-enemy-HP / 2.

No collision registration or balance change is intended.

### Tower identity — from #43

- explicit `{ level }` metadata on tower bases;
- pointer upgrade reads metadata rather than parsing a character from the mesh name.

Upgrade cost and current level-3 behavior are intentionally preserved for characterization.

### Projectile/turret scaling — from #45

- pure projectile HP / impulse / mass / shot-interval helpers;
- live call sites route through those helpers with unchanged level²/level³ arithmetic.

### Enemy scaling — from #46

- pure enemy diameter / HP / mass / movement impulse / restitution helpers;
- live spawn and movement call sites use those helpers;
- current negative restitution values remain intentionally preserved for Cannon characterization.

### Enemy finite lifetime — from #51

- pure decay and health-meter helpers;
- live decay remains 20 HP per eligible decision check with the same ordering;
- legacy health-meter expression remains unclamped and may exceed 1.0 initially.

## Aggregate diff

Exactly 15 files relative to the assembly base:

- 4 new pure gameplay modules;
- 11 narrow live call-site modifications;
- no package/dependency/tooling changes;
- no rendering/audio/wave scheduler/new gameplay-system changes.

## Preferred local certification workflow

Follow `docs/LOCAL_CERTIFICATION.md` and #92. Use the dedicated certification clone and detach at this exact head.

### Build/static gate

1. record environment + `git status --short`;
2. install the historical root dependency graph without modifying unrelated tracked files;
3. run `npm run lint` and confirm it is non-mutating;
4. run `npm run build` and confirm the one-shot production build terminates;
5. capture exact commands and exit codes.

### One coherent browser/runtime session

Exercise all five contracts in one run where practical:

#### Economy
- projectile hit reduces enemy HP and recovers exactly projectile HP × 0.14;
- recovery caps at 30000;
- surviving enemy bank collision subtracts remaining HP / 2 and may cross below zero.

#### Tower identity
- place L1 and upgrade 1→2 and 2→3;
- costs charged once and metadata survives reconstruction;
- record current level-3 tap behavior without changing it;
- non-tower taps remain harmless.

#### Projectile/turret scaling
- L2: HP 1760, mass 120, impulse magnitude 26560, interval 208 ms;
- L3: HP 5940, mass 270, impulse magnitude 89640, interval 702 ms;
- knockback/targeting behavior remains observationally equivalent to baseline.

#### Enemy scaling
- L1/L2/L3 diameter 6/9/14;
- HP 15440/60880/136320;
- mass 5400/21600/48600;
- movement impulse 7400/29600/66600;
- characterize Cannon's handling of restitution -0.02/-0.32/-0.82 and compare rolling/collision behavior.

#### Enemy lifetime / meter
- each eligible decay check subtracts exactly 20 HP;
- measure actual decay interval at representative frame rates;
- record initial/post-decay meter scale for L1/L2/L3, including values above 1 if Babylon presents them;
- confirm death still occurs on the subsequent decision check after decay first reaches the threshold.

### Regression pass

Also run the compact #30 baseline behaviors that these seams touch: energy economy, tower placement/upgrades, projectile collisions/knockback, enemy movement/ejection/decay and defeat path. Record browser console output.

## Promotion rule

Keep draft until this **exact batch head** has local PASS evidence.

If it passes, prefer merging this batch once and close #36/#43/#45/#46/#51 as superseded by the certified integration. This preserves one tested SHA rather than merging five individually untested heads afterward.

If one ownership boundary fails, record the failure against this batch and the originating PR. Either remove/remediate only that slice and recertify the changed batch, or abandon the batch and continue with independent PRs. Do not broaden fixes during the certification session.

## Dependent energy-flow lane

#97 is the prepared successor to #78 for local certification. It is based on this exact head and reapplies #78's two-file child delta with matching source blob SHAs. After this PR's economy behavior passes, certify #97; do not spend a separate local checkout on #78's obsolete #36-based head.

If this PR head changes materially, #97 must be reassembled/rechecked before any previous #97 evidence can be used.