### PR TITLE
Add deterministic mothership navigation and silo-attraction contract

### DIFF
--- a/experiments/storybook/src/Foundations/Physics/MothershipNavigation.stories.ts
+++ b/experiments/storybook/src/Foundations/Physics/MothershipNavigation.stories.ts
@@ -23,7 +23,6 @@ type NavigationArgs = {
 interface TracePoint {
 	time: number;
 	position: NavigationVector2;
-	reserve: number;
 	phase: string;
 }
 
@@ -54,7 +53,6 @@ function config(args: NavigationArgs): MothershipNavigationConfig {
 		captureInwardSpeed: args.captureInwardSpeed,
 		capturedAccelerationMultiplier: 1.35,
 		overspeedFactor: 1.35,
-		hoverDrainPerSecond: 0.0025,
 		movementDrainPerAcceleration: 0.00028
 	};
 }
@@ -74,7 +72,6 @@ function simulate(
 		points.push({
 			time: elapsed,
 			position: { x: state.position.x, z: state.position.z },
-			reserve: state.reserve,
 			phase: state.phase
 		});
 		const step = stepMothershipNavigation(state, deltaSeconds, calibration);
@@ -130,13 +127,12 @@ const meta = {
 		);
 		const safeTargetDistance = navigationVectorLength(projection.desiredPosition);
 
-		let farState = createMothershipNavigationState(start, 1, nearSector, calibration);
+		let farState = createMothershipNavigationState(start, nearSector, calibration);
 		farState = setMothershipRaidSector(farState, farSector, calibration);
 		const farTrace = simulate(farState, args.simulationSeconds, 1 / 60, calibration);
 
 		const captureBase = createMothershipNavigationState(
 			{ x: 13, z: 0 },
-			1,
 			nearSector,
 			calibration
 		);
@@ -163,7 +159,7 @@ const meta = {
 		const shell = createLabShell(
 			"Foundations / physics",
 			"Mothership inertia and silo attraction",
-			"Ground input chooses intent, not position. A near-silo raid sector is projected to a safe ship target, but persistent inward momentum can still carry the vessel into the attraction field and eventually remove steering authority. Propulsion energy follows engine steering effort; the silo field itself is external."
+			"Ground input chooses intent, not position. A near-silo raid sector is projected to a safe ship target, but persistent inward momentum can still carry the vessel into the attraction field and eventually remove steering authority. Navigation reports propulsion demand; the mothership energy/lift authority decides whether that demand can be paid."
 		);
 
 		shell.frame.innerHTML = `
@@ -203,10 +199,10 @@ const meta = {
 						<div class="lab__metric"><dt>Safe target radius</dt><dd data-target-distance="${safeTargetDistance}">${safeTargetDistance.toFixed(2)}</dd></div>
 						<div class="lab__metric"><dt>Max engine acceleration</dt><dd data-max-steering="${farTrace.maximumSteeringAcceleration}">${farTrace.maximumSteeringAcceleration.toFixed(2)}</dd></div>
 						<div class="lab__metric"><dt>Far final speed</dt><dd>${navigationVectorLength(farTrace.finalState.velocity).toFixed(2)}</dd></div>
-						<div class="lab__metric"><dt>Far reserve</dt><dd>${(farTrace.finalState.reserve * 100).toFixed(2)}%</dd></div>
+						<div class="lab__metric"><dt>Far propulsion demand</dt><dd>${(farTrace.finalState.totalMovementEnergy * 100).toFixed(3)}%</dd></div>
 						<div class="lab__metric"><dt>Capture @ 60 Hz</dt><dd data-capture60="${capture60.captureAt ?? -1}">${capture60.captureAt === null ? "—" : `${capture60.captureAt.toFixed(3)} s`}</dd></div>
 						<div class="lab__metric"><dt>Capture @ 30 Hz</dt><dd data-capture30="${capture30.captureAt ?? -1}">${capture30.captureAt === null ? "—" : `${capture30.captureAt.toFixed(3)} s`}</dd></div>
-						<div class="lab__metric"><dt>Captured movement cost</dt><dd>${(captureTrace.finalState.totalMovementEnergy * 100).toFixed(3)}%</dd></div>
+						<div class="lab__metric"><dt>Captured propulsion demand</dt><dd>${(captureTrace.finalState.totalMovementEnergy * 100).toFixed(3)}%</dd></div>
 					</dl>
 				</aside>
 			</div>

--- a/experiments/storybook/src/Foundations/Physics/MothershipNavigation.stories.ts
+++ b/experiments/storybook/src/Foundations/Physics/MothershipNavigation.stories.ts
@@ -1,0 +1,244 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	createMothershipNavigationState,
+	navigationVectorLength,
+	projectMothershipTargetForSector,
+	setMothershipRaidSector,
+	stepMothershipNavigation,
+	type MothershipNavigationConfig,
+	type MothershipNavigationState,
+	type NavigationVector2
+} from "@defend/gameplay/mothershipNavigation";
+import { createLabShell } from "../../labTheme";
+
+type NavigationArgs = {
+	simulationSeconds: number;
+	maxAcceleration: number;
+	linearDamping: number;
+	attractionStrength: number;
+	captureInwardSpeed: number;
+};
+
+interface TracePoint {
+	time: number;
+	position: NavigationVector2;
+	reserve: number;
+	phase: string;
+}
+
+interface NavigationTrace {
+	points: TracePoint[];
+	finalState: MothershipNavigationState;
+	captureAt: number | null;
+	maximumSteeringAcceleration: number;
+}
+
+function config(args: NavigationArgs): MothershipNavigationConfig {
+	return {
+		maxAcceleration: args.maxAcceleration,
+		maxSpeed: 22,
+		linearDamping: args.linearDamping,
+		arrivalRadius: 4,
+		arrivalBrakeGain: 1.2,
+		minimumCruiseSpeed: 4,
+		approachSpeedPerDistance: 0.38,
+		warningRadius: 31,
+		criticalRadius: 17,
+		safeTargetRadius: 35,
+		targetLaunchOffset: 24,
+		attractionStrength: args.attractionStrength,
+		criticalAttractionStrength: 34,
+		criticalBasePull: 0.45,
+		captureRadiusFactor: 0.55,
+		captureInwardSpeed: args.captureInwardSpeed,
+		capturedAccelerationMultiplier: 1.35,
+		overspeedFactor: 1.35,
+		hoverDrainPerSecond: 0.0025,
+		movementDrainPerAcceleration: 0.00028
+	};
+}
+
+function simulate(
+	initial: MothershipNavigationState,
+	seconds: number,
+	deltaSeconds: number,
+	calibration: MothershipNavigationConfig
+): NavigationTrace {
+	let state = initial;
+	const points: TracePoint[] = [];
+	let captureAt: number | null = null;
+	let maximumSteeringAcceleration = 0;
+	let elapsed = 0;
+	while (elapsed <= seconds + 1e-9) {
+		points.push({
+			time: elapsed,
+			position: { x: state.position.x, z: state.position.z },
+			reserve: state.reserve,
+			phase: state.phase
+		});
+		const step = stepMothershipNavigation(state, deltaSeconds, calibration);
+		state = step.state;
+		elapsed += deltaSeconds;
+		maximumSteeringAcceleration = Math.max(
+			maximumSteeringAcceleration,
+			navigationVectorLength(step.steeringAcceleration)
+		);
+		if (captureAt === null && step.captureStarted) {
+			captureAt = elapsed;
+		}
+	}
+	return { points, finalState: state, captureAt, maximumSteeringAcceleration };
+}
+
+function path(points: TracePoint[], scale: number, centerX: number, centerY: number): string {
+	return points
+		.map((point, index) => {
+			const x = centerX + point.position.x * scale;
+			const y = centerY + point.position.z * scale;
+			return `${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`;
+		})
+		.join(" ");
+}
+
+const meta = {
+	title: "Foundations/Physics/Mothership Navigation",
+	tags: ["test", "visual"],
+	args: {
+		simulationSeconds: 12,
+		maxAcceleration: 7.2,
+		linearDamping: 0.42,
+		attractionStrength: 19,
+		captureInwardSpeed: 3
+	},
+	argTypes: {
+		simulationSeconds: { control: { type: "range", min: 4, max: 24, step: 1 } },
+		maxAcceleration: { control: { type: "range", min: 2, max: 14, step: 0.2 } },
+		linearDamping: { control: { type: "range", min: 0, max: 1.2, step: 0.02 } },
+		attractionStrength: { control: { type: "range", min: 0, max: 40, step: 1 } },
+		captureInwardSpeed: { control: { type: "range", min: 0.5, max: 10, step: 0.5 } }
+	},
+	render: (args: NavigationArgs) => {
+		const calibration = config(args);
+		const start = { x: 48, z: 30 };
+		const nearSector = { x: 4, z: 3 };
+		const farSector = { x: -66, z: 46 };
+		const projection = projectMothershipTargetForSector(
+			nearSector,
+			start,
+			calibration
+		);
+		const safeTargetDistance = navigationVectorLength(projection.desiredPosition);
+
+		let farState = createMothershipNavigationState(start, 1, nearSector, calibration);
+		farState = setMothershipRaidSector(farState, farSector, calibration);
+		const farTrace = simulate(farState, args.simulationSeconds, 1 / 60, calibration);
+
+		const captureBase = createMothershipNavigationState(
+			{ x: 13, z: 0 },
+			1,
+			nearSector,
+			calibration
+		);
+		const captureState: MothershipNavigationState = {
+			...captureBase,
+			velocity: { x: -8, z: 0 },
+			phase: "critical"
+		};
+		const captureTrace = simulate(captureState, 2, 1 / 60, calibration);
+		const capture30 = simulate(captureState, 2, 1 / 30, calibration);
+		const capture60 = simulate(captureState, 2, 1 / 60, calibration);
+
+		const centerX = 250;
+		const centerY = 180;
+		const worldScale = 2.2;
+		const warningR = calibration.warningRadius * worldScale;
+		const criticalR = calibration.criticalRadius * worldScale;
+		const safeR = calibration.safeTargetRadius * worldScale;
+		const desiredX = centerX + projection.desiredPosition.x * worldScale;
+		const desiredY = centerY + projection.desiredPosition.z * worldScale;
+		const nearX = centerX + nearSector.x * worldScale;
+		const nearY = centerY + nearSector.z * worldScale;
+
+		const shell = createLabShell(
+			"Foundations / physics",
+			"Mothership inertia and silo attraction",
+			"Ground input chooses intent, not position. A near-silo raid sector is projected to a safe ship target, but persistent inward momentum can still carry the vessel into the attraction field and eventually remove steering authority. Propulsion energy follows engine steering effort; the silo field itself is external."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.nav-grid { display:grid; grid-template-columns:minmax(0,1.35fr) minmax(280px,.65fr); gap:16px; }
+				.nav-map { width:100%; min-height:410px; }
+				.nav-ring { fill:none; vector-effect:non-scaling-stroke; }
+				.nav-warning { stroke:rgba(228,185,128,.28); stroke-dasharray:6 5; }
+				.nav-critical { stroke:rgba(239,90,104,.38); stroke-width:1.5; }
+				.nav-safe { stroke:rgba(73,215,209,.22); stroke-dasharray:3 5; }
+				.nav-far-path { fill:none; stroke:#e4b980; stroke-width:2.2; }
+				.nav-capture-path { fill:none; stroke:#b46bd3; stroke-width:2.2; }
+				.nav-sector { fill:#49d7d1; }
+				.nav-target { fill:none; stroke:#f4edf7; stroke-width:2; }
+				.nav-link { stroke:rgba(244,237,247,.26); stroke-dasharray:4 4; }
+				.nav-label { fill:rgba(244,237,247,.5); font-size:10px; }
+			</style>
+			<div class="nav-grid">
+				<section class="lab__panel lab__stage">
+					<svg class="nav-map" viewBox="0 0 500 370" aria-label="Mothership navigation traces around the silo">
+						<circle class="nav-ring nav-safe" cx="${centerX}" cy="${centerY}" r="${safeR}" />
+						<circle class="nav-ring nav-warning" cx="${centerX}" cy="${centerY}" r="${warningR}" />
+						<circle class="nav-ring nav-critical" cx="${centerX}" cy="${centerY}" r="${criticalR}" />
+						<circle cx="${centerX}" cy="${centerY}" r="9" fill="rgba(73,215,209,.38)" />
+						<path class="nav-far-path" d="${path(farTrace.points, worldScale, centerX, centerY)}" />
+						<path class="nav-capture-path" d="${path(captureTrace.points, worldScale, centerX, centerY)}" />
+						<line class="nav-link" x1="${nearX}" y1="${nearY}" x2="${desiredX}" y2="${desiredY}" />
+						<circle class="nav-sector" cx="${nearX}" cy="${nearY}" r="5" />
+						<circle class="nav-target" cx="${desiredX}" cy="${desiredY}" r="6" />
+						<text class="nav-label" x="18" y="24">copper = commanded far reposition · violet = dangerous inertial approach</text>
+					</svg>
+				</section>
+				<aside class="lab__panel lab__panel--padded">
+					<h2 class="lab__section-title">Navigation contract</h2>
+					<dl class="lab__metrics">
+						<div class="lab__metric"><dt>Near target projected</dt><dd data-projected="${projection.projected}">${projection.projected ? "YES" : "NO"}</dd></div>
+						<div class="lab__metric"><dt>Safe target radius</dt><dd data-target-distance="${safeTargetDistance}">${safeTargetDistance.toFixed(2)}</dd></div>
+						<div class="lab__metric"><dt>Max engine acceleration</dt><dd data-max-steering="${farTrace.maximumSteeringAcceleration}">${farTrace.maximumSteeringAcceleration.toFixed(2)}</dd></div>
+						<div class="lab__metric"><dt>Far final speed</dt><dd>${navigationVectorLength(farTrace.finalState.velocity).toFixed(2)}</dd></div>
+						<div class="lab__metric"><dt>Far reserve</dt><dd>${(farTrace.finalState.reserve * 100).toFixed(2)}%</dd></div>
+						<div class="lab__metric"><dt>Capture @ 60 Hz</dt><dd data-capture60="${capture60.captureAt ?? -1}">${capture60.captureAt === null ? "—" : `${capture60.captureAt.toFixed(3)} s`}</dd></div>
+						<div class="lab__metric"><dt>Capture @ 30 Hz</dt><dd data-capture30="${capture30.captureAt ?? -1}">${capture30.captureAt === null ? "—" : `${capture30.captureAt.toFixed(3)} s`}</dd></div>
+						<div class="lab__metric"><dt>Captured movement cost</dt><dd>${(captureTrace.finalState.totalMovementEnergy * 100).toFixed(3)}%</dd></div>
+					</dl>
+				</aside>
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<NavigationArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ProjectionInertiaAndCapture: Story = {
+	play: async ({ canvasElement, args }) => {
+		const projected = canvasElement.querySelector<HTMLElement>("[data-projected]");
+		const targetDistance = canvasElement.querySelector<HTMLElement>("[data-target-distance]");
+		const maxSteering = canvasElement.querySelector<HTMLElement>("[data-max-steering]");
+		const capture30 = canvasElement.querySelector<HTMLElement>("[data-capture30]");
+		const capture60 = canvasElement.querySelector<HTMLElement>("[data-capture60]");
+		await expect(projected).not.toBeNull();
+		await expect(targetDistance).not.toBeNull();
+		await expect(maxSteering).not.toBeNull();
+		await expect(capture30).not.toBeNull();
+		await expect(capture60).not.toBeNull();
+		if (!projected || !targetDistance || !maxSteering || !capture30 || !capture60) return;
+
+		await expect(projected.dataset.projected).toBe("true");
+		await expect(Number(targetDistance.dataset.targetDistance)).toBeGreaterThanOrEqual(35 - 1e-9);
+		await expect(Number(maxSteering.dataset.maxSteering)).toBeLessThanOrEqual(args.maxAcceleration + 1e-9);
+		const t30 = Number(capture30.dataset.capture30);
+		const t60 = Number(capture60.dataset.capture60);
+		if (t30 >= 0 && t60 >= 0) {
+			await expect(Math.abs(t30 - t60)).toBeLessThan(0.08);
+		}
+	}
+};

--- a/src/js/gameplay/mothershipNavigation.ts
+++ b/src/js/gameplay/mothershipNavigation.ts
@@ -24,7 +24,6 @@ export interface MothershipNavigationConfig {
 	captureInwardSpeed: number;
 	capturedAccelerationMultiplier: number;
 	overspeedFactor: number;
-	hoverDrainPerSecond: number;
 	movementDrainPerAcceleration: number;
 }
 
@@ -33,7 +32,6 @@ export interface MothershipNavigationState {
 	velocity: NavigationVector2;
 	desiredPosition: NavigationVector2;
 	raidSector: NavigationVector2;
-	reserve: number;
 	phase: MothershipNavigationPhase;
 	totalMovementEnergy: number;
 	projectedTargetCount: number;
@@ -49,8 +47,8 @@ export interface MothershipNavigationStep {
 	steeringAcceleration: NavigationVector2;
 	attractionAcceleration: NavigationVector2;
 	appliedAcceleration: NavigationVector2;
+	/** Propulsion-energy demand for this step. A separate reserve authority applies it. */
 	movementEnergy: number;
-	hoverEnergy: number;
 	captureStarted: boolean;
 }
 
@@ -136,7 +134,6 @@ function safeConfig(config: MothershipNavigationConfig): MothershipNavigationCon
 		captureInwardSpeed: positive(config.captureInwardSpeed),
 		capturedAccelerationMultiplier: positive(config.capturedAccelerationMultiplier),
 		overspeedFactor: Math.max(1, positive(config.overspeedFactor)),
-		hoverDrainPerSecond: positive(config.hoverDrainPerSecond),
 		movementDrainPerAcceleration: positive(config.movementDrainPerAcceleration)
 	};
 }
@@ -175,7 +172,6 @@ export function projectMothershipTargetForSector(
 
 export function createMothershipNavigationState(
 	position: NavigationVector2,
-	reserve: number,
 	sector: NavigationVector2,
 	config: MothershipNavigationConfig
 ): MothershipNavigationState {
@@ -185,7 +181,6 @@ export function createMothershipNavigationState(
 		velocity: { x: 0, z: 0 },
 		desiredPosition: projection.desiredPosition,
 		raidSector: vector(sector.x, sector.z),
-		reserve: clamp(reserve, 0, 1),
 		phase: mothershipNavigationPhase(position, config),
 		totalMovementEnergy: 0,
 		projectedTargetCount: projection.projected ? 1 : 0
@@ -203,7 +198,6 @@ export function setMothershipRaidSector(
 		velocity: vector(state.velocity.x, state.velocity.z),
 		desiredPosition: projection.desiredPosition,
 		raidSector: vector(sector.x, sector.z),
-		reserve: clamp(state.reserve, 0, 1),
 		phase: state.phase,
 		totalMovementEnergy: positive(state.totalMovementEnergy),
 		projectedTargetCount:
@@ -299,13 +293,12 @@ export function stepMothershipNavigation(
 	velocity = limitMagnitude(velocity, safe.maxSpeed * safe.overspeedFactor);
 	const position = add(state.position, scale(velocity, dt));
 
-	// Only engine steering consumes movement reserve. Silo attraction is an
-	// external field; charging it as propulsion would make being pulled inward
-	// consume energy even after control authority is lost.
+	// Only engine steering produces propulsion demand. Silo attraction is an
+	// external field; a separate mothership energy authority decides whether the
+	// requested movement energy can actually be paid together with hover/launch
+	// costs and what low reserve does to lift.
 	const movementEnergy =
 		navigationVectorLength(steering) * safe.movementDrainPerAcceleration * dt;
-	const hoverEnergy = safe.hoverDrainPerSecond * dt;
-	const reserve = Math.max(0, finite(state.reserve) - movementEnergy - hoverEnergy);
 
 	return {
 		state: {
@@ -313,7 +306,6 @@ export function stepMothershipNavigation(
 			velocity,
 			desiredPosition: vector(state.desiredPosition.x, state.desiredPosition.z),
 			raidSector: vector(state.raidSector.x, state.raidSector.z),
-			reserve,
 			phase,
 			totalMovementEnergy: positive(state.totalMovementEnergy) + movementEnergy,
 			projectedTargetCount: positive(state.projectedTargetCount)
@@ -322,7 +314,6 @@ export function stepMothershipNavigation(
 		attractionAcceleration: attraction,
 		appliedAcceleration: acceleration,
 		movementEnergy,
-		hoverEnergy,
 		captureStarted
 	};
 }

--- a/src/js/gameplay/mothershipNavigation.ts
+++ b/src/js/gameplay/mothershipNavigation.ts
@@ -1,0 +1,321 @@
+export type MothershipNavigationPhase = "stable" | "warning" | "critical" | "captured";
+
+export interface NavigationVector2 {
+	x: number;
+	z: number;
+}
+
+export interface MothershipNavigationConfig {
+	maxAcceleration: number;
+	maxSpeed: number;
+	linearDamping: number;
+	arrivalRadius: number;
+	arrivalBrakeGain: number;
+	minimumCruiseSpeed: number;
+	approachSpeedPerDistance: number;
+	warningRadius: number;
+	criticalRadius: number;
+	safeTargetRadius: number;
+	targetLaunchOffset: number;
+	attractionStrength: number;
+	criticalAttractionStrength: number;
+	criticalBasePull: number;
+	captureRadiusFactor: number;
+	captureInwardSpeed: number;
+	capturedAccelerationMultiplier: number;
+	overspeedFactor: number;
+	hoverDrainPerSecond: number;
+	movementDrainPerAcceleration: number;
+}
+
+export interface MothershipNavigationState {
+	position: NavigationVector2;
+	velocity: NavigationVector2;
+	desiredPosition: NavigationVector2;
+	raidSector: NavigationVector2;
+	reserve: number;
+	phase: MothershipNavigationPhase;
+	totalMovementEnergy: number;
+	projectedTargetCount: number;
+}
+
+export interface MothershipTargetProjection {
+	desiredPosition: NavigationVector2;
+	projected: boolean;
+}
+
+export interface MothershipNavigationStep {
+	state: MothershipNavigationState;
+	steeringAcceleration: NavigationVector2;
+	attractionAcceleration: NavigationVector2;
+	appliedAcceleration: NavigationVector2;
+	movementEnergy: number;
+	hoverEnergy: number;
+	captureStarted: boolean;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
+}
+
+function vector(x: number, z: number): NavigationVector2 {
+	return { x: finite(x), z: finite(z) };
+}
+
+function add(a: NavigationVector2, b: NavigationVector2): NavigationVector2 {
+	return vector(a.x + b.x, a.z + b.z);
+}
+
+function subtract(a: NavigationVector2, b: NavigationVector2): NavigationVector2 {
+	return vector(a.x - b.x, a.z - b.z);
+}
+
+function scale(value: NavigationVector2, amount: number): NavigationVector2 {
+	return vector(value.x * finite(amount), value.z * finite(amount));
+}
+
+export function navigationVectorLength(value: NavigationVector2): number {
+	const x = finite(value.x);
+	const z = finite(value.z);
+	return Math.sqrt(x * x + z * z);
+}
+
+function normalize(
+	value: NavigationVector2,
+	fallback: NavigationVector2 = { x: 1, z: 0 }
+): NavigationVector2 {
+	const length = navigationVectorLength(value);
+	if (length > 0.000001) {
+		return scale(value, 1 / length);
+	}
+	const fallbackLength = navigationVectorLength(fallback);
+	if (fallbackLength > 0.000001) {
+		return scale(fallback, 1 / fallbackLength);
+	}
+	return { x: 1, z: 0 };
+}
+
+function limitMagnitude(value: NavigationVector2, maximum: number): NavigationVector2 {
+	const limit = positive(maximum);
+	const length = navigationVectorLength(value);
+	if (length <= limit || length <= 0.000001) {
+		return vector(value.x, value.z);
+	}
+	return scale(value, limit / length);
+}
+
+function safeConfig(config: MothershipNavigationConfig): MothershipNavigationConfig {
+	const warningRadius = positive(config.warningRadius);
+	return {
+		maxAcceleration: positive(config.maxAcceleration),
+		maxSpeed: positive(config.maxSpeed),
+		linearDamping: positive(config.linearDamping),
+		arrivalRadius: positive(config.arrivalRadius),
+		arrivalBrakeGain: positive(config.arrivalBrakeGain),
+		minimumCruiseSpeed: positive(config.minimumCruiseSpeed),
+		approachSpeedPerDistance: positive(config.approachSpeedPerDistance),
+		warningRadius,
+		criticalRadius: clamp(config.criticalRadius, 0, warningRadius),
+		safeTargetRadius: Math.max(warningRadius, positive(config.safeTargetRadius)),
+		targetLaunchOffset: positive(config.targetLaunchOffset),
+		attractionStrength: positive(config.attractionStrength),
+		criticalAttractionStrength: positive(config.criticalAttractionStrength),
+		criticalBasePull: positive(config.criticalBasePull),
+		captureRadiusFactor: clamp(config.captureRadiusFactor, 0, 1),
+		captureInwardSpeed: positive(config.captureInwardSpeed),
+		capturedAccelerationMultiplier: positive(config.capturedAccelerationMultiplier),
+		overspeedFactor: Math.max(1, positive(config.overspeedFactor)),
+		hoverDrainPerSecond: positive(config.hoverDrainPerSecond),
+		movementDrainPerAcceleration: positive(config.movementDrainPerAcceleration)
+	};
+}
+
+export function mothershipNavigationPhase(
+	position: NavigationVector2,
+	config: MothershipNavigationConfig
+): MothershipNavigationPhase {
+	const safe = safeConfig(config);
+	const distance = navigationVectorLength(position);
+	if (distance <= safe.criticalRadius) return "critical";
+	if (distance <= safe.warningRadius) return "warning";
+	return "stable";
+}
+
+/**
+ * Convert a desired ground raid sector into a ship target offset away from the
+ * silo. Target projection prevents ordinary input from commanding the ship into
+ * the attraction field, while existing momentum may still carry it there.
+ */
+export function projectMothershipTargetForSector(
+	sector: NavigationVector2,
+	currentPosition: NavigationVector2,
+	config: MothershipNavigationConfig
+): MothershipTargetProjection {
+	const safe = safeConfig(config);
+	const outward = normalize(sector, currentPosition);
+	let desired = add(sector, scale(outward, safe.targetLaunchOffset));
+	const distance = navigationVectorLength(desired);
+	if (distance >= safe.safeTargetRadius) {
+		return { desiredPosition: desired, projected: false };
+	}
+	desired = scale(outward, safe.safeTargetRadius);
+	return { desiredPosition: desired, projected: true };
+}
+
+export function createMothershipNavigationState(
+	position: NavigationVector2,
+	reserve: number,
+	sector: NavigationVector2,
+	config: MothershipNavigationConfig
+): MothershipNavigationState {
+	const projection = projectMothershipTargetForSector(sector, position, config);
+	return {
+		position: vector(position.x, position.z),
+		velocity: { x: 0, z: 0 },
+		desiredPosition: projection.desiredPosition,
+		raidSector: vector(sector.x, sector.z),
+		reserve: clamp(reserve, 0, 1),
+		phase: mothershipNavigationPhase(position, config),
+		totalMovementEnergy: 0,
+		projectedTargetCount: projection.projected ? 1 : 0
+	};
+}
+
+export function setMothershipRaidSector(
+	state: MothershipNavigationState,
+	sector: NavigationVector2,
+	config: MothershipNavigationConfig
+): MothershipNavigationState {
+	const projection = projectMothershipTargetForSector(sector, state.position, config);
+	return {
+		position: vector(state.position.x, state.position.z),
+		velocity: vector(state.velocity.x, state.velocity.z),
+		desiredPosition: projection.desiredPosition,
+		raidSector: vector(sector.x, sector.z),
+		reserve: clamp(state.reserve, 0, 1),
+		phase: state.phase,
+		totalMovementEnergy: positive(state.totalMovementEnergy),
+		projectedTargetCount:
+			positive(state.projectedTargetCount) + (projection.projected ? 1 : 0)
+	};
+}
+
+function steeringAcceleration(
+	state: MothershipNavigationState,
+	config: MothershipNavigationConfig
+): NavigationVector2 {
+	const safe = safeConfig(config);
+	const error = subtract(state.desiredPosition, state.position);
+	const distance = navigationVectorLength(error);
+	if (distance < safe.arrivalRadius) {
+		return scale(state.velocity, -safe.arrivalBrakeGain);
+	}
+	const desiredDirection = normalize(error);
+	const desiredSpeed = Math.min(
+		safe.maxSpeed,
+		Math.max(safe.minimumCruiseSpeed, distance * safe.approachSpeedPerDistance)
+	);
+	const desiredVelocity = scale(desiredDirection, desiredSpeed);
+	return limitMagnitude(subtract(desiredVelocity, state.velocity), safe.maxAcceleration);
+}
+
+function attractionAcceleration(
+	position: NavigationVector2,
+	phase: MothershipNavigationPhase,
+	config: MothershipNavigationConfig
+): NavigationVector2 {
+	const safe = safeConfig(config);
+	const distance = navigationVectorLength(position);
+	if (distance >= safe.warningRadius || distance < 0.000001) {
+		return { x: 0, z: 0 };
+	}
+	const inward = normalize(scale(position, -1));
+	const normalized = 1 - distance / Math.max(0.000001, safe.warningRadius);
+	const strength =
+		phase === "critical"
+			? safe.criticalAttractionStrength *
+				(safe.criticalBasePull + normalized * normalized)
+			: safe.attractionStrength * normalized * normalized;
+	return scale(inward, strength);
+}
+
+function inwardSpeed(state: MothershipNavigationState): number {
+	const outward = normalize(state.position);
+	return -(state.velocity.x * outward.x + state.velocity.z * outward.z);
+}
+
+export function stepMothershipNavigation(
+	state: MothershipNavigationState,
+	deltaSeconds: number,
+	config: MothershipNavigationConfig
+): MothershipNavigationStep {
+	const safe = safeConfig(config);
+	const dt = positive(deltaSeconds);
+	let phase =
+		state.phase === "captured"
+			? "captured"
+			: mothershipNavigationPhase(state.position, safe);
+	let captureStarted = false;
+	let steering = steeringAcceleration(state, safe);
+	let attraction = attractionAcceleration(state.position, phase, safe);
+	let acceleration = add(steering, attraction);
+
+	if (
+		phase === "critical" &&
+		navigationVectorLength(state.position) <
+			safe.criticalRadius * safe.captureRadiusFactor &&
+		inwardSpeed(state) > safe.captureInwardSpeed
+	) {
+		phase = "captured";
+		captureStarted = true;
+	}
+
+	if (phase === "captured") {
+		steering = { x: 0, z: 0 };
+		attraction = scale(
+			normalize(scale(state.position, -1)),
+			safe.criticalAttractionStrength * safe.capturedAccelerationMultiplier
+		);
+		acceleration = attraction;
+	}
+
+	let velocity = add(state.velocity, scale(acceleration, dt));
+	const damping = Math.exp(-safe.linearDamping * dt);
+	velocity = scale(velocity, damping);
+	velocity = limitMagnitude(velocity, safe.maxSpeed * safe.overspeedFactor);
+	const position = add(state.position, scale(velocity, dt));
+	const movementEnergy =
+		navigationVectorLength(acceleration) * safe.movementDrainPerAcceleration * dt;
+	const hoverEnergy = safe.hoverDrainPerSecond * dt;
+	const reserve = Math.max(0, finite(state.reserve) - movementEnergy - hoverEnergy);
+
+	return {
+		state: {
+			position,
+			velocity,
+			desiredPosition: vector(state.desiredPosition.x, state.desiredPosition.z),
+			raidSector: vector(state.raidSector.x, state.raidSector.z),
+			reserve,
+			phase,
+			totalMovementEnergy: positive(state.totalMovementEnergy) + movementEnergy,
+			projectedTargetCount: positive(state.projectedTargetCount)
+		},
+		steeringAcceleration: steering,
+		attractionAcceleration: attraction,
+		appliedAcceleration: acceleration,
+		movementEnergy,
+		hoverEnergy,
+		captureStarted
+	};
+}

--- a/src/js/gameplay/mothershipNavigation.ts
+++ b/src/js/gameplay/mothershipNavigation.ts
@@ -219,7 +219,10 @@ function steeringAcceleration(
 	const error = subtract(state.desiredPosition, state.position);
 	const distance = navigationVectorLength(error);
 	if (distance < safe.arrivalRadius) {
-		return scale(state.velocity, -safe.arrivalBrakeGain);
+		return limitMagnitude(
+			scale(state.velocity, -safe.arrivalBrakeGain),
+			safe.maxAcceleration
+		);
 	}
 	const desiredDirection = normalize(error);
 	const desiredSpeed = Math.min(
@@ -295,8 +298,12 @@ export function stepMothershipNavigation(
 	velocity = scale(velocity, damping);
 	velocity = limitMagnitude(velocity, safe.maxSpeed * safe.overspeedFactor);
 	const position = add(state.position, scale(velocity, dt));
+
+	// Only engine steering consumes movement reserve. Silo attraction is an
+	// external field; charging it as propulsion would make being pulled inward
+	// consume energy even after control authority is lost.
 	const movementEnergy =
-		navigationVectorLength(acceleration) * safe.movementDrainPerAcceleration * dt;
+		navigationVectorLength(steering) * safe.movementDrainPerAcceleration * dt;
 	const hoverEnergy = safe.hoverDrainPerSecond * dt;
 	const reserve = Math.max(0, finite(state.reserve) - movementEnergy - hoverEnergy);
 


### PR DESCRIPTION
Refs #83, #79, #92
Related: #87, #100, #102

## Purpose

Extract the reusable **horizontal** mothership-motion rules from the merged navigation lab so player input, AI, camera presentation, and later production physics can share one deterministic notion of inertia and silo attraction.

This PR intentionally does **not** own mothership reserve, hover, loss of lift, or crash. #102 is the proposed single reserve/lift authority. Navigation only reports propulsion-energy demand.

## `src/js/gameplay/mothershipNavigation.ts`

Adds an engine-free 2D navigation contract with:

- persistent position/velocity;
- desired ground raid sector distinct from desired mothership position;
- outward launch offset;
- safe-radius target projection when ordinary input would command a position too close to the silo;
- bounded engine steering acceleration;
- bounded arrival braking using the same engine acceleration ceiling;
- configurable cruise/approach speed and exponential damping;
- stable / warning / critical / captured phases from silo distance;
- continuous nonlinear inward silo-attraction field;
- capture only when the vessel is deep inside the critical region **and already moving inward above a threshold**;
- captured state removes steering authority and applies stronger inward attraction;
- horizontal overspeed cap;
- per-step propulsion-energy demand derived from **engine steering effort only**;
- cumulative movement-demand diagnostics;
- projected target count and capture-transition diagnostics.

### Intentional corrections from the lab prototype

The merged `mothershipNavigationPrototype.ts` contains three shortcuts that should not become shared gameplay semantics:

1. its near-target braking (`velocity * -1.2`) can exceed nominal max engine acceleration; the extracted contract bounds braking to engine capability;
2. its movement-energy accounting charges steering **plus external silo attraction**; the extracted contract reports propulsion demand from engine steering only;
3. it directly decrements a local reserve and hover drain. The extracted contract owns no reserve at all; #102 is intended to apply movement demand together with hover, launch spend, and extraction inflow to one conserved teal pool.

These are physical/ownership corrections, not balance tuning.

## Storybook playground

Adds `Foundations/Physics/Mothership Navigation`.

The deterministic fixture overlays:

- safe / warning / critical silo radii;
- a near-silo ground sector whose desired ship position is projected outward to the safe radius;
- a commanded far reposition trace showing acceleration/inertia/braking;
- a deliberately dangerous inertial approach starting inside the critical region with inward velocity, demonstrating that safe target projection does not erase momentum risk;
- propulsion-demand and steering diagnostics;
- 30 Hz versus 60 Hz capture timing.

The default capture fixture preserves the existing PoC condition shape: capture radius factor 0.55 and inward-speed threshold 3, while all calibration values remain Storybook/PoC values rather than production campaign balance.

The Storybook assertion verifies:

- the near-silo target is projected;
- projected desired position is outside the 35-unit lab safe radius;
- engine steering never exceeds configured max acceleration;
- when capture occurs at both 30 Hz and 60 Hz, event timing differs by less than 0.08 s.

The story creates no RAF, Worker, AudioContext, Babylon scene, timer, or global listener.

## Scope

Current head: `adb584b6d68e23f3bc3fed07e2c4331f4c60c93f`.

Relative to `master` at branch creation:

- 2 files only;
- no package/dependency changes;
- no live Babylon/Cannon call-site changes;
- no camera implementation changes;
- no vertical crash/lift changes;
- no reserve authority;
- no final balance constants.

## Certification

Include in the next #92 root + Storybook campaign when practical:

- root TypeScript/build compatibility for `mothershipNavigation.ts`;
- Storybook typecheck/build/test;
- exercise acceleration, damping, attraction and capture-threshold controls;
- verify normal sector targeting cannot directly command the ship inside the safe radius;
- verify inertia can nevertheless enter warning/critical/capture states;
- verify engine steering remains bounded during arrival braking;
- verify propulsion demand follows steering effort and becomes zero after captured steering authority is removed;
- compare 30/60 Hz traces and capture timing.

Keep draft until those gates are recorded.

## Follow-up

After certification, update the merged `mothershipNavigationPrototype.ts` to consume this contract while leaving Babylon rendering/camera presentation intact. Its local reserve/drain logic should be replaced by #102 after that contract is certified. Separately, #100 can replace the prototype raid-plan queue; launch cost remains an explicit later economy decision.