### PR TITLE
Add deterministic three-set raid planning contract

### DIFF
--- a/experiments/storybook/src/Foundations/Topology/RaidPlanning.stories.ts
+++ b/experiments/storybook/src/Foundations/Topology/RaidPlanning.stories.ts
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	advanceRaidPlan,
+	assignRaidSector,
+	createRaidPlan,
+	raidSetCommitment,
+	raidSetIsHold,
+	resolveRaidSector,
+	type RaidCommitmentWeights,
+	type RaidSectorTarget,
+	type RaidSetPlan
+} from "@defend/gameplay/raidPlanning";
+import { createLabShell } from "../../labTheme";
+
+type RaidPlanningArgs = {
+	maximumPerTier: number;
+	currentSectorX: number;
+	currentSectorZ: number;
+	snapshotSectorX: number;
+	snapshotSectorZ: number;
+	set1R1: number;
+	set2R1: number;
+	set2R2: number;
+};
+
+const LAB_WEIGHTS: RaidCommitmentWeights = { r1: 1, r2: 4, r3: 9 };
+
+function composition(plan: RaidSetPlan): string {
+	if (raidSetIsHold(plan)) return "HOLD / NO RAID";
+	const parts: string[] = [];
+	if (plan.r1 > 0) parts.push(`R1×${plan.r1}`);
+	if (plan.r2 > 0) parts.push(`R2×${plan.r2}`);
+	if (plan.r3 > 0) parts.push(`R3×${plan.r3}`);
+	return parts.join("  ");
+}
+
+function sectorText(plan: RaidSetPlan): string {
+	return plan.sector === null
+		? "sector deferred until launch"
+		: `sector ${plan.sector.x.toFixed(1)}, ${plan.sector.z.toFixed(1)}`;
+}
+
+function setCard(plan: RaidSetPlan, index: number, prefix: string): string {
+	return `
+		<article class="raid-card ${raidSetIsHold(plan) ? "raid-card--hold" : ""}" data-${prefix}-index="${index}" data-${prefix}-hold="${raidSetIsHold(plan)}">
+			<header><strong>Set ${index + 1}</strong><span>weight ${raidSetCommitment(plan, LAB_WEIGHTS)}</span></header>
+			<div class="raid-composition">${composition(plan)}</div>
+			<div class="raid-sector">${sectorText(plan)}</div>
+		</article>
+	`;
+}
+
+const meta = {
+	title: "Foundations/Topology/Raid Planning",
+	tags: ["test", "visual"],
+	args: {
+		maximumPerTier: 9,
+		currentSectorX: -14,
+		currentSectorZ: 22,
+		snapshotSectorX: 18,
+		snapshotSectorZ: -12,
+		set1R1: 3,
+		set2R1: 1,
+		set2R2: 1
+	},
+	argTypes: {
+		maximumPerTier: { control: { type: "range", min: 1, max: 16, step: 1 } },
+		currentSectorX: { control: { type: "range", min: -50, max: 50, step: 1 } },
+		currentSectorZ: { control: { type: "range", min: -50, max: 50, step: 1 } },
+		snapshotSectorX: { control: { type: "range", min: -50, max: 50, step: 1 } },
+		snapshotSectorZ: { control: { type: "range", min: -50, max: 50, step: 1 } },
+		set1R1: { control: { type: "range", min: 0, max: 16, step: 1 } },
+		set2R1: { control: { type: "range", min: 0, max: 16, step: 1 } },
+		set2R2: { control: { type: "range", min: 0, max: 16, step: 1 } }
+	},
+	render: (args: RaidPlanningArgs) => {
+		const currentSector: RaidSectorTarget = {
+			x: args.currentSectorX,
+			z: args.currentSectorZ
+		};
+		const snapshotSector: RaidSectorTarget = {
+			x: args.snapshotSectorX,
+			z: args.snapshotSectorZ
+		};
+		const initial = createRaidPlan(
+			[
+				{ r1: args.set1R1, r2: 0, r3: 0, sector: null },
+				{ r1: args.set2R1, r2: args.set2R2, r3: 0, sector: null },
+				{ r1: 0, r2: 0, r3: 0, sector: null }
+			],
+			args.maximumPerTier
+		);
+		const planned = assignRaidSector(initial, 1, snapshotSector, args.maximumPerTier);
+		const advanced = advanceRaidPlan(planned, args.maximumPerTier);
+		const deferredResolved = resolveRaidSector(planned[0], currentSector);
+		const snappedResolved = resolveRaidSector(planned[1], currentSector);
+
+		const shell = createLabShell(
+			"Foundations / topology",
+			"Three-set raid planning",
+			"The mothership owns exactly three upcoming decisions. A set may be a real composition or an intentional HOLD, and its ground sector may either be snapshotted now or deferred until launch. Queue semantics are deterministic; launch costs remain caller-owned."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.raid-columns { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+				.raid-stack { display:grid; gap:10px; }
+				.raid-card { padding:12px; border:1px solid rgba(228,185,128,.22); background:rgba(10,3,17,.42); }
+				.raid-card--hold { border-style:dashed; opacity:.68; }
+				.raid-card header { display:flex; justify-content:space-between; gap:12px; font-size:12px; }
+				.raid-composition { margin-top:9px; color:#49d7d1; min-height:18px; }
+				.raid-sector { margin-top:5px; font-size:11px; color:rgba(244,237,247,.5); }
+				.raid-resolution { display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-top:14px; }
+				.raid-resolution > div { padding:10px; border:1px solid rgba(244,237,247,.08); }
+				.raid-resolution small { display:block; color:rgba(244,237,247,.42); margin-bottom:5px; }
+				.raid-note { margin-top:12px; font-size:11px; color:rgba(244,237,247,.5); }
+			</style>
+			<div class="raid-columns">
+				<section class="lab__panel lab__panel--padded">
+					<h2 class="lab__section-title">Upcoming horizon</h2>
+					<div class="raid-stack">${planned.map((plan, index) => setCard(plan, index, "planned")).join("")}</div>
+				</section>
+				<section class="lab__panel lab__panel--padded">
+					<h2 class="lab__section-title">After set 1 launches</h2>
+					<div class="raid-stack">${advanced.map((plan, index) => setCard(plan, index, "advanced")).join("")}</div>
+				</section>
+			</div>
+			<section class="lab__panel lab__panel--padded" style="margin-top:16px">
+				<h2 class="lab__section-title">Sector resolution</h2>
+				<div class="raid-resolution">
+					<div><small>Set 1 · deferred</small><strong data-deferred-x="${deferredResolved.x}" data-deferred-z="${deferredResolved.z}">${deferredResolved.x.toFixed(1)}, ${deferredResolved.z.toFixed(1)}</strong></div>
+					<div><small>Set 2 · snapshotted</small><strong data-snapped-x="${snappedResolved.x}" data-snapped-z="${snappedResolved.z}">${snappedResolved.x.toFixed(1)}, ${snappedResolved.z.toFixed(1)}</strong></div>
+				</div>
+				<div class="raid-note">Displayed 1/4/9 weights are supplied by this Storybook fixture only. The gameplay contract does not define launch cost.</div>
+			</section>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<RaidPlanningArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ThreeSetHorizon: Story = {
+	play: async ({ canvasElement, args }) => {
+		const planned = canvasElement.querySelectorAll<HTMLElement>("[data-planned-index]");
+		const advanced = canvasElement.querySelectorAll<HTMLElement>("[data-advanced-index]");
+		const deferred = canvasElement.querySelector<HTMLElement>("[data-deferred-x]");
+		const snapped = canvasElement.querySelector<HTMLElement>("[data-snapped-x]");
+		await expect(planned.length).toBe(3);
+		await expect(advanced.length).toBe(3);
+		await expect(deferred).not.toBeNull();
+		await expect(snapped).not.toBeNull();
+		if (!deferred || !snapped) return;
+		await expect(Number(deferred.dataset.deferredX)).toBe(args.currentSectorX);
+		await expect(Number(deferred.dataset.deferredZ)).toBe(args.currentSectorZ);
+		await expect(Number(snapped.dataset.snappedX)).toBe(args.snapshotSectorX);
+		await expect(Number(snapped.dataset.snappedZ)).toBe(args.snapshotSectorZ);
+		await expect(advanced[2].dataset.advancedHold).toBe("true");
+	}
+};

--- a/src/js/gameplay/raidPlanning.ts
+++ b/src/js/gameplay/raidPlanning.ts
@@ -1,0 +1,208 @@
+export type RaiderTier = 1 | 2 | 3;
+
+export interface RaidSectorTarget {
+	x: number;
+	z: number;
+}
+
+export interface RaidSetPlan {
+	r1: number;
+	r2: number;
+	r3: number;
+	sector: RaidSectorTarget | null;
+}
+
+export interface RaidCommitmentWeights {
+	r1: number;
+	r2: number;
+	r3: number;
+}
+
+const RAID_HORIZON = 3;
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function nonNegativeInteger(value: number, maximum: number): number {
+	const limit = Math.max(0, Math.floor(finite(maximum)));
+	return Math.max(0, Math.min(limit, Math.floor(finite(value))));
+}
+
+function copySector(sector: RaidSectorTarget | null): RaidSectorTarget | null {
+	if (sector === null) {
+		return null;
+	}
+	return { x: finite(sector.x), z: finite(sector.z) };
+}
+
+export function emptyRaidSet(): RaidSetPlan {
+	return { r1: 0, r2: 0, r3: 0, sector: null };
+}
+
+export function normalizeRaidSet(
+	plan: RaidSetPlan,
+	maximumPerTier: number
+): RaidSetPlan {
+	return {
+		r1: nonNegativeInteger(plan.r1, maximumPerTier),
+		r2: nonNegativeInteger(plan.r2, maximumPerTier),
+		r3: nonNegativeInteger(plan.r3, maximumPerTier),
+		sector: copySector(plan.sector)
+	};
+}
+
+/**
+ * Always return exactly three upcoming raid sets. Missing entries become HOLD;
+ * extra entries are intentionally discarded so callers cannot silently grow
+ * an unbounded plan horizon.
+ */
+export function createRaidPlan(
+	initial: RaidSetPlan[],
+	maximumPerTier: number
+): RaidSetPlan[] {
+	const result: RaidSetPlan[] = [];
+	for (let index = 0; index < RAID_HORIZON; index += 1) {
+		const plan = initial[index];
+		result.push(
+			plan === undefined ? emptyRaidSet() : normalizeRaidSet(plan, maximumPerTier)
+		);
+	}
+	return result;
+}
+
+function tierKey(tier: RaiderTier): "r1" | "r2" | "r3" {
+	return tier === 1 ? "r1" : tier === 2 ? "r2" : "r3";
+}
+
+export function setRaidTierCount(
+	queue: RaidSetPlan[],
+	index: number,
+	tier: RaiderTier,
+	count: number,
+	maximumPerTier: number
+): RaidSetPlan[] {
+	const next = createRaidPlan(queue, maximumPerTier);
+	if (index < 0 || index >= RAID_HORIZON) {
+		return next;
+	}
+	const key = tierKey(tier);
+	next[index] = {
+		r1: next[index].r1,
+		r2: next[index].r2,
+		r3: next[index].r3,
+		sector: copySector(next[index].sector)
+	};
+	next[index][key] = nonNegativeInteger(count, maximumPerTier);
+	return next;
+}
+
+export function adjustRaidTierCount(
+	queue: RaidSetPlan[],
+	index: number,
+	tier: RaiderTier,
+	delta: number,
+	maximumPerTier: number
+): RaidSetPlan[] {
+	const normalized = createRaidPlan(queue, maximumPerTier);
+	if (index < 0 || index >= RAID_HORIZON) {
+		return normalized;
+	}
+	const key = tierKey(tier);
+	return setRaidTierCount(
+		normalized,
+		index,
+		tier,
+		normalized[index][key] + finite(delta),
+		maximumPerTier
+	);
+}
+
+export function holdRaidSet(
+	queue: RaidSetPlan[],
+	index: number,
+	maximumPerTier: number
+): RaidSetPlan[] {
+	const next = createRaidPlan(queue, maximumPerTier);
+	if (index < 0 || index >= RAID_HORIZON) {
+		return next;
+	}
+	next[index] = {
+		r1: 0,
+		r2: 0,
+		r3: 0,
+		sector: copySector(next[index].sector)
+	};
+	return next;
+}
+
+export function assignRaidSector(
+	queue: RaidSetPlan[],
+	index: number,
+	sector: RaidSectorTarget | null,
+	maximumPerTier: number
+): RaidSetPlan[] {
+	const next = createRaidPlan(queue, maximumPerTier);
+	if (index < 0 || index >= RAID_HORIZON) {
+		return next;
+	}
+	next[index] = {
+		r1: next[index].r1,
+		r2: next[index].r2,
+		r3: next[index].r3,
+		sector: copySector(sector)
+	};
+	return next;
+}
+
+export function advanceRaidPlan(
+	queue: RaidSetPlan[],
+	maximumPerTier: number
+): RaidSetPlan[] {
+	const normalized = createRaidPlan(queue, maximumPerTier);
+	return [normalized[1], normalized[2], emptyRaidSet()].map(plan =>
+		normalizeRaidSet(plan, maximumPerTier)
+	);
+}
+
+export function raidSetIsHold(plan: RaidSetPlan): boolean {
+	return plan.r1 <= 0 && plan.r2 <= 0 && plan.r3 <= 0;
+}
+
+export function raidSetBodyCount(plan: RaidSetPlan): number {
+	return (
+		nonNegativeInteger(plan.r1, Number.MAX_SAFE_INTEGER) +
+		nonNegativeInteger(plan.r2, Number.MAX_SAFE_INTEGER) +
+		nonNegativeInteger(plan.r3, Number.MAX_SAFE_INTEGER)
+	);
+}
+
+/**
+ * Commitment is deliberately caller-weighted. The gameplay contract owns queue
+ * semantics, not final launch costs or the temporary 1/4/9 lab visualization.
+ */
+export function raidSetCommitment(
+	plan: RaidSetPlan,
+	weights: RaidCommitmentWeights
+): number {
+	return (
+		Math.max(0, finite(plan.r1)) * Math.max(0, finite(weights.r1)) +
+		Math.max(0, finite(plan.r2)) * Math.max(0, finite(weights.r2)) +
+		Math.max(0, finite(plan.r3)) * Math.max(0, finite(weights.r3))
+	);
+}
+
+/**
+ * A set may snapshot a sector in advance or defer until launch. Returning a
+ * copy prevents later UI/navigation mutation from changing the resolved target.
+ */
+export function resolveRaidSector(
+	plan: RaidSetPlan,
+	currentSector: RaidSectorTarget
+): RaidSectorTarget {
+	const chosen = plan.sector === null ? currentSector : plan.sector;
+	return { x: finite(chosen.x), z: finite(chosen.z) };
+}

--- a/src/js/gameplay/raidPlanning.ts
+++ b/src/js/gameplay/raidPlanning.ts
@@ -19,6 +19,7 @@ export interface RaidCommitmentWeights {
 }
 
 const RAID_HORIZON = 3;
+const MAX_COUNT_FOR_SUMMARY = 2147483647;
 
 function finite(value: number, fallback = 0): number {
 	if (value !== value || value === Infinity || value === -Infinity) {
@@ -174,9 +175,9 @@ export function raidSetIsHold(plan: RaidSetPlan): boolean {
 
 export function raidSetBodyCount(plan: RaidSetPlan): number {
 	return (
-		nonNegativeInteger(plan.r1, Number.MAX_SAFE_INTEGER) +
-		nonNegativeInteger(plan.r2, Number.MAX_SAFE_INTEGER) +
-		nonNegativeInteger(plan.r3, Number.MAX_SAFE_INTEGER)
+		nonNegativeInteger(plan.r1, MAX_COUNT_FOR_SUMMARY) +
+		nonNegativeInteger(plan.r2, MAX_COUNT_FOR_SUMMARY) +
+		nonNegativeInteger(plan.r3, MAX_COUNT_FOR_SUMMARY)
 	);
 }
 


### PR DESCRIPTION
Refs #83, #92
Related: #73, #74, #87

## Purpose

Extract the reusable three-set raid-planning semantics from the merged mothership/navigation prototype without carrying over DOM, keyboard listeners, animation-frame refresh, debug globals, or temporary launch-cost assumptions.

This PR does **not** implement raider spawning, mothership movement, launch energy spend, AI planning, or final sector geometry.

## `src/js/gameplay/raidPlanning.ts`

Adds an engine-free immutable planning contract:

- exactly three upcoming raid sets;
- R1/R2/R3 integer counts with caller-supplied per-tier cap;
- missing sets normalize to intentional HOLD;
- extra sets are discarded so the planning horizon cannot silently grow;
- immutable tier-count set/adjust helpers;
- explicit HOLD/clear operation;
- optional per-set sector snapshot;
- deterministic queue advance (`2 → 1`, `3 → 2`, fresh HOLD → `3`);
- body-count summary;
- caller-supplied commitment weights;
- launch-time sector resolution: use a saved snapshot when present, otherwise resolve against the current ground sector at launch;
- copied sector values so later UI/navigation mutation cannot retroactively change a committed target.

The gameplay contract intentionally owns **queue semantics only**. The temporary 1/4/9 commitment weights from the hybrid lab are not baked into the module and do not become production launch costs.

## Storybook playground

Adds `Foundations/Topology/Raid Planning`.

The fixture shows:

- the full upcoming three-set horizon;
- a first swarm set whose sector is deliberately deferred until launch;
- a second mixed set whose sector is snapshotted in advance;
- an intentional HOLD third set;
- the queue after the first set launches;
- side-by-side resolution of deferred versus snapshotted sectors;
- lab-only commitment weights supplied by the story rather than the gameplay module.

Controls expose per-tier cap, representative R1/R2 composition, current sector, and snapshotted sector.

The Storybook assertion verifies:

- both pre/post queues contain exactly three sets;
- deferred sector resolution follows the current launch sector;
- snapshotted sector resolution remains fixed;
- queue advance appends a HOLD third slot.

The story creates no RAF, Worker, AudioContext, Babylon scene, timer, or global listener.

## Scope

Relative to current `master` `9c5eaa9d93a7037b55e858f4ea14f8eace67f2fa`:

- 3 commits ahead / 0 behind;
- 2 added files;
- no dependency/package changes;
- no production call-site changes;
- no balance-cost constants;
- no rendering or navigation changes.

## Certification

Include in the next #92 root + Storybook campaign when practical:

- root TypeScript/build compatibility for `raidPlanning.ts`;
- Storybook `pnpm typecheck`, `pnpm build`, `pnpm test`;
- exercise count caps and both sector controls;
- verify queue length is always three;
- verify HOLD survives normalization/advance;
- verify current-sector mutation does not alter a snapshotted target.

Keep draft until those gates are recorded.

## Follow-up

After certification, replace the queue mutation logic inside the merged `experiments/hybrid-engine/src/raidPlanPrototype.ts` with this contract while leaving its lab UI presentation intact. Mothership launch-cost and reserve-spend rules should be layered later from explicit economy design rather than inferred from the old 1/4/9 display weights.