### PR TITLE
Add authoritative mothership energy and loss-of-lift lifecycle

### DIFF
--- a/experiments/storybook/src/Foundations/Physics/MothershipEnergyLift.stories.ts
+++ b/experiments/storybook/src/Foundations/Physics/MothershipEnergyLift.stories.ts
@@ -1,0 +1,287 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	createMothershipEnergyLiftState,
+	stepMothershipEnergyLift,
+	type MothershipEnergyLiftConfig,
+	type MothershipEnergyLiftState
+} from "@defend/gameplay/mothershipEnergyLift";
+import { createLabShell } from "../../labTheme";
+
+type LiftArgs = {
+	simulationSeconds: number;
+	externalSpendPerSecond: number;
+	extractionAtSeconds: number;
+	extractionEnergy: number;
+};
+
+interface TracePoint {
+	time: number;
+	reserve: number;
+	altitude: number;
+	phase: string;
+}
+
+interface LiftTrace {
+	points: TracePoint[];
+	finalState: MothershipEnergyLiftState;
+	fallAt: number | null;
+	hulkAt: number | null;
+}
+
+function config(): MothershipEnergyLiftConfig {
+	return {
+		capacity: 1,
+		lowReserve: 0.38,
+		criticalReserve: 0.2,
+		fallReserve: 0.1,
+		hoverDrainPerSecond: 0.0065,
+		fallDrainPerSecond: 0.002,
+		startAltitude: 56,
+		hulkCenterAltitude: 18,
+		reserveSagDistance: 12,
+		maxLiftStiffness: 4.4,
+		minimumLiftStiffnessFactor: 0.32,
+		baseVerticalDamping: 1.1,
+		additionalVerticalDamping: 3.1,
+		baseWobbleAmplitude: 0.08,
+		depletionWobbleAmplitude: 1.5,
+		baseWobbleFrequency: 1.2,
+		depletionWobbleFrequency: 1.8,
+		gravity: 9.81,
+		impactBounceThreshold: 4,
+		impactRestitution: 0.12,
+		allowFallRecovery: false
+	};
+}
+
+function simulate(
+	seconds: number,
+	deltaSeconds: number,
+	externalSpendPerSecond: number,
+	extractionAtSeconds: number | null,
+	extractionEnergy: number
+): LiftTrace {
+	const calibration = config();
+	let state = createMothershipEnergyLiftState(calibration.capacity, calibration);
+	const points: TracePoint[] = [];
+	let fallAt: number | null = null;
+	let hulkAt: number | null = null;
+	let elapsed = 0;
+	let extractionApplied = false;
+
+	while (elapsed <= seconds + 1e-9) {
+		points.push({
+			time: elapsed,
+			reserve: state.reserve / calibration.capacity,
+			altitude: state.altitude,
+			phase: state.phase
+		});
+		const shouldExtract =
+			extractionAtSeconds !== null &&
+			!extractionApplied &&
+			elapsed <= extractionAtSeconds &&
+			elapsed + deltaSeconds > extractionAtSeconds;
+		const step = stepMothershipEnergyLift(
+			state,
+			{
+				inflowEnergy: shouldExtract ? extractionEnergy : 0,
+				externalSpendEnergy: externalSpendPerSecond * deltaSeconds
+			},
+			deltaSeconds,
+			calibration
+		);
+		state = step.state;
+		if (shouldExtract) extractionApplied = true;
+		elapsed += deltaSeconds;
+		if (fallAt === null && step.fallStarted) fallAt = elapsed;
+		if (hulkAt === null && step.becameHulk) hulkAt = elapsed;
+		if (state.phase === "hulk" && elapsed > (hulkAt ?? elapsed) + 1) break;
+	}
+	return { points, finalState: state, fallAt, hulkAt };
+}
+
+function linePath(
+	points: TracePoint[],
+	seconds: number,
+	value: (point: TracePoint) => number,
+	top: number,
+	height: number
+): string {
+	const width = 540;
+	return points
+		.map((point, index) => {
+			const x = 20 + (point.time / Math.max(1, seconds)) * width;
+			const normalized = Math.max(0, Math.min(1, value(point)));
+			const y = top + height - normalized * height;
+			return `${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`;
+		})
+		.join(" ");
+}
+
+function eventMarker(
+	time: number | null,
+	seconds: number,
+	label: string,
+	top: number,
+	height: number
+): string {
+	if (time === null || time > seconds) return "";
+	const x = 20 + (time / Math.max(1, seconds)) * 540;
+	return `<line class="lift-marker" x1="${x}" y1="${top}" x2="${x}" y2="${top + height}" /><text class="lift-label" x="${x + 4}" y="${top + 12}">${label}</text>`;
+}
+
+const meta = {
+	title: "Foundations/Physics/Mothership Energy & Lift",
+	tags: ["test", "visual"],
+	args: {
+		simulationSeconds: 170,
+		externalSpendPerSecond: 0.002,
+		extractionAtSeconds: 70,
+		extractionEnergy: 0.35
+	},
+	argTypes: {
+		simulationSeconds: { control: { type: "range", min: 80, max: 240, step: 5 } },
+		externalSpendPerSecond: { control: { type: "range", min: 0, max: 0.01, step: 0.00025 } },
+		extractionAtSeconds: { control: { type: "range", min: 10, max: 160, step: 5 } },
+		extractionEnergy: { control: { type: "range", min: 0, max: 0.7, step: 0.025 } }
+	},
+	render: (args: LiftArgs) => {
+		const calibration = config();
+		const dry = simulate(
+			args.simulationSeconds,
+			0.1,
+			args.externalSpendPerSecond,
+			null,
+			0
+		);
+		const replenished = simulate(
+			args.simulationSeconds,
+			0.1,
+			args.externalSpendPerSecond,
+			args.extractionAtSeconds,
+			args.extractionEnergy
+		);
+		const dry30 = simulate(
+			args.simulationSeconds,
+			1 / 30,
+			args.externalSpendPerSecond,
+			null,
+			0
+		);
+		const dry60 = simulate(
+			args.simulationSeconds,
+			1 / 60,
+			args.externalSpendPerSecond,
+			null,
+			0
+		);
+
+		const reserveDry = linePath(dry.points, args.simulationSeconds, point => point.reserve, 36, 92);
+		const altitudeDry = linePath(
+			dry.points,
+			args.simulationSeconds,
+			point =>
+				(point.altitude - calibration.hulkCenterAltitude) /
+				(calibration.startAltitude - calibration.hulkCenterAltitude),
+			36,
+			92
+		);
+		const reserveRefill = linePath(replenished.points, args.simulationSeconds, point => point.reserve, 186, 92);
+		const altitudeRefill = linePath(
+			replenished.points,
+			args.simulationSeconds,
+			point =>
+				(point.altitude - calibration.hulkCenterAltitude) /
+				(calibration.startAltitude - calibration.hulkCenterAltitude),
+			186,
+			92
+		);
+
+		const shell = createLabShell(
+			"Foundations / physics",
+			"Mothership energy and loss of lift",
+			"One teal reserve is authoritative for suspension and all externally requested spending. Hover creates a finite raid horizon; movement/launch demand shortens it; extraction can extend it. Once the configured loss-of-lift threshold is crossed, this fixture follows the current irreversible-fall hypothesis through impact and a persistent hulk."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.lift-grid { display:grid; grid-template-columns:minmax(0,1.45fr) minmax(280px,.55fr); gap:16px; }
+				.lift-chart { width:100%; min-height:340px; }
+				.lift-axis { stroke:rgba(244,237,247,.12); stroke-width:1; }
+				.lift-reserve { fill:none; stroke:#49d7d1; stroke-width:2.3; }
+				.lift-altitude { fill:none; stroke:#e4b980; stroke-width:1.9; stroke-dasharray:6 4; }
+				.lift-marker { stroke:rgba(244,237,247,.28); stroke-width:1; stroke-dasharray:3 3; }
+				.lift-label { fill:rgba(244,237,247,.52); font-size:10px; }
+				.lift-title { fill:rgba(244,237,247,.68); font-size:12px; font-weight:600; }
+				.lift-key { display:flex; gap:14px; margin-top:10px; font-size:11px; color:rgba(244,237,247,.58); }
+				.lift-swatch { display:inline-block; width:18px; height:2px; margin-right:6px; vertical-align:middle; background:#49d7d1; }
+				.lift-swatch--alt { background:#e4b980; }
+			</style>
+			<div class="lift-grid">
+				<section class="lab__panel lab__stage">
+					<svg class="lift-chart" viewBox="0 0 590 315" aria-label="Mothership reserve and altitude traces">
+						<line class="lift-axis" x1="20" y1="128" x2="560" y2="128" />
+						<line class="lift-axis" x1="20" y1="278" x2="560" y2="278" />
+						<text class="lift-title" x="20" y="23">raid without extraction</text>
+						<text class="lift-title" x="20" y="173">same spend + successful extraction</text>
+						<path class="lift-reserve" d="${reserveDry}" />
+						<path class="lift-altitude" d="${altitudeDry}" />
+						<path class="lift-reserve" d="${reserveRefill}" />
+						<path class="lift-altitude" d="${altitudeRefill}" />
+						${eventMarker(dry.fallAt, args.simulationSeconds, "fall", 36, 92)}
+						${eventMarker(dry.hulkAt, args.simulationSeconds, "hulk", 36, 92)}
+						${eventMarker(args.extractionAtSeconds, args.simulationSeconds, "extract", 186, 92)}
+						${eventMarker(replenished.fallAt, args.simulationSeconds, "fall", 186, 92)}
+						${eventMarker(replenished.hulkAt, args.simulationSeconds, "hulk", 186, 92)}
+					</svg>
+					<div class="lift-key"><span><i class="lift-swatch"></i>reserve</span><span><i class="lift-swatch lift-swatch--alt"></i>altitude</span></div>
+				</section>
+				<aside class="lab__panel lab__panel--padded">
+					<h2 class="lab__section-title">Lifecycle outcomes</h2>
+					<dl class="lab__metrics">
+						<div class="lab__metric"><dt>Dry fall</dt><dd data-dry-fall="${dry.fallAt ?? -1}">${dry.fallAt === null ? "—" : `${dry.fallAt.toFixed(1)} s`}</dd></div>
+						<div class="lab__metric"><dt>Dry hulk</dt><dd data-dry-hulk="${dry.hulkAt ?? -1}">${dry.hulkAt === null ? "—" : `${dry.hulkAt.toFixed(1)} s`}</dd></div>
+						<div class="lab__metric"><dt>Replenished fall</dt><dd data-refill-fall="${replenished.fallAt ?? -1}">${replenished.fallAt === null ? "—" : `${replenished.fallAt.toFixed(1)} s`}</dd></div>
+						<div class="lab__metric"><dt>Replenished hulk</dt><dd>${replenished.hulkAt === null ? "—" : `${replenished.hulkAt.toFixed(1)} s`}</dd></div>
+						<div class="lab__metric"><dt>30 Hz dry hulk</dt><dd data-hulk30="${dry30.hulkAt ?? -1}">${dry30.hulkAt === null ? "—" : `${dry30.hulkAt.toFixed(3)} s`}</dd></div>
+						<div class="lab__metric"><dt>60 Hz dry hulk</dt><dd data-hulk60="${dry60.hulkAt ?? -1}">${dry60.hulkAt === null ? "—" : `${dry60.hulkAt.toFixed(3)} s`}</dd></div>
+						<div class="lab__metric"><dt>Final dry phase</dt><dd>${dry.finalState.phase}</dd></div>
+						<div class="lab__metric"><dt>Final refill phase</dt><dd>${replenished.finalState.phase}</dd></div>
+					</dl>
+				</aside>
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<LiftArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FiniteRaidHorizon: Story = {
+	play: async ({ canvasElement }) => {
+		const dryFall = canvasElement.querySelector<HTMLElement>("[data-dry-fall]");
+		const dryHulk = canvasElement.querySelector<HTMLElement>("[data-dry-hulk]");
+		const refillFall = canvasElement.querySelector<HTMLElement>("[data-refill-fall]");
+		const hulk30 = canvasElement.querySelector<HTMLElement>("[data-hulk30]");
+		const hulk60 = canvasElement.querySelector<HTMLElement>("[data-hulk60]");
+		await expect(dryFall).not.toBeNull();
+		await expect(dryHulk).not.toBeNull();
+		await expect(refillFall).not.toBeNull();
+		await expect(hulk30).not.toBeNull();
+		await expect(hulk60).not.toBeNull();
+		if (!dryFall || !dryHulk || !refillFall || !hulk30 || !hulk60) return;
+
+		const fall = Number(dryFall.dataset.dryFall);
+		const hulk = Number(dryHulk.dataset.dryHulk);
+		const refill = Number(refillFall.dataset.refillFall);
+		if (fall >= 0 && hulk >= 0) await expect(fall).toBeLessThan(hulk);
+		if (fall >= 0 && refill >= 0) await expect(fall).toBeLessThan(refill);
+		const t30 = Number(hulk30.dataset.hulk30);
+		const t60 = Number(hulk60.dataset.hulk60);
+		if (t30 >= 0 && t60 >= 0) {
+			await expect(Math.abs(t30 - t60)).toBeLessThan(0.12);
+		}
+	}
+};

--- a/src/js/gameplay/mothershipEnergyAuthorization.ts
+++ b/src/js/gameplay/mothershipEnergyAuthorization.ts
@@ -1,0 +1,88 @@
+import type { MothershipEnergyLiftState } from "./mothershipEnergyLift";
+
+export interface MothershipDiscreteSpendAuthorization {
+	authorized: boolean;
+	requestedEnergy: number;
+	availableEnergy: number;
+	shortfallEnergy: number;
+}
+
+export interface MothershipContinuousSpendFunding {
+	requestedEnergy: number;
+	fundedEnergy: number;
+	unmetEnergy: number;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+/**
+ * Check an all-or-nothing action before committing its physical side effect.
+ *
+ * This helper does not mutate reserve. The caller should only spawn/commit the
+ * action when `authorized` is true, then submit exactly `requestedEnergy` to
+ * the authoritative energy/lift step in the same simulation transaction.
+ *
+ * `protectedReserve` is optional policy: zero allows spending down to empty;
+ * a caller may reserve a survival/hover buffer without changing core physics.
+ */
+export function authorizeDiscreteMothershipSpend(
+	state: MothershipEnergyLiftState,
+	requestedEnergy: number,
+	protectedReserve = 0
+): MothershipDiscreteSpendAuthorization {
+	const requested = positive(requestedEnergy);
+	const reserve = positive(state.reserve);
+	const protectedAmount = Math.min(reserve, positive(protectedReserve));
+	const available = state.phase === "hulk" ? 0 : Math.max(0, reserve - protectedAmount);
+	const shortfall = Math.max(0, requested - available);
+	return {
+		authorized: shortfall <= 0,
+		requestedEnergy: requested,
+		availableEnergy: available,
+		shortfallEnergy: shortfall
+	};
+}
+
+/**
+ * Determine how much continuously requested propulsion/service demand can be
+ * funded this step. Unlike a discrete launch, continuous authority may degrade
+ * proportionally instead of creating energy debt.
+ *
+ * This helper also does not mutate reserve. The funded amount is intended to be
+ * submitted to the single reserve authority while the calling motion/actuator
+ * layer scales its commanded authority by `funded / requested`.
+ */
+export function fundContinuousMothershipSpend(
+	state: MothershipEnergyLiftState,
+	requestedEnergy: number,
+	protectedReserve = 0
+): MothershipContinuousSpendFunding {
+	const requested = positive(requestedEnergy);
+	const reserve = positive(state.reserve);
+	const protectedAmount = Math.min(reserve, positive(protectedReserve));
+	const available = state.phase === "hulk" ? 0 : Math.max(0, reserve - protectedAmount);
+	const funded = Math.min(requested, available);
+	return {
+		requestedEnergy: requested,
+		fundedEnergy: funded,
+		unmetEnergy: Math.max(0, requested - funded)
+	};
+}
+
+export function mothershipFundingFraction(
+	funding: MothershipContinuousSpendFunding
+): number {
+	if (funding.requestedEnergy <= 0) {
+		return 1;
+	}
+	return Math.max(0, Math.min(1, funding.fundedEnergy / funding.requestedEnergy));
+}

--- a/src/js/gameplay/mothershipEnergyLift.ts
+++ b/src/js/gameplay/mothershipEnergyLift.ts
@@ -1,0 +1,286 @@
+export type MothershipLiftPhase =
+	| "stable"
+	| "low-reserve"
+	| "critical"
+	| "falling"
+	| "hulk";
+
+export interface MothershipEnergyLiftConfig {
+	capacity: number;
+	lowReserve: number;
+	criticalReserve: number;
+	fallReserve: number;
+	hoverDrainPerSecond: number;
+	fallDrainPerSecond: number;
+	startAltitude: number;
+	hulkCenterAltitude: number;
+	reserveSagDistance: number;
+	maxLiftStiffness: number;
+	minimumLiftStiffnessFactor: number;
+	baseVerticalDamping: number;
+	additionalVerticalDamping: number;
+	baseWobbleAmplitude: number;
+	depletionWobbleAmplitude: number;
+	baseWobbleFrequency: number;
+	depletionWobbleFrequency: number;
+	gravity: number;
+	impactBounceThreshold: number;
+	impactRestitution: number;
+	allowFallRecovery: boolean;
+}
+
+export interface MothershipEnergyLiftState {
+	reserve: number;
+	phase: MothershipLiftPhase;
+	altitude: number;
+	verticalVelocity: number;
+	elapsedSeconds: number;
+	impactCount: number;
+}
+
+export interface MothershipEnergyExchange {
+	/** Energy arriving from extraction/recovery during this step. */
+	inflowEnergy: number;
+	/** Aggregate spend already requested by movement, launch, or other systems. */
+	externalSpendEnergy: number;
+}
+
+export interface MothershipEnergyLiftStep {
+	state: MothershipEnergyLiftState;
+	inflowApplied: number;
+	externalSpendApplied: number;
+	unmetExternalSpend: number;
+	baseDrainApplied: number;
+	liftFraction: number;
+	targetAltitude: number;
+	instability: number;
+	fallStarted: boolean;
+	impactOccurred: boolean;
+	becameHulk: boolean;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
+}
+
+function safeConfig(config: MothershipEnergyLiftConfig): MothershipEnergyLiftConfig {
+	const capacity = Math.max(0.000001, positive(config.capacity));
+	const fallReserve = clamp(config.fallReserve, 0, capacity);
+	const criticalReserve = clamp(config.criticalReserve, fallReserve, capacity);
+	const lowReserve = clamp(config.lowReserve, criticalReserve, capacity);
+	return {
+		capacity,
+		lowReserve,
+		criticalReserve,
+		fallReserve,
+		hoverDrainPerSecond: positive(config.hoverDrainPerSecond),
+		fallDrainPerSecond: positive(config.fallDrainPerSecond),
+		startAltitude: finite(config.startAltitude),
+		hulkCenterAltitude: finite(config.hulkCenterAltitude),
+		reserveSagDistance: positive(config.reserveSagDistance),
+		maxLiftStiffness: positive(config.maxLiftStiffness),
+		minimumLiftStiffnessFactor: clamp(config.minimumLiftStiffnessFactor, 0, 1),
+		baseVerticalDamping: positive(config.baseVerticalDamping),
+		additionalVerticalDamping: positive(config.additionalVerticalDamping),
+		baseWobbleAmplitude: positive(config.baseWobbleAmplitude),
+		depletionWobbleAmplitude: positive(config.depletionWobbleAmplitude),
+		baseWobbleFrequency: positive(config.baseWobbleFrequency),
+		depletionWobbleFrequency: positive(config.depletionWobbleFrequency),
+		gravity: positive(config.gravity),
+		impactBounceThreshold: positive(config.impactBounceThreshold),
+		impactRestitution: clamp(config.impactRestitution, 0, 1),
+		allowFallRecovery: config.allowFallRecovery === true
+	};
+}
+
+export function mothershipLiftPhaseForReserve(
+	reserve: number,
+	config: MothershipEnergyLiftConfig
+): MothershipLiftPhase {
+	const safe = safeConfig(config);
+	const value = clamp(reserve, 0, safe.capacity);
+	if (value <= safe.fallReserve) return "falling";
+	if (value <= safe.criticalReserve) return "critical";
+	if (value <= safe.lowReserve) return "low-reserve";
+	return "stable";
+}
+
+export function mothershipLiftFraction(
+	reserve: number,
+	config: MothershipEnergyLiftConfig
+): number {
+	const safe = safeConfig(config);
+	const denominator = Math.max(0.000001, safe.capacity - safe.fallReserve);
+	return clamp((finite(reserve) - safe.fallReserve) / denominator, 0, 1);
+}
+
+export function createMothershipEnergyLiftState(
+	reserve: number,
+	config: MothershipEnergyLiftConfig
+): MothershipEnergyLiftState {
+	const safe = safeConfig(config);
+	const boundedReserve = clamp(reserve, 0, safe.capacity);
+	return {
+		reserve: boundedReserve,
+		phase: mothershipLiftPhaseForReserve(boundedReserve, safe),
+		altitude: safe.startAltitude,
+		verticalVelocity: 0,
+		elapsedSeconds: 0,
+		impactCount: 0
+	};
+}
+
+/**
+ * Single authoritative mothership reserve + vertical-lift step.
+ *
+ * Navigation/launch/extraction systems submit energy quantities but do not own
+ * the reserve. The caller retains category-level accounting for player-facing
+ * transparency; this contract only conserves the shared scalar pool and derives
+ * suspension/crash consequences from it.
+ */
+export function stepMothershipEnergyLift(
+	state: MothershipEnergyLiftState,
+	exchange: MothershipEnergyExchange,
+	deltaSeconds: number,
+	config: MothershipEnergyLiftConfig
+): MothershipEnergyLiftStep {
+	const safe = safeConfig(config);
+	const dt = positive(deltaSeconds);
+	let next: MothershipEnergyLiftState = {
+		reserve: clamp(state.reserve, 0, safe.capacity),
+		phase: state.phase,
+		altitude: finite(state.altitude, safe.startAltitude),
+		verticalVelocity: finite(state.verticalVelocity),
+		elapsedSeconds: positive(state.elapsedSeconds),
+		impactCount: Math.max(0, Math.floor(positive(state.impactCount)))
+	};
+
+	if (next.phase === "hulk") {
+		return {
+			state: next,
+			inflowApplied: 0,
+			externalSpendApplied: 0,
+			unmetExternalSpend: positive(exchange.externalSpendEnergy),
+			baseDrainApplied: 0,
+			liftFraction: 0,
+			targetAltitude: safe.hulkCenterAltitude,
+			instability: 1,
+			fallStarted: false,
+			impactOccurred: false,
+			becameHulk: false
+		};
+	}
+
+	next.elapsedSeconds += dt;
+
+	const inflowRequested = positive(exchange.inflowEnergy);
+	const inflowApplied = Math.min(safe.capacity - next.reserve, inflowRequested);
+	next.reserve += inflowApplied;
+
+	const externalRequested = positive(exchange.externalSpendEnergy);
+	const externalSpendApplied = Math.min(next.reserve, externalRequested);
+	next.reserve -= externalSpendApplied;
+	const unmetExternalSpend = Math.max(0, externalRequested - externalSpendApplied);
+
+	const drainRate =
+		next.phase === "falling" ? safe.fallDrainPerSecond : safe.hoverDrainPerSecond;
+	const baseDrainRequested = drainRate * dt;
+	const baseDrainApplied = Math.min(next.reserve, baseDrainRequested);
+	next.reserve -= baseDrainApplied;
+
+	let fallStarted = false;
+	let impactOccurred = false;
+	let becameHulk = false;
+
+	if (next.phase === "falling" && safe.allowFallRecovery) {
+		const recoveredPhase = mothershipLiftPhaseForReserve(next.reserve, safe);
+		if (recoveredPhase !== "falling") {
+			next.phase = recoveredPhase;
+		}
+	}
+
+	if (next.phase !== "falling") {
+		const reservePhase = mothershipLiftPhaseForReserve(next.reserve, safe);
+		if (reservePhase === "falling") {
+			next.phase = "falling";
+			fallStarted = true;
+		} else {
+			next.phase = reservePhase;
+		}
+	}
+
+	let liftFraction = mothershipLiftFraction(next.reserve, safe);
+	let targetAltitude =
+		safe.startAltitude - (1 - liftFraction) * safe.reserveSagDistance;
+	let instability = (1 - liftFraction) * (1 - liftFraction);
+
+	if (next.phase === "falling") {
+		next.verticalVelocity -= safe.gravity * dt;
+		next.altitude += next.verticalVelocity * dt;
+		if (next.altitude <= safe.hulkCenterAltitude) {
+			next.altitude = safe.hulkCenterAltitude;
+			next.impactCount += 1;
+			impactOccurred = true;
+			if (
+				next.impactCount === 1 &&
+				Math.abs(next.verticalVelocity) > safe.impactBounceThreshold
+			) {
+				next.verticalVelocity =
+					Math.abs(next.verticalVelocity) * safe.impactRestitution;
+			} else {
+				next.verticalVelocity = 0;
+				next.phase = "hulk";
+				becameHulk = true;
+			}
+		}
+		liftFraction = 0;
+		targetAltitude = safe.hulkCenterAltitude;
+		instability = 1;
+	} else {
+		const depletion = 1 - liftFraction;
+		const stiffness =
+			safe.maxLiftStiffness *
+			(safe.minimumLiftStiffnessFactor +
+				liftFraction * (1 - safe.minimumLiftStiffnessFactor));
+		const damping =
+			safe.baseVerticalDamping + liftFraction * safe.additionalVerticalDamping;
+		const wobbleAmplitude =
+			safe.baseWobbleAmplitude +
+			depletion * depletion * safe.depletionWobbleAmplitude;
+		const wobbleFrequency =
+			safe.baseWobbleFrequency +
+			depletion * safe.depletionWobbleFrequency;
+		const wobble = Math.sin(next.elapsedSeconds * wobbleFrequency) * wobbleAmplitude;
+		const acceleration =
+			(targetAltitude - next.altitude) * stiffness -
+			next.verticalVelocity * damping +
+			wobble;
+		next.verticalVelocity += acceleration * dt;
+		next.altitude += next.verticalVelocity * dt;
+	}
+
+	return {
+		state: next,
+		inflowApplied,
+		externalSpendApplied,
+		unmetExternalSpend,
+		baseDrainApplied,
+		liftFraction,
+		targetAltitude,
+		instability,
+		fallStarted,
+		impactOccurred,
+		becameHulk
+	};
+}


### PR DESCRIPTION
Refs #79, #83, #92
Related: #87, #101, #100

## Purpose

Establish one authoritative mothership teal-energy pool and vertical lift/crash lifecycle, rather than letting navigation, launch planning, and the Babylon hover prototype each own their own reserve.

Other systems submit energy inflow/spend demand; this domain owns conservation, authorization semantics, suspension state, loss of lift, impact and hulk consequences. Category-level accounting remains with the caller for player-facing transparency.

## `src/js/gameplay/mothershipEnergyLift.ts`

Adds an engine-free lifecycle with:

- absolute configurable energy capacity rather than assuming the final game uses normalized 0–1 energy;
- stable / low-reserve / critical / falling / hulk phases;
- configurable low/critical/fall thresholds;
- continuous hover drain and separate falling drain;
- externally supplied energy inflow (extraction/recovery);
- externally requested spend (navigation, launch or other systems);
- applied versus unmet spend accounting;
- reserve-derived lift fraction and target-altitude sag;
- reserve-dependent lift stiffness/damping and deterministic instability;
- irreversible-by-default loss of lift, with explicit experimental `allowFallRecovery`;
- gravity-driven fall;
- bounded first impact/bounce and final persistent hulk.

## `src/js/gameplay/mothershipEnergyAuthorization.ts`

Makes the no-energy-debt rule executable before adapters are written:

- `authorizeDiscreteMothershipSpend()` is all-or-nothing for physical actions such as raider launch;
- it reports requested/available/shortfall and never mutates reserve;
- optional protected reserve allows later policy to preserve a survival/hover buffer without changing core physics;
- `fundContinuousMothershipSpend()` permits proportional funding for continuous propulsion/service demand rather than allowing implicit debt;
- `mothershipFundingFraction()` gives an actuator scaling factor;
- hulk has zero spend authority.

These helpers are intentionally non-mutating. The integration transaction is: authorize/fund → apply the permitted physical authority → submit exactly the funded spend to `stepMothershipEnergyLift()` as the single reserve mutation.

A discrete launch must not spawn first and discover afterward that the mothership could not pay.

## Reserve ownership boundary

#101 navigation owns **no reserve**. It reports propulsion demand only. #102 is intended to apply that demand together with hover drain, raid launch spend, and physically delivered extraction inflow.

External silo attraction is not propulsion and must continue to act even when engine funding falls to zero.

This prevents double-draining and keeps the exposed central teal core semantically tied to one conserved value.

## Storybook playground

Adds `Foundations/Physics/Mothership Energy & Lift`.

The fixture compares two otherwise identical raid horizons:

1. hover + external raid spending with no extraction;
2. the same spending with one successful mid-raid extraction pulse.

It overlays reserve and altitude and marks fall/hulk/extraction events, demonstrating that extraction extends the raid horizon without removing the continuous survival cost.

Default visual calibration mirrors the merged Babylon PoC where useful (capacity 1; low .38 / critical .20 / fall .10; hover drain .0065/s; falling drain .002/s; altitude 56→18; gravity 9.81; first-impact restitution .12). These remain experimental lab calibration, not final campaign balance.

The Storybook assertion verifies fall before hulk, representative extraction postponing fall, and close 30/60 Hz hulk timing.

## Scope

Current head: `1c363ec385fb65e7f53188bd8545f1e00dc4e537`.

Relative to branch base `master` `9c5eaa9d93a7037b55e858f4ea14f8eace67f2fa`:

- 3 commits;
- 3 added files;
- no package/dependency changes;
- no live Babylon/Cannon call-site changes;
- no final reserve capacity, launch cost, or threshold commitment.

## Certification

Include in #92 when practical:

- root TypeScript/build compatibility for both gameplay modules;
- Storybook typecheck/build/test;
- reserve remains bounded by capacity;
- discrete authorization rejects a request larger than spendable reserve and hulk always rejects;
- continuous funding returns funded + unmet = requested and a bounded 0..1 funding fraction;
- no-extraction raid has a finite horizon;
- extraction extends that horizon under representative settings;
- 30/60 Hz fall/hulk timing;
- first-impact bounce and final persistent hulk.

Keep draft until those gates are recorded.

## Follow-up

After certification, `mothershipPrototype.ts` should consume this reserve/lift contract and delete its local reserve/phase/vertical-velocity transition math. #101 navigation demand and later #100 launch demand should pass through the authorization/funding boundary before becoming physical actions.