### PR TITLE
Add bounded spatial motion estimation primitives

### DIFF
--- a/experiments/storybook/src/Audio/Spatial/SpatialMotion.stories.ts
+++ b/experiments/storybook/src/Audio/Spatial/SpatialMotion.stories.ts
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+  initialSpatialMotionEstimate,
+  predictSpatialMotionFromCalibration,
+  spatialMotionSpeed,
+  updateSpatialMotionEstimate,
+  type SpatialMotionCalibration,
+  type SpatialMotionEstimate
+} from "@defend/audio/spatialMotion";
+import { createLabShell } from "../../labTheme";
+
+type MotionArgs = {
+  sampleHz: number;
+  speed: number;
+  halfLife: number;
+  maxSpeed: number;
+  teleportDistance: number;
+  includeTeleport: boolean;
+};
+
+type TracePoint = {
+  x: number;
+  z: number;
+  estimate: SpatialMotionEstimate;
+};
+
+type MotionTrace = {
+  points: TracePoint[];
+  resetCount: number;
+  finalSpeed: number;
+  predictedX: number;
+  predictedZ: number;
+};
+
+function buildTrace(args: MotionArgs): MotionTrace {
+  const sampleHz = Math.max(1, Math.floor(args.sampleHz));
+  const deltaSeconds = 1 / sampleHz;
+  const calibration: SpatialMotionCalibration = {
+    minSampleDeltaSeconds: 1 / 500,
+    maxSampleDeltaSeconds: 0.25,
+    teleportDistance: Math.max(0, args.teleportDistance),
+    velocityHalfLifeSeconds: Math.max(0, args.halfLife),
+    maxSpeed: Math.max(0, args.maxSpeed),
+    maxPredictionSeconds: 0.12
+  };
+  const startX = -72;
+  const startZ = -22;
+  const duration = 1.5;
+  let offsetX = 0;
+  let offsetZ = 0;
+  let teleported = false;
+  let estimate = initialSpatialMotionEstimate({
+    position: { x: startX, y: 0, z: startZ },
+    timeSeconds: 0
+  });
+  const points: TracePoint[] = [{ x: startX, z: startZ, estimate }];
+  let resetCount = 0;
+
+  for (let timeSeconds = deltaSeconds; timeSeconds <= duration + 1e-9; timeSeconds += deltaSeconds) {
+    if (args.includeTeleport && !teleported && timeSeconds >= 0.75) {
+      const distance = Math.max(1, calibration.teleportDistance);
+      offsetX = distance + 28;
+      offsetZ = -(distance * 0.45 + 10);
+      teleported = true;
+    }
+
+    const position = {
+      x: startX + args.speed * timeSeconds + offsetX,
+      y: 0,
+      z: startZ + args.speed * 0.18 * timeSeconds + offsetZ
+    };
+    estimate = updateSpatialMotionEstimate(
+      estimate,
+      { position, timeSeconds },
+      calibration
+    );
+    if (estimate.reset) resetCount += 1;
+    points.push({ x: position.x, z: position.z, estimate });
+  }
+
+  const predicted = predictSpatialMotionFromCalibration(
+    estimate,
+    estimate.timeSeconds + 0.12,
+    calibration
+  );
+
+  return {
+    points,
+    resetCount,
+    finalSpeed: spatialMotionSpeed(estimate.velocity),
+    predictedX: predicted.x,
+    predictedZ: predicted.z
+  };
+}
+
+function bounds(trace: MotionTrace) {
+  const xs = trace.points.map(point => point.x).concat(trace.predictedX);
+  const zs = trace.points.map(point => point.z).concat(trace.predictedZ);
+  const minimumX = Math.min(...xs);
+  const maximumX = Math.max(...xs);
+  const minimumZ = Math.min(...zs);
+  const maximumZ = Math.max(...zs);
+  const padding = 18;
+  return {
+    x: minimumX - padding,
+    y: minimumZ - padding,
+    width: Math.max(60, maximumX - minimumX + padding * 2),
+    height: Math.max(60, maximumZ - minimumZ + padding * 2)
+  };
+}
+
+function polyline(trace: MotionTrace): string {
+  return trace.points.map(point => `${point.x},${point.z}`).join(" ");
+}
+
+const meta = {
+  title: "Audio/Spatial/Motion Estimator",
+  tags: ["test", "visual"],
+  args: {
+    sampleHz: 60,
+    speed: 54,
+    halfLife: 0.12,
+    maxSpeed: 120,
+    teleportDistance: 36,
+    includeTeleport: true
+  },
+  argTypes: {
+    sampleHz: { control: { type: "range", min: 15, max: 144, step: 1 } },
+    speed: { control: { type: "range", min: 0, max: 160, step: 2 } },
+    halfLife: { control: { type: "range", min: 0, max: 0.5, step: 0.01 } },
+    maxSpeed: { control: { type: "range", min: 10, max: 220, step: 5 } },
+    teleportDistance: { control: { type: "range", min: 0, max: 100, step: 2 } },
+    includeTeleport: { control: "boolean" }
+  },
+  render: (args: MotionArgs) => {
+    const shell = createLabShell(
+      "Audio / spatial",
+      "Timestamped motion estimator",
+      "Scrub sampling cadence, smoothing and reset thresholds before listener/source velocity feeds Doppler, closest-approach priority or Web Audio transform scheduling."
+    );
+    const trace = buildTrace(args);
+    const view = bounds(trace);
+    const finalPoint = trace.points[trace.points.length - 1];
+    const velocityScale = 0.2;
+    const velocityEndX = finalPoint.x + finalPoint.estimate.velocity.x * velocityScale;
+    const velocityEndZ = finalPoint.z + finalPoint.estimate.velocity.z * velocityScale;
+
+    shell.frame.innerHTML = `
+      <style>
+        .motion-stage { background: radial-gradient(circle at center, rgba(173, 97, 26, 0.08), transparent 48%); }
+        .motion-path { fill: none; stroke: rgba(215, 164, 108, 0.72); stroke-width: 1.4; vector-effect: non-scaling-stroke; }
+        .motion-sample { fill: rgba(244, 237, 247, 0.36); }
+        .motion-reset { fill: #e4b980; stroke: #f4edf7; stroke-width: 1.2; vector-effect: non-scaling-stroke; }
+        .motion-final { fill: #f4edf7; stroke: #1c0530; stroke-width: 1.5; vector-effect: non-scaling-stroke; }
+        .motion-predicted { fill: none; stroke: rgba(228, 185, 128, 0.8); stroke-dasharray: 4 4; stroke-width: 1.4; vector-effect: non-scaling-stroke; }
+        .motion-velocity { stroke: rgba(228, 185, 128, 0.92); stroke-width: 1.8; vector-effect: non-scaling-stroke; }
+      </style>
+      <div class="lab__grid">
+        <section class="lab__panel lab__stage motion-stage">
+          <svg viewBox="${view.x} ${view.y} ${view.width} ${view.height}" aria-label="Timestamped spatial motion trace">
+            <polyline class="motion-path" points="${polyline(trace)}" />
+            ${trace.points.map((point, index) => {
+              const runtimeReset = index > 0 && point.estimate.reset;
+              return `<circle class="${runtimeReset ? "motion-reset" : "motion-sample"}" cx="${point.x}" cy="${point.z}" r="${runtimeReset ? 3.3 : 1.4}" ${runtimeReset ? "data-motion-reset" : ""} />`;
+            }).join("")}
+            <line class="motion-velocity" x1="${finalPoint.x}" y1="${finalPoint.z}" x2="${velocityEndX}" y2="${velocityEndZ}" />
+            <circle class="motion-final" cx="${finalPoint.x}" cy="${finalPoint.z}" r="3.5" />
+            <line class="motion-predicted" x1="${finalPoint.x}" y1="${finalPoint.z}" x2="${trace.predictedX}" y2="${trace.predictedZ}" />
+            <circle class="motion-predicted" cx="${trace.predictedX}" cy="${trace.predictedZ}" r="3" />
+          </svg>
+        </section>
+        <aside class="lab__panel lab__panel--padded">
+          <h2 class="lab__section-title">Estimator state</h2>
+          <dl class="lab__metrics">
+            <div class="lab__metric"><dt>Sample cadence</dt><dd data-sample-hz>${Math.max(1, Math.floor(args.sampleHz))} Hz</dd></div>
+            <div class="lab__metric"><dt>Runtime resets</dt><dd data-reset-count>${trace.resetCount}</dd></div>
+            <div class="lab__metric"><dt>Final speed</dt><dd data-final-speed>${trace.finalSpeed.toFixed(2)}</dd></div>
+            <div class="lab__metric"><dt>Speed limit</dt><dd data-max-speed>${Math.max(0, args.maxSpeed).toFixed(2)}</dd></div>
+            <div class="lab__metric"><dt>Prediction horizon</dt><dd>120 ms</dd></div>
+            <div class="lab__metric"><dt>Final reset</dt><dd data-final-reset>${String(finalPoint.estimate.reset)}</dd></div>
+          </dl>
+          <p class="lab__note">Copper markers are discontinuity resets. The solid vector is the final smoothed velocity; the dashed segment is bounded forward prediction for lower-rate audio/control snapshots.</p>
+        </aside>
+      </div>
+    `;
+
+    shell.root.dataset.runtimeResets = String(trace.resetCount);
+    shell.root.dataset.finalSpeed = String(trace.finalSpeed);
+    shell.root.dataset.maxSpeed = String(Math.max(0, args.maxSpeed));
+    return shell.root;
+  }
+} satisfies Meta<MotionArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CadenceAndTeleport: Story = {
+  play: async ({ canvasElement }) => {
+    const root = canvasElement.querySelector<HTMLElement>("[data-runtime-resets]");
+    const reset = canvasElement.querySelector<SVGCircleElement>("[data-motion-reset]");
+    await expect(root).not.toBeNull();
+    await expect(reset).not.toBeNull();
+    if (!root) return;
+    const finalSpeed = Number(root.dataset.finalSpeed || "Infinity");
+    const maximum = Number(root.dataset.maxSpeed || "0");
+    await expect(root.dataset.runtimeResets).toBe("1");
+    await expect(Number.isFinite(finalSpeed)).toBe(true);
+    await expect(finalSpeed <= maximum).toBe(true);
+  }
+};

