### PR TITLE
experiment: model deterrence taper and anti-farming economy

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/DeterrenceEconomy.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/DeterrenceEconomy.stories.ts
@@ -1,0 +1,311 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	compareDeterrencePolicies,
+	DEFAULT_DETERRENCE_CONFIG,
+	DEFAULT_DETERRENCE_POLICIES,
+	DEFAULT_DETERRENCE_RAIDERS,
+	type DeterrenceModelConfig,
+	type DeterrencePolicyId,
+	type DeterrenceScenarioResult,
+	type DeterrenceStateCounts
+} from "@defend/gameplay/deterrenceEconomy";
+import { createLabShell } from "../../labTheme";
+
+type DeterrenceArgs = {
+	horizon: number;
+	seed: number;
+	seedCount: number;
+	collectionEfficiency: number;
+	confidenceSmoothing: number;
+	breachLossMultiplier: number;
+	starvationThreshold: number;
+};
+
+type PolicyAggregate = {
+	id: DeterrencePolicyId;
+	label: string;
+	meanEndingEnergy: number;
+	meanSurvival: number;
+	ruinRate: number;
+	meanRaids: number;
+	meanBreaches: number;
+	meanAttackerRoi: number;
+	stateCounts: DeterrenceStateCounts;
+	representative: DeterrenceScenarioResult;
+};
+
+function fixed(value: number, digits = 1): string {
+	if (value !== value || value === Infinity || value === -Infinity) return "0";
+	return value.toFixed(digits);
+}
+
+function percent(value: number): string {
+	return `${fixed(value * 100, 0)}%`;
+}
+
+function copyCounts(): DeterrenceStateCounts {
+	return { contested: 0, adapting: 0, probing: 0, quiet: 0, starvation: 0 };
+}
+
+function addCounts(
+	target: DeterrenceStateCounts,
+	source: DeterrenceStateCounts
+): void {
+	target.contested += source.contested;
+	target.adapting += source.adapting;
+	target.probing += source.probing;
+	target.quiet += source.quiet;
+	target.starvation += source.starvation;
+}
+
+function aggregatePolicies(args: DeterrenceArgs): PolicyAggregate[] {
+	const config: DeterrenceModelConfig = {
+		...DEFAULT_DETERRENCE_CONFIG,
+		horizon: args.horizon,
+		collectionEfficiency: args.collectionEfficiency,
+		confidenceSmoothing: args.confidenceSmoothing,
+		breachLossMultiplier: args.breachLossMultiplier,
+		starvationThreshold: args.starvationThreshold
+	};
+	const seedCount = Math.max(1, Math.floor(args.seedCount));
+	const accumulators = DEFAULT_DETERRENCE_POLICIES.map(policy => ({
+		id: policy.id,
+		label: policy.label,
+		endingEnergy: 0,
+		survival: 0,
+		ruins: 0,
+		raids: 0,
+		breaches: 0,
+		attackerRoi: 0,
+		stateCounts: copyCounts(),
+		representative: compareDeterrencePolicies(
+			[policy],
+			config,
+			DEFAULT_DETERRENCE_RAIDERS,
+			args.seed
+		)[0]
+	}));
+
+	for (let offset = 0; offset < seedCount; offset += 1) {
+		const results = compareDeterrencePolicies(
+			DEFAULT_DETERRENCE_POLICIES,
+			config,
+			DEFAULT_DETERRENCE_RAIDERS,
+			args.seed + offset
+		);
+		for (let index = 0; index < results.length; index += 1) {
+			const result = results[index];
+			const acc = accumulators[index];
+			acc.endingEnergy += result.summary.endingDefenderEnergy;
+			acc.survival += result.summary.survivalOpportunities;
+			if (result.summary.ruined) acc.ruins += 1;
+			acc.raids += result.summary.raids;
+			acc.breaches += result.summary.breaches;
+			acc.attackerRoi += result.summary.attackerReturnOnCommitment;
+			addCounts(acc.stateCounts, result.summary.stateCounts);
+		}
+	}
+
+	return accumulators.map(acc => ({
+		id: acc.id,
+		label: acc.label,
+		meanEndingEnergy: acc.endingEnergy / seedCount,
+		meanSurvival: acc.survival / seedCount,
+		ruinRate: acc.ruins / seedCount,
+		meanRaids: acc.raids / seedCount,
+		meanBreaches: acc.breaches / seedCount,
+		meanAttackerRoi: acc.attackerRoi / seedCount,
+		stateCounts: {
+			contested: acc.stateCounts.contested / seedCount,
+			adapting: acc.stateCounts.adapting / seedCount,
+			probing: acc.stateCounts.probing / seedCount,
+			quiet: acc.stateCounts.quiet / seedCount,
+			starvation: acc.stateCounts.starvation / seedCount
+		},
+		representative: acc.representative
+	}));
+}
+
+function energyTrace(result: DeterrenceScenarioResult): string {
+	const maxEnergy = DEFAULT_DETERRENCE_CONFIG.maxDefenderEnergy;
+	const width = 320;
+	const height = 64;
+	if (result.steps.length === 0) return "";
+	const points: string[] = [];
+	for (let index = 0; index < result.steps.length; index += 1) {
+		const step = result.steps[index];
+		const x =
+			result.steps.length <= 1
+				? 0
+				: (index / (result.steps.length - 1)) * width;
+		const y =
+			height -
+			(step.defenderEnergyAfter / Math.max(1, maxEnergy)) * height;
+		points.push(`${fixed(x, 1)},${fixed(y, 1)}`);
+	}
+	return `<svg class="det-trace" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-label="Representative defender-energy trajectory"><polyline points="${points.join(" ")}" fill="none" stroke="currentColor" stroke-width="2" vector-effect="non-scaling-stroke" /></svg>`;
+}
+
+function stateStrip(counts: DeterrenceStateCounts): string {
+	const total =
+		counts.contested +
+		counts.adapting +
+		counts.probing +
+		counts.quiet +
+		counts.starvation;
+	if (total <= 0) return "";
+	const segments = [
+		["contested", counts.contested],
+		["adapting", counts.adapting],
+		["probing", counts.probing],
+		["quiet", counts.quiet],
+		["starvation", counts.starvation]
+	];
+	return segments
+		.map(segment => {
+			const name = segment[0] as string;
+			const value = segment[1] as number;
+			return `<span class="det-state det-state--${name}" title="${name}: ${fixed(value, 1)} opportunities" style="flex:${Math.max(0.001, value / total)}"></span>`;
+		})
+		.join("");
+}
+
+function policyCard(aggregate: PolicyAggregate): string {
+	const summary = aggregate.representative.summary;
+	return `
+		<article class="det-card" data-policy="${aggregate.id}" data-ruin-rate="${aggregate.ruinRate}" data-survival="${aggregate.meanSurvival}">
+			<header>
+				<div><small>policy hypothesis</small><strong>${aggregate.label}</strong></div>
+				<span>${percent(aggregate.ruinRate)} ruin</span>
+			</header>
+			${energyTrace(aggregate.representative)}
+			<div class="det-state-strip">${stateStrip(aggregate.stateCounts)}</div>
+			<div class="det-metrics">
+				<div><small>mean end reserve</small><strong>${fixed(aggregate.meanEndingEnergy, 0)}</strong></div>
+				<div><small>mean survival</small><strong>${fixed(aggregate.meanSurvival, 1)}</strong></div>
+				<div><small>raids / breaches</small><strong>${fixed(aggregate.meanRaids, 1)} / ${fixed(aggregate.meanBreaches, 1)}</strong></div>
+				<div><small>attacker ROI</small><strong>${fixed(aggregate.meanAttackerRoi, 2)}</strong></div>
+			</div>
+			<footer>Representative seed: ${summary.raids} raids · ${summary.breaches} breaches · ${fixed(summary.totalDefenderRecoveredEnergy, 0)} captured energy · ${fixed(summary.totalDefenderBreachLoss, 0)} breach loss</footer>
+		</article>
+	`;
+}
+
+const meta = {
+	title: "Foundations/Strategy/Deterrence Economy",
+	tags: ["test", "visual"],
+	args: {
+		horizon: 120,
+		seed: 7,
+		seedCount: 24,
+		collectionEfficiency: 0.78,
+		confidenceSmoothing: 0.14,
+		breachLossMultiplier: 1,
+		starvationThreshold: 6500
+	},
+	argTypes: {
+		horizon: { control: { type: "range", min: 20, max: 240, step: 10 } },
+		seed: { control: { type: "number", min: 1, max: 100000, step: 1 } },
+		seedCount: { control: { type: "range", min: 1, max: 64, step: 1 } },
+		collectionEfficiency: { control: { type: "range", min: 0.1, max: 1, step: 0.02 } },
+		confidenceSmoothing: { control: { type: "range", min: 0.02, max: 0.5, step: 0.01 } },
+		breachLossMultiplier: { control: { type: "range", min: 0.25, max: 1.5, step: 0.05 } },
+		starvationThreshold: { control: { type: "range", min: 1000, max: 15000, step: 500 } }
+	},
+	render: (args: DeterrenceArgs) => {
+		const aggregates = aggregatePolicies(args);
+		const competent = aggregates.find(
+			entry => entry.id === "competent-defense"
+		);
+		const leak = aggregates.find(entry => entry.id === "intentional-leak");
+		const antiFarmingPass =
+			competent !== undefined &&
+			leak !== undefined &&
+			competent.meanSurvival > leak.meanSurvival &&
+			competent.ruinRate < leak.ruinRate;
+
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Deterrence and anti-farming economy",
+			"Engine-free normalized model for the defender → deterrence → starvation hinge. Values are experimental, injectable hypotheses rather than production balance. The default sweep should make active competent defense outperform deliberate breach farming while over-fortification still risks self-starvation."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.det-banner { display:flex; justify-content:space-between; align-items:center; gap:16px; padding:12px 14px; border:1px solid rgba(244,237,247,.12); margin-bottom:14px; }
+				.det-banner strong { font-size:13px; }
+				.det-banner span { font-size:11px; opacity:.68; }
+				.det-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:12px; }
+				.det-card { padding:13px; border:1px solid rgba(228,185,128,.2); background:rgba(10,3,17,.42); }
+				.det-card header { display:flex; justify-content:space-between; gap:14px; align-items:start; }
+				.det-card header div { display:grid; gap:3px; }
+				.det-card small { display:block; color:rgba(244,237,247,.43); font-size:10px; text-transform:uppercase; letter-spacing:.08em; }
+				.det-card header span { font-size:11px; color:rgba(244,237,247,.62); }
+				.det-trace { width:100%; height:64px; margin:12px 0 8px; color:#49d7d1; background:linear-gradient(to bottom,rgba(73,215,209,.04),transparent); }
+				.det-state-strip { display:flex; height:5px; overflow:hidden; margin-bottom:12px; background:rgba(244,237,247,.04); }
+				.det-state--contested { background:#dc7c55; }
+				.det-state--adapting { background:#e0ad66; }
+				.det-state--probing { background:#49d7d1; }
+				.det-state--quiet { background:#54708a; }
+				.det-state--starvation { background:#6d596f; }
+				.det-metrics { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+				.det-metrics > div { border-top:1px solid rgba(244,237,247,.08); padding-top:7px; }
+				.det-metrics strong { display:block; margin-top:3px; font-size:13px; }
+				.det-card footer { margin-top:11px; font-size:10px; line-height:1.45; color:rgba(244,237,247,.46); }
+				.det-legend { display:flex; flex-wrap:wrap; gap:12px; margin-top:14px; font-size:10px; color:rgba(244,237,247,.5); }
+				.det-legend span::before { content:""; display:inline-block; width:7px; height:7px; margin-right:5px; background:currentColor; }
+			</style>
+			<div class="det-banner" data-anti-farming-pass="${antiFarmingPass}">
+				<strong>${antiFarmingPass ? "Default anti-farming gate passes" : "Current parameters expose an anti-farming failure"}</strong>
+				<span>${args.seedCount} deterministic seeds · ${args.horizon} opportunities each</span>
+			</div>
+			<div class="det-grid">${aggregates.map(policyCard).join("")}</div>
+			<div class="det-legend">
+				<span style="color:#dc7c55">contested</span>
+				<span style="color:#e0ad66">adapting</span>
+				<span style="color:#49d7d1">probing</span>
+				<span style="color:#54708a">deterrent quiet</span>
+				<span style="color:#6d596f">strategic starvation</span>
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<DeterrenceArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PolicySweep: Story = {
+	play: async ({ canvasElement }) => {
+		const cards = canvasElement.querySelectorAll<HTMLElement>("[data-policy]");
+		const gate = canvasElement.querySelector<HTMLElement>(
+			"[data-anti-farming-pass]"
+		);
+		await expect(cards.length).toBe(DEFAULT_DETERRENCE_POLICIES.length);
+		await expect(gate).not.toBeNull();
+		if (!gate) return;
+		await expect(gate.dataset.antiFarmingPass).toBe("true");
+
+		const config = DEFAULT_DETERRENCE_CONFIG;
+		const invariantResults = compareDeterrencePolicies(
+			DEFAULT_DETERRENCE_POLICIES,
+			config,
+			DEFAULT_DETERRENCE_RAIDERS,
+			7
+		);
+		for (let resultIndex = 0; resultIndex < invariantResults.length; resultIndex += 1) {
+			const result = invariantResults[resultIndex];
+			for (let stepIndex = 0; stepIndex < result.steps.length; stepIndex += 1) {
+				const step = result.steps[stepIndex];
+				await expect(step.defenderRecoveredEnergy).toBeLessThanOrEqual(
+					step.committedEnergy
+				);
+				await expect(step.defenderEnergyAfter).toBeLessThanOrEqual(
+					config.maxDefenderEnergy
+				);
+				await expect(step.defenderEnergyAfter).toBeGreaterThanOrEqual(0);
+			}
+		}
+	}
+};

--- a/experiments/storybook/src/Foundations/Strategy/DeterrenceEconomy.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/DeterrenceEconomy.stories.ts
@@ -20,6 +20,7 @@ type DeterrenceArgs = {
 	confidenceSmoothing: number;
 	breachLossMultiplier: number;
 	starvationThreshold: number;
+	targetSignalFloor: number;
 };
 
 type PolicyAggregate = {
@@ -31,6 +32,7 @@ type PolicyAggregate = {
 	meanRaids: number;
 	meanBreaches: number;
 	meanAttackerRoi: number;
+	meanTargetSignal: number;
 	stateCounts: DeterrenceStateCounts;
 	representative: DeterrenceScenarioResult;
 };
@@ -48,10 +50,7 @@ function copyCounts(): DeterrenceStateCounts {
 	return { contested: 0, adapting: 0, probing: 0, quiet: 0, starvation: 0 };
 }
 
-function addCounts(
-	target: DeterrenceStateCounts,
-	source: DeterrenceStateCounts
-): void {
+function addCounts(target: DeterrenceStateCounts, source: DeterrenceStateCounts): void {
 	target.contested += source.contested;
 	target.adapting += source.adapting;
 	target.probing += source.probing;
@@ -66,7 +65,8 @@ function aggregatePolicies(args: DeterrenceArgs): PolicyAggregate[] {
 		collectionEfficiency: args.collectionEfficiency,
 		confidenceSmoothing: args.confidenceSmoothing,
 		breachLossMultiplier: args.breachLossMultiplier,
-		starvationThreshold: args.starvationThreshold
+		starvationThreshold: args.starvationThreshold,
+		targetSignalFloor: args.targetSignalFloor
 	};
 	const seedCount = Math.max(1, Math.floor(args.seedCount));
 	const accumulators = DEFAULT_DETERRENCE_POLICIES.map(policy => ({
@@ -78,6 +78,7 @@ function aggregatePolicies(args: DeterrenceArgs): PolicyAggregate[] {
 		raids: 0,
 		breaches: 0,
 		attackerRoi: 0,
+		targetSignal: 0,
 		stateCounts: copyCounts(),
 		representative: compareDeterrencePolicies(
 			[policy],
@@ -103,6 +104,7 @@ function aggregatePolicies(args: DeterrenceArgs): PolicyAggregate[] {
 			acc.raids += result.summary.raids;
 			acc.breaches += result.summary.breaches;
 			acc.attackerRoi += result.summary.attackerReturnOnCommitment;
+			acc.targetSignal += result.summary.meanTargetSignal;
 			addCounts(acc.stateCounts, result.summary.stateCounts);
 		}
 	}
@@ -116,6 +118,7 @@ function aggregatePolicies(args: DeterrenceArgs): PolicyAggregate[] {
 		meanRaids: acc.raids / seedCount,
 		meanBreaches: acc.breaches / seedCount,
 		meanAttackerRoi: acc.attackerRoi / seedCount,
+		meanTargetSignal: acc.targetSignal / seedCount,
 		stateCounts: {
 			contested: acc.stateCounts.contested / seedCount,
 			adapting: acc.stateCounts.adapting / seedCount,
@@ -128,7 +131,6 @@ function aggregatePolicies(args: DeterrenceArgs): PolicyAggregate[] {
 }
 
 function energyTrace(result: DeterrenceScenarioResult): string {
-	const maxEnergy = DEFAULT_DETERRENCE_CONFIG.maxDefenderEnergy;
 	const width = 320;
 	const height = 64;
 	if (result.steps.length === 0) return "";
@@ -136,12 +138,10 @@ function energyTrace(result: DeterrenceScenarioResult): string {
 	for (let index = 0; index < result.steps.length; index += 1) {
 		const step = result.steps[index];
 		const x =
-			result.steps.length <= 1
-				? 0
-				: (index / (result.steps.length - 1)) * width;
+			result.steps.length <= 1 ? 0 : (index / (result.steps.length - 1)) * width;
 		const y =
 			height -
-			(step.defenderEnergyAfter / Math.max(1, maxEnergy)) * height;
+			(step.defenderEnergyAfter / DEFAULT_DETERRENCE_CONFIG.maxDefenderEnergy) * height;
 		points.push(`${fixed(x, 1)},${fixed(y, 1)}`);
 	}
 	return `<svg class="det-trace" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-label="Representative defender-energy trajectory"><polyline points="${points.join(" ")}" fill="none" stroke="currentColor" stroke-width="2" vector-effect="non-scaling-stroke" /></svg>`;
@@ -149,13 +149,9 @@ function energyTrace(result: DeterrenceScenarioResult): string {
 
 function stateStrip(counts: DeterrenceStateCounts): string {
 	const total =
-		counts.contested +
-		counts.adapting +
-		counts.probing +
-		counts.quiet +
-		counts.starvation;
+		counts.contested + counts.adapting + counts.probing + counts.quiet + counts.starvation;
 	if (total <= 0) return "";
-	const segments = [
+	const segments: Array<[string, number]> = [
 		["contested", counts.contested],
 		["adapting", counts.adapting],
 		["probing", counts.probing],
@@ -163,11 +159,10 @@ function stateStrip(counts: DeterrenceStateCounts): string {
 		["starvation", counts.starvation]
 	];
 	return segments
-		.map(segment => {
-			const name = segment[0] as string;
-			const value = segment[1] as number;
-			return `<span class="det-state det-state--${name}" title="${name}: ${fixed(value, 1)} opportunities" style="flex:${Math.max(0.001, value / total)}"></span>`;
-		})
+		.map(
+			([name, value]) =>
+				`<span class="det-state det-state--${name}" title="${name}: ${fixed(value, 1)} opportunities" style="flex:${Math.max(0.001, value / total)}"></span>`
+		)
 		.join("");
 }
 
@@ -186,8 +181,9 @@ function policyCard(aggregate: PolicyAggregate): string {
 				<div><small>mean survival</small><strong>${fixed(aggregate.meanSurvival, 1)}</strong></div>
 				<div><small>raids / breaches</small><strong>${fixed(aggregate.meanRaids, 1)} / ${fixed(aggregate.meanBreaches, 1)}</strong></div>
 				<div><small>attacker ROI</small><strong>${fixed(aggregate.meanAttackerRoi, 2)}</strong></div>
+				<div><small>target signal</small><strong>${fixed(aggregate.meanTargetSignal, 2)}</strong></div>
 			</div>
-			<footer>Representative seed: ${summary.raids} raids · ${summary.breaches} breaches · ${fixed(summary.totalDefenderRecoveredEnergy, 0)} captured energy · ${fixed(summary.totalDefenderBreachLoss, 0)} breach loss</footer>
+			<footer>Representative seed: ${summary.raids} raids · ${summary.breaches} breaches · ${fixed(summary.totalAttackerExtractedEnergy, 0)} actually extracted · ${fixed(summary.totalDefenderRecoveredEnergy, 0)} captured · ${fixed(summary.totalDefenderBreachLoss, 0)} breach loss</footer>
 		</article>
 	`;
 }
@@ -202,7 +198,8 @@ const meta = {
 		collectionEfficiency: 0.78,
 		confidenceSmoothing: 0.14,
 		breachLossMultiplier: 1,
-		starvationThreshold: 6500
+		starvationThreshold: 6500,
+		targetSignalFloor: 0.08
 	},
 	argTypes: {
 		horizon: { control: { type: "range", min: 20, max: 240, step: 10 } },
@@ -210,14 +207,13 @@ const meta = {
 		seedCount: { control: { type: "range", min: 1, max: 64, step: 1 } },
 		collectionEfficiency: { control: { type: "range", min: 0.1, max: 1, step: 0.02 } },
 		confidenceSmoothing: { control: { type: "range", min: 0.02, max: 0.5, step: 0.01 } },
-		breachLossMultiplier: { control: { type: "range", min: 0.25, max: 1.5, step: 0.05 } },
-		starvationThreshold: { control: { type: "range", min: 1000, max: 15000, step: 500 } }
+		breachLossMultiplier: { control: { type: "range", min: 1, max: 2, step: 0.05 } },
+		starvationThreshold: { control: { type: "range", min: 1000, max: 15000, step: 500 } },
+		targetSignalFloor: { control: { type: "range", min: 0.01, max: 0.3, step: 0.01 } }
 	},
 	render: (args: DeterrenceArgs) => {
 		const aggregates = aggregatePolicies(args);
-		const competent = aggregates.find(
-			entry => entry.id === "competent-defense"
-		);
+		const competent = aggregates.find(entry => entry.id === "competent-defense");
 		const leak = aggregates.find(entry => entry.id === "intentional-leak");
 		const antiFarmingPass =
 			competent !== undefined &&
@@ -228,7 +224,7 @@ const meta = {
 		const shell = createLabShell(
 			"Foundations / strategy",
 			"Deterrence and anti-farming economy",
-			"Engine-free normalized model for the defender → deterrence → starvation hinge. Values are experimental, injectable hypotheses rather than production balance. The default sweep should make active competent defense outperform deliberate breach farming while over-fortification still risks self-starvation."
+			"Engine-free conserved-value model for the defender → deterrence → starvation hinge. Actual extraction is capped by available reserve, captured raider energy is bounded by committed value, and dim targets suppress expensive attacker commitments. All values remain experimental hypotheses."
 		);
 
 		shell.frame.innerHTML = `
@@ -279,9 +275,7 @@ type Story = StoryObj<typeof meta>;
 export const PolicySweep: Story = {
 	play: async ({ canvasElement }) => {
 		const cards = canvasElement.querySelectorAll<HTMLElement>("[data-policy]");
-		const gate = canvasElement.querySelector<HTMLElement>(
-			"[data-anti-farming-pass]"
-		);
+		const gate = canvasElement.querySelector<HTMLElement>("[data-anti-farming-pass]");
 		await expect(cards.length).toBe(DEFAULT_DETERRENCE_POLICIES.length);
 		await expect(gate).not.toBeNull();
 		if (!gate) return;
@@ -298,12 +292,16 @@ export const PolicySweep: Story = {
 			const result = invariantResults[resultIndex];
 			for (let stepIndex = 0; stepIndex < result.steps.length; stepIndex += 1) {
 				const step = result.steps[stepIndex];
-				await expect(step.defenderRecoveredEnergy).toBeLessThanOrEqual(
-					step.committedEnergy
-				);
-				await expect(step.defenderEnergyAfter).toBeLessThanOrEqual(
-					config.maxDefenderEnergy
-				);
+				await expect(step.defenderRecoveredEnergy).toBeLessThanOrEqual(step.committedEnergy);
+				await expect(step.extractedEnergy).toBeLessThanOrEqual(step.requestedExtraction);
+				await expect(step.extractedEnergy).toBeLessThanOrEqual(step.defenderEnergyAfterUpkeep);
+				await expect(step.defenderBreachLoss).toBeLessThanOrEqual(step.defenderEnergyAfterUpkeep);
+				await expect(step.extractedEnergy).toBeLessThanOrEqual(step.defenderBreachLoss);
+				await expect(step.targetSignal).toBeGreaterThanOrEqual(config.targetSignalFloor);
+				await expect(step.targetSignal).toBeLessThanOrEqual(1);
+				await expect(step.raidChance).toBeGreaterThanOrEqual(0);
+				await expect(step.raidChance).toBeLessThanOrEqual(1);
+				await expect(step.defenderEnergyAfter).toBeLessThanOrEqual(config.maxDefenderEnergy);
 				await expect(step.defenderEnergyAfter).toBeGreaterThanOrEqual(0);
 			}
 		}

--- a/src/js/gameplay/deterrenceEconomy.ts
+++ b/src/js/gameplay/deterrenceEconomy.ts
@@ -38,11 +38,12 @@ export interface DeterrenceModelConfig {
 	initialAttackerConfidence: number;
 	collectionEfficiency: number;
 	confidenceSmoothing: number;
-	idleConfidenceDecay: number;
+	idleConfidenceSmoothing: number;
 	travelCost: number;
 	breachLossMultiplier: number;
 	starvationThreshold: number;
 	confidenceHysteresis: number;
+	targetSignalFloor: number;
 }
 
 export interface DeterrenceStep {
@@ -50,7 +51,10 @@ export interface DeterrenceStep {
 	stateBefore: DeterrenceState;
 	stateAfter: DeterrenceState;
 	defenderEnergyBefore: number;
+	defenderEnergyAfterUpkeep: number;
 	defenderEnergyAfter: number;
+	targetSignal: number;
+	raidChance: number;
 	attackerConfidenceBefore: number;
 	attackerConfidenceAfter: number;
 	raidOccurred: boolean;
@@ -58,6 +62,7 @@ export interface DeterrenceStep {
 	breached: boolean;
 	remainingViability: number;
 	committedEnergy: number;
+	requestedExtraction: number;
 	extractedEnergy: number;
 	defenderRecoveredEnergy: number;
 	defenderBreachLoss: number;
@@ -85,6 +90,7 @@ export interface DeterrenceSummary {
 	totalDefenderRecoveredEnergy: number;
 	totalDefenderBreachLoss: number;
 	attackerReturnOnCommitment: number;
+	meanTargetSignal: number;
 	stateCounts: DeterrenceStateCounts;
 }
 
@@ -120,25 +126,20 @@ function normalizedConfig(config: DeterrenceModelConfig): DeterrenceModelConfig 
 	return {
 		horizon: Math.max(1, Math.floor(nonNegative(config.horizon, 120))),
 		maxDefenderEnergy: maximum,
-		initialDefenderEnergy: clamp(
-			config.initialDefenderEnergy,
-			0,
-			maximum
-		),
+		initialDefenderEnergy: clamp(config.initialDefenderEnergy, 0, maximum),
 		initialAttackerConfidence: clamp01(config.initialAttackerConfidence),
 		collectionEfficiency: clamp01(config.collectionEfficiency),
 		confidenceSmoothing: clamp01(config.confidenceSmoothing),
-		idleConfidenceDecay: clamp01(config.idleConfidenceDecay),
+		idleConfidenceSmoothing: clamp01(config.idleConfidenceSmoothing),
 		travelCost: nonNegative(config.travelCost),
-		breachLossMultiplier: nonNegative(config.breachLossMultiplier, 1),
+		breachLossMultiplier: clamp(config.breachLossMultiplier, 1, 3),
 		starvationThreshold: clamp(config.starvationThreshold, 0, maximum),
-		confidenceHysteresis: clamp(config.confidenceHysteresis, 0, 0.2)
+		confidenceHysteresis: clamp(config.confidenceHysteresis, 0, 0.2),
+		targetSignalFloor: clamp(config.targetSignalFloor, 0.01, 0.5)
 	};
 }
 
-function normalizedPolicy(
-	policy: DeterrencePolicyProfile
-): DeterrencePolicyProfile {
+function normalizedPolicy(policy: DeterrencePolicyProfile): DeterrencePolicyProfile {
 	return {
 		id: policy.id,
 		label: policy.label,
@@ -148,9 +149,7 @@ function normalizedPolicy(
 	};
 }
 
-function normalizedRaider(
-	profile: RaiderEconomyProfile
-): RaiderEconomyProfile {
+function normalizedRaider(profile: RaiderEconomyProfile): RaiderEconomyProfile {
 	return {
 		tier: profile.tier,
 		committedEnergy: nonNegative(profile.committedEnergy),
@@ -161,10 +160,7 @@ function normalizedRaider(
 	};
 }
 
-/**
- * Deterministic 32-bit LCG. This is an experiment repeatability tool, not a
- * gameplay-randomness recommendation.
- */
+/** Deterministic repeatability tool, not a gameplay-RNG recommendation. */
 export function createDeterrenceRandom(seed: number): () => number {
 	let state = Math.floor(finite(seed, 1)) >>> 0;
 	return () => {
@@ -187,10 +183,6 @@ function candidateState(
 	return "DETERRENT_QUIET";
 }
 
-/**
- * Small confidence hysteresis prevents one marginal result from bouncing the
- * conceptual world state across a threshold every opportunity.
- */
 export function resolveDeterrenceState(
 	previous: DeterrenceState,
 	confidenceInput: number,
@@ -212,7 +204,6 @@ export function resolveDeterrenceState(
 	if (energy <= config.starvationThreshold && confidence < 0.18) {
 		return "STRATEGIC_STARVATION";
 	}
-
 	if (previous === "CONTESTED" && confidence >= 0.62 - hysteresis) {
 		return "CONTESTED";
 	}
@@ -236,11 +227,23 @@ export function resolveDeterrenceState(
 	) {
 		return "DETERRENT_QUIET";
 	}
-
 	return candidateState(confidence, energy, config);
 }
 
-export function deterrenceRaidChance(state: DeterrenceState): number {
+/**
+ * Lossy strategic signature: stored energy is informative but not an exact
+ * meter. The floor preserves occasional cheap probing of dim targets.
+ */
+export function deterrenceTargetSignal(
+	energyInput: number,
+	configInput: DeterrenceModelConfig
+): number {
+	const config = normalizedConfig(configInput);
+	const richness = clamp(energyInput, 0, config.maxDefenderEnergy) / config.maxDefenderEnergy;
+	return Math.max(config.targetSignalFloor, Math.sqrt(richness));
+}
+
+function baseRaidChance(state: DeterrenceState): number {
 	if (state === "CONTESTED") return 0.94;
 	if (state === "ADAPTING") return 0.72;
 	if (state === "PROBING") return 0.42;
@@ -248,22 +251,42 @@ export function deterrenceRaidChance(state: DeterrenceState): number {
 	return 0.06;
 }
 
+export function deterrenceRaidChance(
+	state: DeterrenceState,
+	targetSignal = 1
+): number {
+	const signal = clamp01(targetSignal);
+	return baseRaidChance(state) * (0.2 + 0.8 * signal);
+}
+
+/**
+ * State controls behavioral caution while target signal suppresses expensive
+ * commitment against poor targets. Quiet/starving systems receive probes only.
+ */
 export function selectDeterrenceRaidTier(
 	state: DeterrenceState,
-	randomValue: number
+	randomValue: number,
+	targetSignal = 1
 ): RaiderTier {
 	const value = clamp01(randomValue);
+	const signal = clamp01(targetSignal);
+	if (signal < 0.25) return 1;
+	if (state === "DETERRENT_QUIET" || state === "STRATEGIC_STARVATION") {
+		return 1;
+	}
+	if (state === "PROBING") {
+		return signal >= 0.6 && value >= 0.9 ? 2 : 1;
+	}
 	if (state === "CONTESTED") {
+		if (signal < 0.5) return value < 0.8 ? 1 : 2;
 		if (value < 0.25) return 1;
 		if (value < 0.7) return 2;
 		return 3;
 	}
-	if (state === "ADAPTING") {
-		if (value < 0.45) return 1;
-		if (value < 0.85) return 2;
-		return 3;
-	}
-	return value < 0.9 ? 1 : 2;
+	if (signal < 0.5) return value < 0.85 ? 1 : 2;
+	if (value < 0.45) return 1;
+	if (value < 0.85) return 2;
+	return 3;
 }
 
 function raiderForTier(
@@ -271,32 +294,77 @@ function raiderForTier(
 	profiles: RaiderEconomyProfile[]
 ): RaiderEconomyProfile {
 	for (let index = 0; index < profiles.length; index += 1) {
-		if (profiles[index].tier === tier) {
-			return normalizedRaider(profiles[index]);
-		}
+		if (profiles[index].tier === tier) return normalizedRaider(profiles[index]);
 	}
 	throw new Error(`Missing Raider ${tier} economy profile`);
 }
 
-function stateCounts(): DeterrenceStateCounts {
-	return {
-		contested: 0,
-		adapting: 0,
-		probing: 0,
-		quiet: 0,
-		starvation: 0
-	};
+/**
+ * High-tier investment should not be made when even perfect extraction from the
+ * currently visible reserve cannot plausibly repay commitment plus travel.
+ * R1 remains available as the cheap probe even when its own expected ROI is poor.
+ */
+function economicallyPlausibleTier(
+	requestedTier: RaiderTier,
+	availableEnergy: number,
+	profiles: RaiderEconomyProfile[],
+	travelCost: number
+): RaiderEconomyProfile {
+	let tier = requestedTier;
+	while (tier > 1) {
+		const profile = raiderForTier(tier, profiles);
+		const grossCeiling = Math.min(profile.extractionPotential, availableEnergy);
+		if (grossCeiling >= profile.committedEnergy + travelCost) return profile;
+		tier = (tier - 1) as RaiderTier;
+	}
+	return raiderForTier(1, profiles);
 }
 
-function countState(
-	counts: DeterrenceStateCounts,
-	state: DeterrenceState
-): void {
+function emptyCounts(): DeterrenceStateCounts {
+	return { contested: 0, adapting: 0, probing: 0, quiet: 0, starvation: 0 };
+}
+
+function countState(counts: DeterrenceStateCounts, state: DeterrenceState): void {
 	if (state === "CONTESTED") counts.contested += 1;
 	else if (state === "ADAPTING") counts.adapting += 1;
 	else if (state === "PROBING") counts.probing += 1;
 	else if (state === "DETERRENT_QUIET") counts.quiet += 1;
 	else counts.starvation += 1;
+}
+
+function noRaidStep(
+	opportunity: number,
+	stateBefore: DeterrenceState,
+	stateAfter: DeterrenceState,
+	energyBefore: number,
+	energyAfterUpkeep: number,
+	targetSignal: number,
+	raidChance: number,
+	confidenceBefore: number,
+	confidenceAfter: number
+): DeterrenceStep {
+	return {
+		opportunity,
+		stateBefore,
+		stateAfter,
+		defenderEnergyBefore: energyBefore,
+		defenderEnergyAfterUpkeep: energyAfterUpkeep,
+		defenderEnergyAfter: energyAfterUpkeep,
+		targetSignal,
+		raidChance,
+		attackerConfidenceBefore: confidenceBefore,
+		attackerConfidenceAfter: confidenceAfter,
+		raidOccurred: false,
+		tier: null,
+		breached: false,
+		remainingViability: 0,
+		committedEnergy: 0,
+		requestedExtraction: 0,
+		extractedEnergy: 0,
+		defenderRecoveredEnergy: 0,
+		defenderBreachLoss: 0,
+		attackerNetReturn: 0
+	};
 }
 
 export function runDeterrenceScenario(
@@ -309,7 +377,6 @@ export function runDeterrenceScenario(
 	const config = normalizedConfig(configInput);
 	const random = createDeterrenceRandom(seed);
 	const steps: DeterrenceStep[] = [];
-
 	let defenderEnergy = config.initialDefenderEnergy;
 	let attackerConfidence = config.initialAttackerConfidence;
 	let state = candidateState(attackerConfidence, defenderEnergy, config);
@@ -318,75 +385,59 @@ export function runDeterrenceScenario(
 		const energyBefore = defenderEnergy;
 		const confidenceBefore = attackerConfidence;
 		const stateBefore = state;
-
-		defenderEnergy = Math.max(
-			0,
-			defenderEnergy - policy.upkeepPerOpportunity
-		);
-
-		state = resolveDeterrenceState(
-			state,
-			attackerConfidence,
-			defenderEnergy,
-			config
-		);
+		defenderEnergy = Math.max(0, defenderEnergy - policy.upkeepPerOpportunity);
+		const energyAfterUpkeep = defenderEnergy;
+		state = resolveDeterrenceState(state, attackerConfidence, defenderEnergy, config);
+		const targetSignal = deterrenceTargetSignal(defenderEnergy, config);
+		const raidChance = deterrenceRaidChance(state, targetSignal);
 
 		if (defenderEnergy <= 0) {
-			steps.push({
-				opportunity,
-				stateBefore,
-				stateAfter: state,
-				defenderEnergyBefore: energyBefore,
-				defenderEnergyAfter: 0,
-				attackerConfidenceBefore: confidenceBefore,
-				attackerConfidenceAfter: attackerConfidence,
-				raidOccurred: false,
-				tier: null,
-				breached: false,
-				remainingViability: 0,
-				committedEnergy: 0,
-				extractedEnergy: 0,
-				defenderRecoveredEnergy: 0,
-				defenderBreachLoss: 0,
-				attackerNetReturn: 0
-			});
+			steps.push(
+				noRaidStep(
+					opportunity,
+					stateBefore,
+					state,
+					energyBefore,
+					0,
+					targetSignal,
+					raidChance,
+					confidenceBefore,
+					attackerConfidence
+				)
+			);
 			break;
 		}
 
-		const raidOccurred = random() < deterrenceRaidChance(state);
-		if (!raidOccurred) {
+		if (random() >= raidChance) {
+			const idlePrior = clamp01(0.12 + 0.58 * targetSignal);
 			attackerConfidence = clamp01(
-				attackerConfidence - config.idleConfidenceDecay
+				attackerConfidence +
+					config.idleConfidenceSmoothing * (idlePrior - attackerConfidence)
 			);
-			state = resolveDeterrenceState(
-				state,
-				attackerConfidence,
-				defenderEnergy,
-				config
+			state = resolveDeterrenceState(state, attackerConfidence, defenderEnergy, config);
+			steps.push(
+				noRaidStep(
+					opportunity,
+					stateBefore,
+					state,
+					energyBefore,
+					energyAfterUpkeep,
+					targetSignal,
+					raidChance,
+					confidenceBefore,
+					attackerConfidence
+				)
 			);
-			steps.push({
-				opportunity,
-				stateBefore,
-				stateAfter: state,
-				defenderEnergyBefore: energyBefore,
-				defenderEnergyAfter: defenderEnergy,
-				attackerConfidenceBefore: confidenceBefore,
-				attackerConfidenceAfter: attackerConfidence,
-				raidOccurred: false,
-				tier: null,
-				breached: false,
-				remainingViability: 0,
-				committedEnergy: 0,
-				extractedEnergy: 0,
-				defenderRecoveredEnergy: 0,
-				defenderBreachLoss: 0,
-				attackerNetReturn: 0
-			});
 			continue;
 		}
 
-		const tier = selectDeterrenceRaidTier(state, random());
-		const raider = raiderForTier(tier, raiderProfiles);
+		const requestedTier = selectDeterrenceRaidTier(state, random(), targetSignal);
+		const raider = economicallyPlausibleTier(
+			requestedTier,
+			defenderEnergy,
+			raiderProfiles,
+			config.travelCost
+		);
 		const breachChance = clamp01(
 			raider.baseBreachChance +
 				policy.deliberateLeakBias -
@@ -397,81 +448,73 @@ export function runDeterrenceScenario(
 		if (breached) {
 			const jitter = (random() - 0.5) * 0.08;
 			remainingViability = clamp(
-				0.86 -
-					policy.defenseStrength *
-						(0.78 - raider.resistance * 0.2) +
-					jitter,
+				0.86 - policy.defenseStrength * (0.78 - raider.resistance * 0.2) + jitter,
 				0.08,
 				0.95
 			);
 		}
 
-		const extractedEnergy = breached
+		const requestedExtraction = breached
 			? raider.extractionPotential * remainingViability
 			: 0;
-		const defenderBreachLoss =
-			extractedEnergy * config.breachLossMultiplier;
-
-		const liberatedFraction = clamp01(
-			0.35 +
-				policy.defenseStrength * 0.55 -
-				remainingViability * 0.25
-		);
+		const extractedEnergy = Math.min(requestedExtraction, defenderEnergy);
+		const defenderBreachLoss = breached
+			? Math.min(
+					defenderEnergy,
+					extractedEnergy * config.breachLossMultiplier
+				)
+			: 0;
+		const damagedFraction = breached ? 1 - remainingViability : 1;
 		const defenderRecoveredEnergy = Math.min(
 			raider.committedEnergy,
 			raider.committedEnergy *
 				raider.recoverableFraction *
-				liberatedFraction *
+				damagedFraction *
 				config.collectionEfficiency
 		);
 
 		defenderEnergy = clamp(
-			defenderEnergy + defenderRecoveredEnergy - defenderBreachLoss,
+			defenderEnergy - defenderBreachLoss + defenderRecoveredEnergy,
 			0,
 			config.maxDefenderEnergy
 		);
-
 		const attackerNetReturn =
 			extractedEnergy - raider.committedEnergy - config.travelCost;
 		const normalizedOutcome = clamp01(
-			0.5 +
-				attackerNetReturn /
-					(2 * Math.max(1, raider.committedEnergy))
+			0.5 + attackerNetReturn / (2 * Math.max(1, raider.committedEnergy))
 		);
 		attackerConfidence = clamp01(
 			(1 - config.confidenceSmoothing) * attackerConfidence +
 				config.confidenceSmoothing * normalizedOutcome
 		);
-		state = resolveDeterrenceState(
-			state,
-			attackerConfidence,
-			defenderEnergy,
-			config
-		);
+		state = resolveDeterrenceState(state, attackerConfidence, defenderEnergy, config);
 
 		steps.push({
 			opportunity,
 			stateBefore,
 			stateAfter: state,
 			defenderEnergyBefore: energyBefore,
+			defenderEnergyAfterUpkeep: energyAfterUpkeep,
 			defenderEnergyAfter: defenderEnergy,
+			targetSignal,
+			raidChance,
 			attackerConfidenceBefore: confidenceBefore,
 			attackerConfidenceAfter: attackerConfidence,
 			raidOccurred: true,
-			tier,
+			tier: raider.tier,
 			breached,
 			remainingViability,
 			committedEnergy: raider.committedEnergy,
+			requestedExtraction,
 			extractedEnergy,
 			defenderRecoveredEnergy,
 			defenderBreachLoss,
 			attackerNetReturn
 		});
-
 		if (defenderEnergy <= 0) break;
 	}
 
-	const counts = stateCounts();
+	const counts = emptyCounts();
 	let raids = 0;
 	let breaches = 0;
 	let committed = 0;
@@ -479,6 +522,7 @@ export function runDeterrenceScenario(
 	let recovered = 0;
 	let breachLoss = 0;
 	let attackerNet = 0;
+	let targetSignalTotal = 0;
 
 	for (let index = 0; index < steps.length; index += 1) {
 		const step = steps[index];
@@ -490,6 +534,7 @@ export function runDeterrenceScenario(
 		recovered += step.defenderRecoveredEnergy;
 		breachLoss += step.defenderBreachLoss;
 		attackerNet += step.attackerNetReturn;
+		targetSignalTotal += step.targetSignal;
 	}
 
 	return {
@@ -507,8 +552,9 @@ export function runDeterrenceScenario(
 			totalAttackerExtractedEnergy: extracted,
 			totalDefenderRecoveredEnergy: recovered,
 			totalDefenderBreachLoss: breachLoss,
-			attackerReturnOnCommitment:
-				committed <= 0 ? 0 : attackerNet / committed,
+			attackerReturnOnCommitment: committed <= 0 ? 0 : attackerNet / committed,
+			meanTargetSignal:
+				steps.length <= 0 ? 0 : targetSignalTotal / steps.length,
 			stateCounts: counts
 		}
 	};
@@ -522,19 +568,12 @@ export function compareDeterrencePolicies(
 ): DeterrenceScenarioResult[] {
 	const results: DeterrenceScenarioResult[] = [];
 	for (let index = 0; index < policies.length; index += 1) {
-		results.push(
-			runDeterrenceScenario(policies[index], config, raiderProfiles, seed)
-		);
+		results.push(runDeterrenceScenario(policies[index], config, raiderProfiles, seed));
 	}
 	return results;
 }
 
-/**
- * Normalized lab defaults only. These values are deliberately injectable and
- * must not be treated as production balance. The raider commitment/extraction
- * scale mirrors current design hypotheses so the experiment can reason about
- * anti-farming and deterrence before live tuning.
- */
+/** Normalized lab hypotheses only; none of these are production balance. */
 export const DEFAULT_DETERRENCE_CONFIG: DeterrenceModelConfig = {
 	horizon: 120,
 	maxDefenderEnergy: 30000,
@@ -542,11 +581,12 @@ export const DEFAULT_DETERRENCE_CONFIG: DeterrenceModelConfig = {
 	initialAttackerConfidence: 0.72,
 	collectionEfficiency: 0.78,
 	confidenceSmoothing: 0.14,
-	idleConfidenceDecay: 0.008,
+	idleConfidenceSmoothing: 0.03,
 	travelCost: 500,
 	breachLossMultiplier: 1,
 	starvationThreshold: 6500,
-	confidenceHysteresis: 0.05
+	confidenceHysteresis: 0.05,
+	targetSignalFloor: 0.08
 };
 
 export const DEFAULT_DETERRENCE_RAIDERS: RaiderEconomyProfile[] = [

--- a/src/js/gameplay/deterrenceEconomy.ts
+++ b/src/js/gameplay/deterrenceEconomy.ts
@@ -1,0 +1,615 @@
+export type RaiderTier = 1 | 2 | 3;
+
+export type DeterrenceState =
+	| "CONTESTED"
+	| "ADAPTING"
+	| "PROBING"
+	| "DETERRENT_QUIET"
+	| "STRATEGIC_STARVATION";
+
+export type DeterrencePolicyId =
+	| "competent-defense"
+	| "intentional-leak"
+	| "over-fortified"
+	| "resource-conservative"
+	| "passive-isolation";
+
+export interface DeterrencePolicyProfile {
+	id: DeterrencePolicyId;
+	label: string;
+	defenseStrength: number;
+	deliberateLeakBias: number;
+	upkeepPerOpportunity: number;
+}
+
+export interface RaiderEconomyProfile {
+	tier: RaiderTier;
+	committedEnergy: number;
+	extractionPotential: number;
+	baseBreachChance: number;
+	resistance: number;
+	recoverableFraction: number;
+}
+
+export interface DeterrenceModelConfig {
+	horizon: number;
+	maxDefenderEnergy: number;
+	initialDefenderEnergy: number;
+	initialAttackerConfidence: number;
+	collectionEfficiency: number;
+	confidenceSmoothing: number;
+	idleConfidenceDecay: number;
+	travelCost: number;
+	breachLossMultiplier: number;
+	starvationThreshold: number;
+	confidenceHysteresis: number;
+}
+
+export interface DeterrenceStep {
+	opportunity: number;
+	stateBefore: DeterrenceState;
+	stateAfter: DeterrenceState;
+	defenderEnergyBefore: number;
+	defenderEnergyAfter: number;
+	attackerConfidenceBefore: number;
+	attackerConfidenceAfter: number;
+	raidOccurred: boolean;
+	tier: RaiderTier | null;
+	breached: boolean;
+	remainingViability: number;
+	committedEnergy: number;
+	extractedEnergy: number;
+	defenderRecoveredEnergy: number;
+	defenderBreachLoss: number;
+	attackerNetReturn: number;
+}
+
+export interface DeterrenceStateCounts {
+	contested: number;
+	adapting: number;
+	probing: number;
+	quiet: number;
+	starvation: number;
+}
+
+export interface DeterrenceSummary {
+	policy: DeterrencePolicyId;
+	label: string;
+	survivalOpportunities: number;
+	ruined: boolean;
+	endingDefenderEnergy: number;
+	raids: number;
+	breaches: number;
+	totalAttackerCommittedEnergy: number;
+	totalAttackerExtractedEnergy: number;
+	totalDefenderRecoveredEnergy: number;
+	totalDefenderBreachLoss: number;
+	attackerReturnOnCommitment: number;
+	stateCounts: DeterrenceStateCounts;
+}
+
+export interface DeterrenceScenarioResult {
+	policy: DeterrencePolicyProfile;
+	steps: DeterrenceStep[];
+	summary: DeterrenceSummary;
+}
+
+const UINT32_RANGE = 4294967296;
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function nonNegative(value: number, fallback = 0): number {
+	return Math.max(0, finite(value, fallback));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
+}
+
+function clamp01(value: number): number {
+	return clamp(value, 0, 1);
+}
+
+function normalizedConfig(config: DeterrenceModelConfig): DeterrenceModelConfig {
+	const maximum = Math.max(1, nonNegative(config.maxDefenderEnergy, 30000));
+	return {
+		horizon: Math.max(1, Math.floor(nonNegative(config.horizon, 120))),
+		maxDefenderEnergy: maximum,
+		initialDefenderEnergy: clamp(
+			config.initialDefenderEnergy,
+			0,
+			maximum
+		),
+		initialAttackerConfidence: clamp01(config.initialAttackerConfidence),
+		collectionEfficiency: clamp01(config.collectionEfficiency),
+		confidenceSmoothing: clamp01(config.confidenceSmoothing),
+		idleConfidenceDecay: clamp01(config.idleConfidenceDecay),
+		travelCost: nonNegative(config.travelCost),
+		breachLossMultiplier: nonNegative(config.breachLossMultiplier, 1),
+		starvationThreshold: clamp(config.starvationThreshold, 0, maximum),
+		confidenceHysteresis: clamp(config.confidenceHysteresis, 0, 0.2)
+	};
+}
+
+function normalizedPolicy(
+	policy: DeterrencePolicyProfile
+): DeterrencePolicyProfile {
+	return {
+		id: policy.id,
+		label: policy.label,
+		defenseStrength: clamp01(policy.defenseStrength),
+		deliberateLeakBias: clamp(policy.deliberateLeakBias, -0.5, 0.5),
+		upkeepPerOpportunity: nonNegative(policy.upkeepPerOpportunity)
+	};
+}
+
+function normalizedRaider(
+	profile: RaiderEconomyProfile
+): RaiderEconomyProfile {
+	return {
+		tier: profile.tier,
+		committedEnergy: nonNegative(profile.committedEnergy),
+		extractionPotential: nonNegative(profile.extractionPotential),
+		baseBreachChance: clamp01(profile.baseBreachChance),
+		resistance: clamp01(profile.resistance),
+		recoverableFraction: clamp01(profile.recoverableFraction)
+	};
+}
+
+/**
+ * Deterministic 32-bit LCG. This is an experiment repeatability tool, not a
+ * gameplay-randomness recommendation.
+ */
+export function createDeterrenceRandom(seed: number): () => number {
+	let state = Math.floor(finite(seed, 1)) >>> 0;
+	return () => {
+		state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+		return state / UINT32_RANGE;
+	};
+}
+
+function candidateState(
+	confidence: number,
+	energy: number,
+	config: DeterrenceModelConfig
+): DeterrenceState {
+	if (energy <= config.starvationThreshold && confidence < 0.18) {
+		return "STRATEGIC_STARVATION";
+	}
+	if (confidence >= 0.62) return "CONTESTED";
+	if (confidence >= 0.42) return "ADAPTING";
+	if (confidence >= 0.2) return "PROBING";
+	return "DETERRENT_QUIET";
+}
+
+/**
+ * Small confidence hysteresis prevents one marginal result from bouncing the
+ * conceptual world state across a threshold every opportunity.
+ */
+export function resolveDeterrenceState(
+	previous: DeterrenceState,
+	confidenceInput: number,
+	energyInput: number,
+	configInput: DeterrenceModelConfig
+): DeterrenceState {
+	const config = normalizedConfig(configInput);
+	const confidence = clamp01(confidenceInput);
+	const energy = clamp(energyInput, 0, config.maxDefenderEnergy);
+	const hysteresis = config.confidenceHysteresis;
+
+	if (
+		previous === "STRATEGIC_STARVATION" &&
+		energy <= config.starvationThreshold * 1.15 &&
+		confidence < 0.2 + hysteresis
+	) {
+		return "STRATEGIC_STARVATION";
+	}
+	if (energy <= config.starvationThreshold && confidence < 0.18) {
+		return "STRATEGIC_STARVATION";
+	}
+
+	if (previous === "CONTESTED" && confidence >= 0.62 - hysteresis) {
+		return "CONTESTED";
+	}
+	if (
+		previous === "ADAPTING" &&
+		confidence >= 0.42 - hysteresis &&
+		confidence < 0.62 + hysteresis
+	) {
+		return "ADAPTING";
+	}
+	if (
+		previous === "PROBING" &&
+		confidence >= 0.2 - hysteresis &&
+		confidence < 0.42 + hysteresis
+	) {
+		return "PROBING";
+	}
+	if (
+		previous === "DETERRENT_QUIET" &&
+		confidence < 0.2 + hysteresis
+	) {
+		return "DETERRENT_QUIET";
+	}
+
+	return candidateState(confidence, energy, config);
+}
+
+export function deterrenceRaidChance(state: DeterrenceState): number {
+	if (state === "CONTESTED") return 0.94;
+	if (state === "ADAPTING") return 0.72;
+	if (state === "PROBING") return 0.42;
+	if (state === "DETERRENT_QUIET") return 0.12;
+	return 0.06;
+}
+
+export function selectDeterrenceRaidTier(
+	state: DeterrenceState,
+	randomValue: number
+): RaiderTier {
+	const value = clamp01(randomValue);
+	if (state === "CONTESTED") {
+		if (value < 0.25) return 1;
+		if (value < 0.7) return 2;
+		return 3;
+	}
+	if (state === "ADAPTING") {
+		if (value < 0.45) return 1;
+		if (value < 0.85) return 2;
+		return 3;
+	}
+	return value < 0.9 ? 1 : 2;
+}
+
+function raiderForTier(
+	tier: RaiderTier,
+	profiles: RaiderEconomyProfile[]
+): RaiderEconomyProfile {
+	for (let index = 0; index < profiles.length; index += 1) {
+		if (profiles[index].tier === tier) {
+			return normalizedRaider(profiles[index]);
+		}
+	}
+	throw new Error(`Missing Raider ${tier} economy profile`);
+}
+
+function stateCounts(): DeterrenceStateCounts {
+	return {
+		contested: 0,
+		adapting: 0,
+		probing: 0,
+		quiet: 0,
+		starvation: 0
+	};
+}
+
+function countState(
+	counts: DeterrenceStateCounts,
+	state: DeterrenceState
+): void {
+	if (state === "CONTESTED") counts.contested += 1;
+	else if (state === "ADAPTING") counts.adapting += 1;
+	else if (state === "PROBING") counts.probing += 1;
+	else if (state === "DETERRENT_QUIET") counts.quiet += 1;
+	else counts.starvation += 1;
+}
+
+export function runDeterrenceScenario(
+	policyInput: DeterrencePolicyProfile,
+	configInput: DeterrenceModelConfig,
+	raiderProfiles: RaiderEconomyProfile[],
+	seed = 1
+): DeterrenceScenarioResult {
+	const policy = normalizedPolicy(policyInput);
+	const config = normalizedConfig(configInput);
+	const random = createDeterrenceRandom(seed);
+	const steps: DeterrenceStep[] = [];
+
+	let defenderEnergy = config.initialDefenderEnergy;
+	let attackerConfidence = config.initialAttackerConfidence;
+	let state = candidateState(attackerConfidence, defenderEnergy, config);
+
+	for (let opportunity = 0; opportunity < config.horizon; opportunity += 1) {
+		const energyBefore = defenderEnergy;
+		const confidenceBefore = attackerConfidence;
+		const stateBefore = state;
+
+		defenderEnergy = Math.max(
+			0,
+			defenderEnergy - policy.upkeepPerOpportunity
+		);
+
+		state = resolveDeterrenceState(
+			state,
+			attackerConfidence,
+			defenderEnergy,
+			config
+		);
+
+		if (defenderEnergy <= 0) {
+			steps.push({
+				opportunity,
+				stateBefore,
+				stateAfter: state,
+				defenderEnergyBefore: energyBefore,
+				defenderEnergyAfter: 0,
+				attackerConfidenceBefore: confidenceBefore,
+				attackerConfidenceAfter: attackerConfidence,
+				raidOccurred: false,
+				tier: null,
+				breached: false,
+				remainingViability: 0,
+				committedEnergy: 0,
+				extractedEnergy: 0,
+				defenderRecoveredEnergy: 0,
+				defenderBreachLoss: 0,
+				attackerNetReturn: 0
+			});
+			break;
+		}
+
+		const raidOccurred = random() < deterrenceRaidChance(state);
+		if (!raidOccurred) {
+			attackerConfidence = clamp01(
+				attackerConfidence - config.idleConfidenceDecay
+			);
+			state = resolveDeterrenceState(
+				state,
+				attackerConfidence,
+				defenderEnergy,
+				config
+			);
+			steps.push({
+				opportunity,
+				stateBefore,
+				stateAfter: state,
+				defenderEnergyBefore: energyBefore,
+				defenderEnergyAfter: defenderEnergy,
+				attackerConfidenceBefore: confidenceBefore,
+				attackerConfidenceAfter: attackerConfidence,
+				raidOccurred: false,
+				tier: null,
+				breached: false,
+				remainingViability: 0,
+				committedEnergy: 0,
+				extractedEnergy: 0,
+				defenderRecoveredEnergy: 0,
+				defenderBreachLoss: 0,
+				attackerNetReturn: 0
+			});
+			continue;
+		}
+
+		const tier = selectDeterrenceRaidTier(state, random());
+		const raider = raiderForTier(tier, raiderProfiles);
+		const breachChance = clamp01(
+			raider.baseBreachChance +
+				policy.deliberateLeakBias -
+				policy.defenseStrength * (0.52 - raider.resistance * 0.18)
+		);
+		const breached = random() < breachChance;
+		let remainingViability = 0;
+		if (breached) {
+			const jitter = (random() - 0.5) * 0.08;
+			remainingViability = clamp(
+				0.86 -
+					policy.defenseStrength *
+						(0.78 - raider.resistance * 0.2) +
+					jitter,
+				0.08,
+				0.95
+			);
+		}
+
+		const extractedEnergy = breached
+			? raider.extractionPotential * remainingViability
+			: 0;
+		const defenderBreachLoss =
+			extractedEnergy * config.breachLossMultiplier;
+
+		const liberatedFraction = clamp01(
+			0.35 +
+				policy.defenseStrength * 0.55 -
+				remainingViability * 0.25
+		);
+		const defenderRecoveredEnergy = Math.min(
+			raider.committedEnergy,
+			raider.committedEnergy *
+				raider.recoverableFraction *
+				liberatedFraction *
+				config.collectionEfficiency
+		);
+
+		defenderEnergy = clamp(
+			defenderEnergy + defenderRecoveredEnergy - defenderBreachLoss,
+			0,
+			config.maxDefenderEnergy
+		);
+
+		const attackerNetReturn =
+			extractedEnergy - raider.committedEnergy - config.travelCost;
+		const normalizedOutcome = clamp01(
+			0.5 +
+				attackerNetReturn /
+					(2 * Math.max(1, raider.committedEnergy))
+		);
+		attackerConfidence = clamp01(
+			(1 - config.confidenceSmoothing) * attackerConfidence +
+				config.confidenceSmoothing * normalizedOutcome
+		);
+		state = resolveDeterrenceState(
+			state,
+			attackerConfidence,
+			defenderEnergy,
+			config
+		);
+
+		steps.push({
+			opportunity,
+			stateBefore,
+			stateAfter: state,
+			defenderEnergyBefore: energyBefore,
+			defenderEnergyAfter: defenderEnergy,
+			attackerConfidenceBefore: confidenceBefore,
+			attackerConfidenceAfter: attackerConfidence,
+			raidOccurred: true,
+			tier,
+			breached,
+			remainingViability,
+			committedEnergy: raider.committedEnergy,
+			extractedEnergy,
+			defenderRecoveredEnergy,
+			defenderBreachLoss,
+			attackerNetReturn
+		});
+
+		if (defenderEnergy <= 0) break;
+	}
+
+	const counts = stateCounts();
+	let raids = 0;
+	let breaches = 0;
+	let committed = 0;
+	let extracted = 0;
+	let recovered = 0;
+	let breachLoss = 0;
+	let attackerNet = 0;
+
+	for (let index = 0; index < steps.length; index += 1) {
+		const step = steps[index];
+		countState(counts, step.stateAfter);
+		if (step.raidOccurred) raids += 1;
+		if (step.breached) breaches += 1;
+		committed += step.committedEnergy;
+		extracted += step.extractedEnergy;
+		recovered += step.defenderRecoveredEnergy;
+		breachLoss += step.defenderBreachLoss;
+		attackerNet += step.attackerNetReturn;
+	}
+
+	return {
+		policy,
+		steps,
+		summary: {
+			policy: policy.id,
+			label: policy.label,
+			survivalOpportunities: steps.length,
+			ruined: defenderEnergy <= 0,
+			endingDefenderEnergy: defenderEnergy,
+			raids,
+			breaches,
+			totalAttackerCommittedEnergy: committed,
+			totalAttackerExtractedEnergy: extracted,
+			totalDefenderRecoveredEnergy: recovered,
+			totalDefenderBreachLoss: breachLoss,
+			attackerReturnOnCommitment:
+				committed <= 0 ? 0 : attackerNet / committed,
+			stateCounts: counts
+		}
+	};
+}
+
+export function compareDeterrencePolicies(
+	policies: DeterrencePolicyProfile[],
+	config: DeterrenceModelConfig,
+	raiderProfiles: RaiderEconomyProfile[],
+	seed = 1
+): DeterrenceScenarioResult[] {
+	const results: DeterrenceScenarioResult[] = [];
+	for (let index = 0; index < policies.length; index += 1) {
+		results.push(
+			runDeterrenceScenario(policies[index], config, raiderProfiles, seed)
+		);
+	}
+	return results;
+}
+
+/**
+ * Normalized lab defaults only. These values are deliberately injectable and
+ * must not be treated as production balance. The raider commitment/extraction
+ * scale mirrors current design hypotheses so the experiment can reason about
+ * anti-farming and deterrence before live tuning.
+ */
+export const DEFAULT_DETERRENCE_CONFIG: DeterrenceModelConfig = {
+	horizon: 120,
+	maxDefenderEnergy: 30000,
+	initialDefenderEnergy: 30000,
+	initialAttackerConfidence: 0.72,
+	collectionEfficiency: 0.78,
+	confidenceSmoothing: 0.14,
+	idleConfidenceDecay: 0.008,
+	travelCost: 500,
+	breachLossMultiplier: 1,
+	starvationThreshold: 6500,
+	confidenceHysteresis: 0.05
+};
+
+export const DEFAULT_DETERRENCE_RAIDERS: RaiderEconomyProfile[] = [
+	{
+		tier: 1,
+		committedEnergy: 3000,
+		extractionPotential: 7720,
+		baseBreachChance: 0.38,
+		resistance: 0.18,
+		recoverableFraction: 0.6
+	},
+	{
+		tier: 2,
+		committedEnergy: 12000,
+		extractionPotential: 30440,
+		baseBreachChance: 0.44,
+		resistance: 0.34,
+		recoverableFraction: 0.55
+	},
+	{
+		tier: 3,
+		committedEnergy: 27000,
+		extractionPotential: 68160,
+		baseBreachChance: 0.5,
+		resistance: 0.5,
+		recoverableFraction: 0.5
+	}
+];
+
+export const DEFAULT_DETERRENCE_POLICIES: DeterrencePolicyProfile[] = [
+	{
+		id: "competent-defense",
+		label: "Competent defense",
+		defenseStrength: 0.74,
+		deliberateLeakBias: 0,
+		upkeepPerOpportunity: 340
+	},
+	{
+		id: "intentional-leak",
+		label: "Intentional leak / farm",
+		defenseStrength: 0.46,
+		deliberateLeakBias: 0.19,
+		upkeepPerOpportunity: 230
+	},
+	{
+		id: "over-fortified",
+		label: "Over-fortified",
+		defenseStrength: 0.91,
+		deliberateLeakBias: 0,
+		upkeepPerOpportunity: 560
+	},
+	{
+		id: "resource-conservative",
+		label: "Resource-conservative",
+		defenseStrength: 0.63,
+		deliberateLeakBias: 0.02,
+		upkeepPerOpportunity: 280
+	},
+	{
+		id: "passive-isolation",
+		label: "Passive isolation",
+		defenseStrength: 0.16,
+		deliberateLeakBias: 0.08,
+		upkeepPerOpportunity: 120
+	}
+];


### PR DESCRIPTION
Refs #107, #103, #73, #74, #76, #92

## Purpose

Make the defender → deterrence → starvation hinge executable as a pure deterministic experiment before changing live wave scheduling or production balance.

## Scope

Exactly two new files on current `master` (`206dc028500f10614504ec0a07b381e5320204ca`):

- `src/js/gameplay/deterrenceEconomy.ts`
- `experiments/storybook/src/Foundations/Strategy/DeterrenceEconomy.stories.ts`

No existing production call site, package/dependency metadata, wave table, balance constant, Babylon/Cannon object, or certification head is modified.

## Model

The engine-free model exposes injectable:

- defender energy / upkeep;
- attacker confidence;
- conserved/capped defender recovery;
- breach loss;
- travel cost;
- R1/R2/R3 commitment/extraction hypotheses;
- defense strength and deliberate leak bias;
- confidence smoothing and hysteresis;
- `CONTESTED → ADAPTING → PROBING → DETERRENT_QUIET → STRATEGIC_STARVATION` states.

Every raid records committed energy, extraction, recovered energy, breach loss, viability and attacker net return. Defender recovery is explicitly bounded by the raid's committed energy so this experiment cannot manufacture unbounded economic value from repeated damage.

All defaults are labeled normalized lab hypotheses. They are not a production-balance proposal.

## Strategy comparison

The Storybook surface compares five policies across deterministic seed sweeps:

1. competent defense;
2. intentional leak/farm;
3. over-fortification;
4. resource-conservative defense;
5. passive isolation.

It visualizes representative reserve trajectories, ruin rate, survival horizon, raids/breaches, attacker ROI and occupancy of the five deterrence states.

The default parameter regime is intentionally only a feasibility witness: competent defense has lower ruin and longer survival than intentional leakage, while aggressive over-fortification is also costly. Controls are provided specifically so reviewers can find failure regimes rather than treating the defaults as solved balance.

## Automated Storybook invariants

The story checks:

- all five policies render;
- default anti-farming comparison passes;
- recovered defender energy never exceeds the corresponding raid commitment;
- defender reserve stays within `[0, max]`.

## Frozen certification boundary

Do **not** add this draft to the current #92 frozen certification cut. It is a later engine-free experimental lane. The frozen exact SHAs for #95/#97/#105 remain unchanged.

## Follow-up evidence

Before this leaves draft status:

- Storybook typecheck/build/test on an appropriate later campaign;
- parameter sweeps beyond the default witness;
- identify regimes with probe farming, runaway energy, over-fast starvation or noisy state oscillation;
- calibrate physical outcome inputs using #72/#86 fixture evidence rather than inventing hidden live-game bonuses;
- decide whether the model remains an experiment, becomes a reusable campaign contract, or is replaced by a better hypothesis.

No production integration should be inferred from this PR alone.