### PR TITLE
Add deterministic geothermal reservoir lifecycle

### DIFF
--- a/experiments/storybook/src/Foundations/Physics/GeothermalReservoir.stories.ts
+++ b/experiments/storybook/src/Foundations/Physics/GeothermalReservoir.stories.ts
@@ -1,0 +1,219 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	createGeothermalReservoirState,
+	stepGeothermalReservoir,
+	type GeothermalReservoirConfig,
+	type GeothermalReservoirPhase,
+	type GeothermalReservoirState
+} from "@defend/gameplay/geothermalReservoir";
+import { createLabShell } from "../../labTheme";
+
+type ReservoirArgs = {
+	simulationSeconds: number;
+	heavyDrawPerSecond: number;
+	deepReplenishPerSecond: number;
+	pressureBuildPerSecond: number;
+};
+
+interface TracePoint {
+	time: number;
+	energy: number;
+	pressure: number;
+	phase: GeothermalReservoirPhase;
+}
+
+interface ScenarioTrace {
+	points: TracePoint[];
+	finalState: GeothermalReservoirState;
+	eruptionAt: number | null;
+	retreatAt: number | null;
+	relocationAt: number | null;
+}
+
+function config(args: ReservoirArgs): GeothermalReservoirConfig {
+	return {
+		capacity: 1,
+		depletedThreshold: 0.075,
+		retreatDelaySeconds: 6,
+		retreatDurationSeconds: 3.2,
+		deepReplenishPerSecond: args.deepReplenishPerSecond,
+		pressureBuildPerSecond: args.pressureBuildPerSecond,
+		pressureReliefPerEnergy: 0.8,
+		drawRateForPressureSuppression: 0.02,
+		eruptionThreshold: 0.96,
+		eruptionDurationSeconds: 5.5,
+		eruptionEnergyLossPerSecond: 0.07,
+		pressureAfterEruption: 0.18
+	};
+}
+
+function simulate(
+	requestedDrawPerSecond: number,
+	seconds: number,
+	deltaSeconds: number,
+	calibration: GeothermalReservoirConfig
+): ScenarioTrace {
+	let state = createGeothermalReservoirState(0.72, 0.25, calibration);
+	const points: TracePoint[] = [];
+	let eruptionAt: number | null = null;
+	let retreatAt: number | null = null;
+	let relocationAt: number | null = null;
+	let elapsed = 0;
+
+	while (elapsed <= seconds + 1e-9) {
+		points.push({
+			time: elapsed,
+			energy: state.accessibleEnergy,
+			pressure: state.pressure,
+			phase: state.phase
+		});
+		const step = stepGeothermalReservoir(
+			state,
+			requestedDrawPerSecond,
+			deltaSeconds,
+			calibration
+		);
+		state = step.state;
+		elapsed += deltaSeconds;
+		if (eruptionAt === null && step.eruptionStarted) eruptionAt = elapsed;
+		if (retreatAt === null && step.retreatStarted) retreatAt = elapsed;
+		if (relocationAt === null && step.relocationReady) relocationAt = elapsed;
+	}
+
+	return { points, finalState: state, eruptionAt, retreatAt, relocationAt };
+}
+
+function linePath(
+	points: TracePoint[],
+	seconds: number,
+	value: (point: TracePoint) => number,
+	top: number,
+	height: number
+): string {
+	const width = 560;
+	return points
+		.map((point, index) => {
+			const x = 18 + (point.time / Math.max(seconds, 0.001)) * width;
+			const y = top + height - Math.max(0, Math.min(1, value(point))) * height;
+			return `${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`;
+		})
+		.join(" ");
+}
+
+function marker(time: number | null, seconds: number, label: string, top: number): string {
+	if (time === null) return "";
+	const x = 18 + (time / Math.max(seconds, 0.001)) * 560;
+	return `<line class="reservoir-marker" x1="${x}" y1="${top}" x2="${x}" y2="${top + 92}" /><text class="reservoir-label" x="${x + 4}" y="${top + 12}">${label}</text>`;
+}
+
+const meta = {
+	title: "Foundations/Physics/Geothermal Reservoir",
+	tags: ["test", "visual"],
+	args: {
+		simulationSeconds: 60,
+		heavyDrawPerSecond: 0.04,
+		deepReplenishPerSecond: 0.0055,
+		pressureBuildPerSecond: 0.018
+	},
+	argTypes: {
+		simulationSeconds: { control: { type: "range", min: 20, max: 120, step: 5 } },
+		heavyDrawPerSecond: { control: { type: "range", min: 0.005, max: 0.07, step: 0.001 } },
+		deepReplenishPerSecond: { control: { type: "range", min: 0, max: 0.02, step: 0.0005 } },
+		pressureBuildPerSecond: { control: { type: "range", min: 0, max: 0.04, step: 0.001 } }
+	},
+	render: (args: ReservoirArgs) => {
+		const calibration = config(args);
+		const heavy = simulate(
+			args.heavyDrawPerSecond,
+			args.simulationSeconds,
+			0.1,
+			calibration
+		);
+		const idle = simulate(0, args.simulationSeconds, 0.1, calibration);
+		const heavyEnergy = linePath(heavy.points, args.simulationSeconds, point => point.energy, 34, 92);
+		const heavyPressure = linePath(heavy.points, args.simulationSeconds, point => point.pressure, 34, 92);
+		const idleEnergy = linePath(idle.points, args.simulationSeconds, point => point.energy, 174, 92);
+		const idlePressure = linePath(idle.points, args.simulationSeconds, point => point.pressure, 174, 92);
+
+		const shell = createLabShell(
+			"Foundations / physics",
+			"Geothermal reservoir lifecycle",
+			"Compare two consequences of the same local magma-access rules: concentrated sustained tower fire can deplete a stream until it retreats, while a rich under-used source can accumulate pressure until it erupts. Relocation geometry remains outside this scalar contract."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.reservoir-grid { display:grid; grid-template-columns:minmax(0,1.45fr) minmax(280px,.55fr); gap:16px; }
+				.reservoir-svg { width:100%; min-height:320px; }
+				.reservoir-axis { stroke:rgba(244,237,247,.12); stroke-width:1; }
+				.reservoir-energy { fill:none; stroke:#49d7d1; stroke-width:2.4; }
+				.reservoir-pressure { fill:none; stroke:#e4b980; stroke-width:1.8; stroke-dasharray:5 4; }
+				.reservoir-marker { stroke:rgba(244,237,247,.28); stroke-width:1; stroke-dasharray:3 3; }
+				.reservoir-label { fill:rgba(244,237,247,.52); font-size:10px; }
+				.reservoir-title { fill:rgba(244,237,247,.68); font-size:12px; font-weight:600; }
+				.reservoir-key { display:flex; gap:14px; margin-top:10px; font-size:11px; color:rgba(244,237,247,.58); }
+				.reservoir-swatch { display:inline-block; width:18px; height:2px; margin-right:6px; vertical-align:middle; background:#49d7d1; }
+				.reservoir-swatch--pressure { background:#e4b980; }
+			</style>
+			<div class="reservoir-grid">
+				<section class="lab__panel lab__stage">
+					<svg class="reservoir-svg" viewBox="0 0 610 300" aria-label="Geothermal energy and pressure traces">
+						<line class="reservoir-axis" x1="18" y1="126" x2="578" y2="126" />
+						<line class="reservoir-axis" x1="18" y1="266" x2="578" y2="266" />
+						<text class="reservoir-title" x="18" y="22">concentrated sustained draw</text>
+						<text class="reservoir-title" x="18" y="162">rich / unused source</text>
+						<path class="reservoir-energy" d="${heavyEnergy}" />
+						<path class="reservoir-pressure" d="${heavyPressure}" />
+						<path class="reservoir-energy" d="${idleEnergy}" />
+						<path class="reservoir-pressure" d="${idlePressure}" />
+						${marker(heavy.retreatAt, args.simulationSeconds, "retreat", 34)}
+						${marker(heavy.relocationAt, args.simulationSeconds, "relocate", 34)}
+						${marker(idle.eruptionAt, args.simulationSeconds, "eruption", 174)}
+					</svg>
+					<div class="reservoir-key"><span><i class="reservoir-swatch"></i>accessible energy</span><span><i class="reservoir-swatch reservoir-swatch--pressure"></i>pressure</span></div>
+				</section>
+				<aside class="lab__panel lab__panel--padded">
+					<h2 class="lab__section-title">Outcomes</h2>
+					<dl class="lab__metrics">
+						<div class="lab__metric"><dt>Heavy-draw phase</dt><dd data-heavy-phase="${heavy.finalState.phase}">${heavy.finalState.phase}</dd></div>
+						<div class="lab__metric"><dt>Heavy retreat</dt><dd data-heavy-retreat="${heavy.retreatAt ?? -1}">${heavy.retreatAt === null ? "—" : `${heavy.retreatAt.toFixed(1)} s`}</dd></div>
+						<div class="lab__metric"><dt>Relocation ready</dt><dd data-heavy-relocation="${heavy.relocationAt ?? -1}">${heavy.relocationAt === null ? "—" : `${heavy.relocationAt.toFixed(1)} s`}</dd></div>
+						<div class="lab__metric"><dt>Idle phase</dt><dd data-idle-phase="${idle.finalState.phase}">${idle.finalState.phase}</dd></div>
+						<div class="lab__metric"><dt>Idle eruption</dt><dd data-idle-eruption="${idle.eruptionAt ?? -1}">${idle.eruptionAt === null ? "—" : `${idle.eruptionAt.toFixed(1)} s`}</dd></div>
+						<div class="lab__metric"><dt>Deep replenish</dt><dd>${calibration.deepReplenishPerSecond.toFixed(4)} /s</dd></div>
+					</dl>
+				</aside>
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<ReservoirArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DepletionVersusPressure: Story = {
+	play: async ({ canvasElement, args }) => {
+		const heavyRetreat = canvasElement.querySelector<HTMLElement>("[data-heavy-retreat]");
+		const heavyRelocation = canvasElement.querySelector<HTMLElement>("[data-heavy-relocation]");
+		const idleEruption = canvasElement.querySelector<HTMLElement>("[data-idle-eruption]");
+		await expect(heavyRetreat).not.toBeNull();
+		await expect(heavyRelocation).not.toBeNull();
+		await expect(idleEruption).not.toBeNull();
+		if (!heavyRetreat || !heavyRelocation || !idleEruption) return;
+
+		const calibration = config(args);
+		const heavy30 = simulate(args.heavyDrawPerSecond, args.simulationSeconds, 1 / 30, calibration);
+		const heavy60 = simulate(args.heavyDrawPerSecond, args.simulationSeconds, 1 / 60, calibration);
+		const idle30 = simulate(0, args.simulationSeconds, 1 / 30, calibration);
+		const idle60 = simulate(0, args.simulationSeconds, 1 / 60, calibration);
+
+		if (heavy30.retreatAt !== null && heavy60.retreatAt !== null) {
+			await expect(Math.abs(heavy30.retreatAt - heavy60.retreatAt)).toBeLessThan(0.2);
+		}
+		if (idle30.eruptionAt !== null && idle60.eruptionAt !== null) {
+			await expect(Math.abs(idle30.eruptionAt - idle60.eruptionAt)).toBeLessThan(0.2);
+		}
+	}
+};

--- a/src/js/gameplay/geothermalReservoir.ts
+++ b/src/js/gameplay/geothermalReservoir.ts
@@ -135,20 +135,21 @@ export function stepGeothermalReservoir(
 			0,
 			next.accessibleEnergy - safe.eruptionEnergyLossPerSecond * dt
 		);
-		const eruptionProgress =
-			safe.eruptionDurationSeconds === 0
-				? 1
-				: Math.min(1, next.eruptionSeconds / safe.eruptionDurationSeconds);
-		next.pressure = Math.max(
-			safe.pressureAfterEruption,
-			next.pressure -
-				(next.pressure - safe.pressureAfterEruption) * eruptionProgress
-		);
+		if (safe.eruptionDurationSeconds === 0) {
+			next.pressure = safe.pressureAfterEruption;
+		} else {
+			const relaxationRate = 5 / safe.eruptionDurationSeconds;
+			const decay = Math.exp(-relaxationRate * dt);
+			next.pressure =
+				safe.pressureAfterEruption +
+				(next.pressure - safe.pressureAfterEruption) * decay;
+		}
 		if (next.eruptionSeconds >= safe.eruptionDurationSeconds) {
 			next.phase = "retreating";
 			next.retreatSeconds = 0;
 			next.depletedSeconds = safe.retreatDelaySeconds;
 			next.eruptionSeconds = safe.eruptionDurationSeconds;
+			next.pressure = safe.pressureAfterEruption;
 			retreatStarted = true;
 		}
 	} else if (next.phase === "retreating") {

--- a/src/js/gameplay/geothermalReservoir.ts
+++ b/src/js/gameplay/geothermalReservoir.ts
@@ -1,0 +1,231 @@
+export type GeothermalReservoirPhase = "active" | "retreating" | "erupting";
+
+export interface GeothermalReservoirState {
+	phase: GeothermalReservoirPhase;
+	accessibleEnergy: number;
+	pressure: number;
+	depletedSeconds: number;
+	retreatSeconds: number;
+	eruptionSeconds: number;
+}
+
+export interface GeothermalReservoirConfig {
+	capacity: number;
+	depletedThreshold: number;
+	retreatDelaySeconds: number;
+	retreatDurationSeconds: number;
+	deepReplenishPerSecond: number;
+	pressureBuildPerSecond: number;
+	pressureReliefPerEnergy: number;
+	drawRateForPressureSuppression: number;
+	eruptionThreshold: number;
+	eruptionDurationSeconds: number;
+	eruptionEnergyLossPerSecond: number;
+	pressureAfterEruption: number;
+}
+
+export interface GeothermalReservoirStep {
+	state: GeothermalReservoirState;
+	requestedEnergy: number;
+	servedEnergy: number;
+	unmetEnergy: number;
+	replenishedEnergy: number;
+	eruptionStarted: boolean;
+	retreatStarted: boolean;
+	relocationReady: boolean;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
+}
+
+function safeConfig(config: GeothermalReservoirConfig): GeothermalReservoirConfig {
+	const capacity = Math.max(0.000001, positive(config.capacity));
+	return {
+		capacity,
+		depletedThreshold: clamp(config.depletedThreshold, 0, capacity),
+		retreatDelaySeconds: positive(config.retreatDelaySeconds),
+		retreatDurationSeconds: positive(config.retreatDurationSeconds),
+		deepReplenishPerSecond: positive(config.deepReplenishPerSecond),
+		pressureBuildPerSecond: positive(config.pressureBuildPerSecond),
+		pressureReliefPerEnergy: positive(config.pressureReliefPerEnergy),
+		drawRateForPressureSuppression: positive(config.drawRateForPressureSuppression),
+		eruptionThreshold: clamp(config.eruptionThreshold, 0, 1),
+		eruptionDurationSeconds: positive(config.eruptionDurationSeconds),
+		eruptionEnergyLossPerSecond: positive(config.eruptionEnergyLossPerSecond),
+		pressureAfterEruption: clamp(config.pressureAfterEruption, 0, 1)
+	};
+}
+
+export function createGeothermalReservoirState(
+	accessibleEnergy: number,
+	pressure: number,
+	config: GeothermalReservoirConfig
+): GeothermalReservoirState {
+	const safe = safeConfig(config);
+	return {
+		phase: "active",
+		accessibleEnergy: clamp(accessibleEnergy, 0, safe.capacity),
+		pressure: clamp(pressure, 0, 1),
+		depletedSeconds: 0,
+		retreatSeconds: 0,
+		eruptionSeconds: 0
+	};
+}
+
+/**
+ * Advance one local geothermal-access reservoir.
+ *
+ * The reservoir owns only scalar state. Geometry, stream routing, eruption
+ * damage, rendering, and the choice of a relocation point remain caller-owned.
+ * This keeps the same resource lifecycle usable by the flat PoC, a future
+ * spherical planet, AI simulation, and deterministic tests.
+ */
+export function stepGeothermalReservoir(
+	state: GeothermalReservoirState,
+	requestedDrawPerSecond: number,
+	deltaSeconds: number,
+	config: GeothermalReservoirConfig
+): GeothermalReservoirStep {
+	const safe = safeConfig(config);
+	const dt = positive(deltaSeconds);
+	const requestedRate = positive(requestedDrawPerSecond);
+	const requestedEnergy = requestedRate * dt;
+	let next: GeothermalReservoirState = {
+		phase: state.phase,
+		accessibleEnergy: clamp(state.accessibleEnergy, 0, safe.capacity),
+		pressure: clamp(state.pressure, 0, 1),
+		depletedSeconds: positive(state.depletedSeconds),
+		retreatSeconds: positive(state.retreatSeconds),
+		eruptionSeconds: positive(state.eruptionSeconds)
+	};
+	let servedEnergy = 0;
+	let replenishedEnergy = 0;
+	let eruptionStarted = false;
+	let retreatStarted = false;
+
+	if (dt === 0) {
+		return {
+			state: next,
+			requestedEnergy,
+			servedEnergy,
+			unmetEnergy: requestedEnergy,
+			replenishedEnergy,
+			eruptionStarted,
+			retreatStarted,
+			relocationReady:
+				next.phase === "retreating" && next.retreatSeconds >= safe.retreatDurationSeconds
+		};
+	}
+
+	if (next.phase === "erupting") {
+		next.eruptionSeconds += dt;
+		next.accessibleEnergy = Math.max(
+			0,
+			next.accessibleEnergy - safe.eruptionEnergyLossPerSecond * dt
+		);
+		const eruptionProgress =
+			safe.eruptionDurationSeconds === 0
+				? 1
+				: Math.min(1, next.eruptionSeconds / safe.eruptionDurationSeconds);
+		next.pressure = Math.max(
+			safe.pressureAfterEruption,
+			next.pressure -
+				(next.pressure - safe.pressureAfterEruption) * eruptionProgress
+		);
+		if (next.eruptionSeconds >= safe.eruptionDurationSeconds) {
+			next.phase = "retreating";
+			next.retreatSeconds = 0;
+			next.depletedSeconds = safe.retreatDelaySeconds;
+			next.eruptionSeconds = safe.eruptionDurationSeconds;
+			retreatStarted = true;
+		}
+	} else if (next.phase === "retreating") {
+		next.retreatSeconds += dt;
+	} else {
+		const replenishRoom = safe.capacity - next.accessibleEnergy;
+		replenishedEnergy = Math.min(
+			replenishRoom,
+			safe.deepReplenishPerSecond * dt
+		);
+		next.accessibleEnergy += replenishedEnergy;
+
+		servedEnergy = Math.min(next.accessibleEnergy, requestedEnergy);
+		next.accessibleEnergy -= servedEnergy;
+
+		if (next.accessibleEnergy <= safe.depletedThreshold) {
+			next.depletedSeconds += dt;
+		} else {
+			next.depletedSeconds = 0;
+		}
+
+		const fullness = next.accessibleEnergy / safe.capacity;
+		const pressureSuppression =
+			safe.drawRateForPressureSuppression === 0
+				? requestedRate > 0
+					? 1
+					: 0
+				: clamp(
+						requestedRate / safe.drawRateForPressureSuppression,
+						0,
+						1
+					);
+		const pressureGain =
+			safe.pressureBuildPerSecond * fullness * (1 - pressureSuppression) * dt;
+		const pressureRelief = servedEnergy * safe.pressureReliefPerEnergy;
+		next.pressure = clamp(next.pressure + pressureGain - pressureRelief, 0, 1);
+
+		if (next.pressure >= safe.eruptionThreshold) {
+			next.phase = "erupting";
+			next.eruptionSeconds = 0;
+			eruptionStarted = true;
+		} else if (next.depletedSeconds >= safe.retreatDelaySeconds) {
+			next.phase = "retreating";
+			next.retreatSeconds = 0;
+			retreatStarted = true;
+		}
+	}
+
+	return {
+		state: next,
+		requestedEnergy,
+		servedEnergy,
+		unmetEnergy: Math.max(0, requestedEnergy - servedEnergy),
+		replenishedEnergy,
+		eruptionStarted,
+		retreatStarted,
+		relocationReady:
+			next.phase === "retreating" && next.retreatSeconds >= safe.retreatDurationSeconds
+	};
+}
+
+/**
+ * Re-seed a reservoir after the world chooses a new physical emergence point.
+ * Relocation itself is intentionally not randomised here.
+ */
+export function relocateGeothermalReservoir(
+	accessibleEnergy: number,
+	pressure: number,
+	config: GeothermalReservoirConfig
+): GeothermalReservoirState {
+	return createGeothermalReservoirState(accessibleEnergy, pressure, config);
+}
+
+export function geothermalReservoirFillRatio(
+	state: GeothermalReservoirState,
+	config: GeothermalReservoirConfig
+): number {
+	const capacity = safeConfig(config).capacity;
+	return clamp(state.accessibleEnergy / capacity, 0, 1);
+}


### PR DESCRIPTION
Refs #82, #89, #92
Related: #87, #91, #96

## Purpose

Extract the scalar geothermal-source lifecycle currently embedded in the Babylon geothermal lab into one renderer/geometry-independent contract that can later be shared by tower power, AI, the spherical planet simulation, and deterministic tests.

This PR does **not** modify the existing `geothermalPrototype.ts` call sites yet and does not promote its current calibration values into production balance.

## `src/js/gameplay/geothermalReservoir.ts`

Adds a deterministic local reservoir state model with:

- phases: `active / erupting / retreating`;
- bounded accessible-energy capacity;
- deep replenishment;
- requested versus actually served tower draw;
- unmet-energy accounting;
- depletion threshold + persistence timer before retreat;
- pressure accumulation weighted by reservoir fullness and suppressed/relieved by sustained consumption;
- eruption threshold;
- eruption-duration energy loss;
- frame-rate-independent pressure relaxation during eruption;
- post-eruption transition toward retreat;
- retreat-duration readiness signal for world-owned relocation;
- explicit re-seeding helper after the world chooses a new emergence point.

The contract deliberately does **not** choose a random relocation position, create particles, melt structures, route conduits, assign towers, or decide terrain deformation. Those remain world/geometry responsibilities.

## Storybook playground

Adds `Foundations/Physics/Geothermal Reservoir`.

The deterministic fixture compares two consequences of one parameter set:

1. **concentrated sustained draw** — local accessible energy is exhausted, remains below the depletion threshold, then retreats and becomes ready for relocation;
2. **rich unused source** — energy stays abundant, pressure accumulates, eruption begins, pressure/energy discharge, then the source transitions toward retreat.

The chart overlays accessible energy and pressure and marks retreat / relocation / eruption events.

Controls expose simulation duration, heavy draw rate, deep replenishment and pressure build rate.

The Storybook `play` test additionally simulates at 30 Hz and 60 Hz and checks retreat/eruption event timing stays within 0.2 s when both events occur, protecting the lifecycle against render-cadence dependence.

## Calibration status

The default fixture mirrors the existing geothermal PoC scale where useful (for example 0.075 depleted threshold, 6 s depletion persistence, 3.2 s retreat, 0.0055/s deep replenish, 0.018/s pressure build, 0.96 eruption threshold, 5.5 s eruption). These values remain **experimental calibration**, not committed campaign balance.

## Scope

Relative to current `master` `9c5eaa9d93a7037b55e858f4ea14f8eace67f2fa`:

- 3 commits ahead / 0 behind;
- 2 added files;
- no dependency/package changes;
- no Babylon/Cannon/production call-site changes;
- no random number generation;
- no new background loop or persistent Storybook resource.

## Certification

Include this head in the next #92 root + Storybook campaign:

- safe root TypeScript/build compatibility for `geothermalReservoir.ts`;
- from `experiments/storybook`: `pnpm typecheck`, `pnpm build`, `pnpm test`;
- exercise draw, replenish, pressure-build and duration controls;
- verify sustained draw reaches retreat while idle-rich conditions can reach eruption;
- compare 30/60 Hz event timing;
- inspect all values for finite/bounded behavior at control extremes.

Keep draft until those gates are recorded.

## Follow-up

After certification, update the already-merged `geothermalPrototype.ts` to consume this reservoir contract, deleting its local `energy / pressure / depletedSeconds / retreatSeconds / eruptionSeconds` transition math. A later integration can then combine this with #96's drilling/maintenance contracts without coupling scalar reservoir evolution to the temporary flat/mesh representation.