--- a/src/js/audio/spatialMotion.ts
+++ b/src/js/audio/spatialMotion.ts
@@ -147,7 +147,9 @@ export function updateSpatialMotionEstimate(
 	const timeSeconds = finiteScalar(sample.timeSeconds, previousTime);
 	const deltaSeconds = finiteScalar(timeSeconds - previousTime);
 	const minDelta = positive(calibration.minSampleDeltaSeconds);
-	const maxDelta = Math.max(minDelta, positive(calibration.maxSampleDeltaSeconds));
+	const configuredMaxDelta = positive(calibration.maxSampleDeltaSeconds);
+	const maxDelta =
+		configuredMaxDelta > 0 ? Math.max(minDelta, configuredMaxDelta) : 0;
 	const displacement = subtract(position, previousPosition);
 	const distance = magnitude(displacement);
 	const teleportDistance = positive(calibration.teleportDistance);

--- a/src/js/audio/spatialMotion.ts
+++ b/src/js/audio/spatialMotion.ts
@@ -1,0 +1,228 @@
+import { SpatialVector3 } from "./spatialAudio";
+
+export interface SpatialMotionSample {
+	position: SpatialVector3;
+	timeSeconds: number;
+}
+
+export interface SpatialMotionCalibration {
+	minSampleDeltaSeconds: number;
+	maxSampleDeltaSeconds: number;
+	teleportDistance: number;
+	velocityHalfLifeSeconds: number;
+	maxSpeed: number;
+	maxPredictionSeconds: number;
+}
+
+export interface SpatialMotionEstimate {
+	position: SpatialVector3;
+	velocity: SpatialVector3;
+	timeSeconds: number;
+	sampleDeltaSeconds: number;
+	reset: boolean;
+}
+
+const MAX_MOTION_SCALAR = 1e150;
+const LN2 = Math.log(2);
+
+function finiteScalar(value: number, fallback = 0): number {
+	if (value !== value) {
+		return fallback;
+	}
+	if (value > MAX_MOTION_SCALAR) {
+		return MAX_MOTION_SCALAR;
+	}
+	if (value < -MAX_MOTION_SCALAR) {
+		return -MAX_MOTION_SCALAR;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finiteScalar(value));
+}
+
+function sanitizeVector(vector: SpatialVector3): SpatialVector3 {
+	return {
+		x: finiteScalar(vector.x),
+		y: finiteScalar(vector.y),
+		z: finiteScalar(vector.z)
+	};
+}
+
+function subtract(a: SpatialVector3, b: SpatialVector3): SpatialVector3 {
+	return {
+		x: finiteScalar(finiteScalar(a.x) - finiteScalar(b.x)),
+		y: finiteScalar(finiteScalar(a.y) - finiteScalar(b.y)),
+		z: finiteScalar(finiteScalar(a.z) - finiteScalar(b.z))
+	};
+}
+
+function addScaled(
+	position: SpatialVector3,
+	velocity: SpatialVector3,
+	seconds: number
+): SpatialVector3 {
+	const time = finiteScalar(seconds);
+	return {
+		x: finiteScalar(finiteScalar(position.x) + finiteScalar(velocity.x) * time),
+		y: finiteScalar(finiteScalar(position.y) + finiteScalar(velocity.y) * time),
+		z: finiteScalar(finiteScalar(position.z) + finiteScalar(velocity.z) * time)
+	};
+}
+
+function magnitude(vector: SpatialVector3): number {
+	const x = finiteScalar(vector.x);
+	const y = finiteScalar(vector.y);
+	const z = finiteScalar(vector.z);
+	return finiteScalar(Math.sqrt(x * x + y * y + z * z), MAX_MOTION_SCALAR);
+}
+
+function scale(vector: SpatialVector3, amount: number): SpatialVector3 {
+	const scalar = finiteScalar(amount);
+	return {
+		x: finiteScalar(finiteScalar(vector.x) * scalar),
+		y: finiteScalar(finiteScalar(vector.y) * scalar),
+		z: finiteScalar(finiteScalar(vector.z) * scalar)
+	};
+}
+
+function clampMagnitude(vector: SpatialVector3, maximum: number): SpatialVector3 {
+	const limit = positive(maximum);
+	if (limit <= 0) {
+		return { x: 0, y: 0, z: 0 };
+	}
+	const length = magnitude(vector);
+	if (length <= limit || length <= 0.000001) {
+		return sanitizeVector(vector);
+	}
+	return scale(vector, limit / length);
+}
+
+function blend(
+	from: SpatialVector3,
+	to: SpatialVector3,
+	amount: number
+): SpatialVector3 {
+	const t = Math.max(0, Math.min(1, finiteScalar(amount)));
+	return {
+		x: finiteScalar(finiteScalar(from.x) + (finiteScalar(to.x) - finiteScalar(from.x)) * t),
+		y: finiteScalar(finiteScalar(from.y) + (finiteScalar(to.y) - finiteScalar(from.y)) * t),
+		z: finiteScalar(finiteScalar(from.z) + (finiteScalar(to.z) - finiteScalar(from.z)) * t)
+	};
+}
+
+export function spatialMotionSpeed(velocity: SpatialVector3): number {
+	return magnitude(velocity);
+}
+
+export function initialSpatialMotionEstimate(
+	sample: SpatialMotionSample
+): SpatialMotionEstimate {
+	return {
+		position: sanitizeVector(sample.position),
+		velocity: { x: 0, y: 0, z: 0 },
+		timeSeconds: finiteScalar(sample.timeSeconds),
+		sampleDeltaSeconds: 0,
+		reset: true
+	};
+}
+
+/**
+ * Derive a bounded, smoothed velocity estimate from timestamped transforms.
+ *
+ * Non-monotonic/long-gap timestamps and explicit teleport-sized position jumps
+ * reset velocity to zero so camera resets, scene loads and debugger scrubs do
+ * not become artificial Doppler spikes. Very small but positive sample deltas
+ * use the configured minimum denominator instead of amplifying transform jitter.
+ */
+export function updateSpatialMotionEstimate(
+	previous: SpatialMotionEstimate,
+	sample: SpatialMotionSample,
+	calibration: SpatialMotionCalibration
+): SpatialMotionEstimate {
+	const previousPosition = sanitizeVector(previous.position);
+	const position = sanitizeVector(sample.position);
+	const previousTime = finiteScalar(previous.timeSeconds);
+	const timeSeconds = finiteScalar(sample.timeSeconds, previousTime);
+	const deltaSeconds = finiteScalar(timeSeconds - previousTime);
+	const minDelta = positive(calibration.minSampleDeltaSeconds);
+	const maxDelta = Math.max(minDelta, positive(calibration.maxSampleDeltaSeconds));
+	const displacement = subtract(position, previousPosition);
+	const distance = magnitude(displacement);
+	const teleportDistance = positive(calibration.teleportDistance);
+	const teleported = teleportDistance > 0 && distance >= teleportDistance;
+	const invalidTime = deltaSeconds <= 0 || (maxDelta > 0 && deltaSeconds > maxDelta);
+
+	if (teleported || invalidTime) {
+		return {
+			position,
+			velocity: { x: 0, y: 0, z: 0 },
+			timeSeconds,
+			sampleDeltaSeconds: deltaSeconds,
+			reset: true
+		};
+	}
+
+	const denominator = Math.max(deltaSeconds, minDelta, 0.000001);
+	const rawVelocity = clampMagnitude(
+		scale(displacement, 1 / denominator),
+		calibration.maxSpeed
+	);
+	const previousVelocity = clampMagnitude(
+		sanitizeVector(previous.velocity),
+		calibration.maxSpeed
+	);
+	const halfLife = positive(calibration.velocityHalfLifeSeconds);
+	const blendAmount =
+		halfLife <= 0
+			? 1
+			: 1 - Math.exp((-LN2 * denominator) / Math.max(halfLife, 0.000001));
+	const velocity = clampMagnitude(
+		blend(previousVelocity, rawVelocity, blendAmount),
+		calibration.maxSpeed
+	);
+
+	return {
+		position,
+		velocity,
+		timeSeconds,
+		sampleDeltaSeconds: deltaSeconds,
+		reset: false
+	};
+}
+
+/**
+ * Short bounded extrapolation for lower-rate transform/control snapshots.
+ * This is presentation/audio planning only; it must never advance simulation
+ * authority or replace the current authoritative transform.
+ */
+export function predictSpatialMotionPosition(
+	estimate: SpatialMotionEstimate,
+	targetTimeSeconds: number,
+	maxPredictionSeconds: number
+): SpatialVector3 {
+	const limit = positive(maxPredictionSeconds);
+	const requested = Math.max(
+		0,
+		finiteScalar(targetTimeSeconds) - finiteScalar(estimate.timeSeconds)
+	);
+	const seconds = Math.min(requested, limit);
+	return addScaled(
+		sanitizeVector(estimate.position),
+		sanitizeVector(estimate.velocity),
+		seconds
+	);
+}
+
+export function predictSpatialMotionFromCalibration(
+	estimate: SpatialMotionEstimate,
+	targetTimeSeconds: number,
+	calibration: SpatialMotionCalibration
+): SpatialVector3 {
+	return predictSpatialMotionPosition(
+		estimate,
+		targetTimeSeconds,
+		calibration.maxPredictionSeconds
+	);
+}


### PR DESCRIPTION
Refs #60, #63
Related: #61, #62, #92

## Purpose

Add the missing timestamped motion layer required by the spatial-audio fly-by lab before any browser/Web Audio bridge starts deriving listener/source velocity ad hoc, together with a deterministic Storybook playground for inspecting the contract visually.

This PR remains isolated from production sound/gameplay. It does not touch WAFXR/Tone, AudioWorklet, Worker code, Babylon camera wiring, production sound routing, or gameplay.

## Pure motion contract

`src/js/audio/spatialMotion.ts`

Adds:

- `SpatialMotionSample` — timestamped world-space position;
- `SpatialMotionCalibration` — minimum/maximum sample delta, teleport threshold, velocity smoothing half-life, maximum speed and bounded prediction horizon;
- `SpatialMotionEstimate` — sanitized position, smoothed bounded velocity, timestamp, observed sample delta and explicit reset flag;
- `initialSpatialMotionEstimate()`;
- `updateSpatialMotionEstimate()`;
- `spatialMotionSpeed()`;
- bounded short-horizon position prediction helpers for lower-rate control snapshots.

## Reset semantics

Camera resets, scene loads, debugger scrubs and other discontinuities must not become artificial Doppler spikes.

The estimator resets velocity to zero when:

- timestamps are non-monotonic;
- the sample gap exceeds the configured maximum, when `maxSampleDeltaSeconds > 0`;
- the position jump meets/exceeds the configured teleport distance, when `teleportDistance > 0`.

`maxSampleDeltaSeconds <= 0` explicitly disables long-gap reset. `teleportDistance <= 0` explicitly disables distance-based reset.

Very small positive sample deltas do not reset. Instead, the velocity denominator is floored by `minSampleDeltaSeconds`, preventing transform jitter from exploding into extreme apparent speed.

## Smoothing

Velocity smoothing is expressed as a time-domain half-life, not a per-frame lerp coefficient. This keeps behavior substantially independent of render/display cadence.

`velocityHalfLifeSeconds <= 0` selects the current bounded raw velocity directly.

`maxSpeed` clamps both previous and newly derived velocities. A non-positive maximum produces zero velocity rather than non-finite output.

## Prediction boundary

`predictSpatialMotionPosition()` only performs bounded forward extrapolation from an already-derived estimate. It is intended for timestamped lower-rate audio/control snapshots and interpolation experiments in #63.

It is explicitly not simulation authority and must never advance gameplay state.

## Numeric boundary

The module mirrors #61's defensive finite-state philosophy:

- NaN maps to neutral/fallback values;
- extreme/infinite scalar state is saturated at an internal defensive ceiling;
- vector math and speed outputs remain finite;
- malformed timing resets instead of poisoning downstream Doppler/closest-approach calculations.

This is robustness, not world/balance calibration.

## Storybook playground

Adds `Audio/Spatial/Motion Estimator` in:

`experiments/storybook/src/Audio/Spatial/SpatialMotion.stories.ts`

The story is deterministic and starts no RAF, AudioContext, Worker or timer. Controls expose:

- sample cadence;
- source/listener speed;
- smoothing half-life;
- maximum derived speed;
- teleport threshold;
- teleport on/off.

The default fixture runs a 1.5-second timestamped trajectory with one persistent position discontinuity. It visualizes:

- the sampled world-space path;
- the discontinuity/reset marker;
- final smoothed velocity vector;
- bounded 120 ms forward prediction;
- reset count and final speed/limit metrics.

The story's interaction assertion expects exactly one runtime reset in the default teleport fixture and verifies the final speed remains finite and within `maxSpeed`.

## Why before the browser lab

#63 already requires a moving-listener fixture with timestamped camera transforms and teleport/reset detection. Centralizing that behavior now prevents the later Babylon camera adapter, Worker planner and Web Audio renderer from each inventing subtly different velocity semantics.

It also supports the planned transform-cadence comparison:

1. render-frame updates;
2. lower-rate timestamped snapshots;
3. Worker-planned snapshots;
4. optional SAB only if profiling justifies it.

## Scope check

Relative to current `master` `9c5eaa9d93a7037b55e858f4ea14f8eace67f2fa`:

- 3 commits ahead / 0 behind;
- exactly 2 added files;
- one pure root audio-math module;
- one deterministic Storybook story;
- no package/dependency/live-runtime changes.

This branch is independent of #95/#97/#96 and must not block that certification sequence.

## Local certification

Keep draft until the local campaign can cover both the root historical TypeScript target and Storybook gate.

### Root numeric/compatibility checks

1. TypeScript 3.2 accepts the module/import from `spatialAudio.ts`.
2. Stationary repeated samples remain exactly zero velocity.
3. Constant-velocity trajectories converge to the expected vector within smoothing tolerance across 30/60/120 Hz sample cadences.
4. A large teleport resets velocity to exactly zero and marks `reset=true`.
5. Non-monotonic timestamp resets.
6. Long sample gap above enabled `maxSampleDeltaSeconds` resets; non-positive maximum disables that reset.
7. Very small positive sample delta remains finite and speed stays <= `maxSpeed`.
8. NaN/Infinity/extreme finite position, time and calibration inputs never produce non-finite outputs.
9. Bounded prediction never extrapolates past `maxPredictionSeconds` and never predicts backward for past target timestamps.
10. Feed derived listener/source velocities into #61 Doppler/closest-approach fixtures and confirm camera reset produces no transient extreme ratio.

### Storybook gate

```sh
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Exercise `Audio/Spatial/Motion Estimator` across 30/60/120 Hz, smoothing extremes, speed-limit changes and teleport on/off. Confirm reset markers/metrics agree with the pure fixtures and the story leaves no persistent browser resource behind.

## Next

After this contract is certified, #63 should use it in the moving-listener/fly-by fixture. Only then should a Web Audio compatibility adapter decide transform scheduling cadence and modern AudioParam vs legacy setter behavior.