### PR TITLE
Add explicit tower interaction intent and rejection states

### DIFF
--- a/experiments/storybook/src/Arena/Interaction/TowerIntent.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/TowerIntent.stories.ts
@@ -58,6 +58,12 @@ function scenarios(args: TowerIntentArgs): Scenario[] {
 			request: request(args, { balance: BASE_COST })
 		},
 		{
+			id: "under-cost",
+			label: "Below cost",
+			description: "A true insufficient-reserve case remains rejected under both affordability policies.",
+			request: request(args, { balance: BASE_COST - 1 })
+		},
+		{
 			id: "occupied",
 			label: "Occupied cell",
 			description: "Affordability must not hide an independent spatial rejection.",
@@ -96,6 +102,12 @@ function scenarios(args: TowerIntentArgs): Scenario[] {
 			request: request(args, { targetKind: "invalid-terrain" })
 		},
 		{
+			id: "outside-arena",
+			label: "Outside arena",
+			description: "A world hit outside the playable surface is distinguishable from invalid terrain.",
+			request: request(args, { targetKind: "outside-arena" })
+		},
+		{
 			id: "camera-gesture",
 			label: "Camera owns gesture",
 			description: "Input arbitration is ignored by world placement rather than reported as an economic failure.",
@@ -111,7 +123,7 @@ function scenarios(args: TowerIntentArgs): Scenario[] {
 }
 
 function statusLabel(result: TowerInteractionPreview): string {
-	if (result.disposition === "allowed") return result.intent.toUpper();
+	if (result.disposition === "allowed") return result.intent.toUpperCase();
 	if (result.disposition === "ignored") return "CAMERA";
 	return result.reason.replace(/-/g, " ").toUpperCase();
 }
@@ -143,7 +155,7 @@ const meta = {
 		const shell = createLabShell(
 			"Arena / interaction",
 			"Tower intent and rejection grammar",
-			"A pointer/touch candidate should be classifiable before the scene mutates. The playground keeps current exact-cost and level-3 behavior visible as explicit policies while exposing occupied, protected, terrain, stale-target and camera-arbitration reasons that production currently collapses into silent or ambiguous feedback."
+			"A pointer/touch candidate should be classifiable before the scene mutates. The playground keeps current exact-cost and level-3 behavior visible as explicit policies while exposing affordability, occupancy, protected-space, terrain, arena-boundary, stale-target and camera-arbitration reasons that production currently collapses into silent or ambiguous feedback."
 		);
 
 		shell.frame.innerHTML = `
@@ -199,31 +211,48 @@ type Story = StoryObj<typeof meta>;
 export const IntentMatrix: Story = {
 	play: async ({ canvasElement, args }) => {
 		const cards = canvasElement.querySelectorAll<HTMLElement>("[data-scenario]");
-		await expect(cards.length).toBe(9);
+		await expect(cards.length).toBe(11);
 
 		const exact = canvasElement.querySelector<HTMLElement>("[data-scenario='exact-cost']");
+		const underCost = canvasElement.querySelector<HTMLElement>("[data-scenario='under-cost']");
 		const occupied = canvasElement.querySelector<HTMLElement>("[data-scenario='occupied']");
 		const protectedCore = canvasElement.querySelector<HTMLElement>("[data-scenario='protected']");
 		const towerL1 = canvasElement.querySelector<HTMLElement>("[data-scenario='tower-l1']");
 		const towerMax = canvasElement.querySelector<HTMLElement>("[data-scenario='tower-max']");
+		const outsideArena = canvasElement.querySelector<HTMLElement>("[data-scenario='outside-arena']");
 		const camera = canvasElement.querySelector<HTMLElement>("[data-scenario='camera-gesture']");
 		const stale = canvasElement.querySelector<HTMLElement>("[data-scenario='stale-target']");
 
 		await expect(exact).not.toBeNull();
+		await expect(underCost).not.toBeNull();
 		await expect(occupied).not.toBeNull();
 		await expect(protectedCore).not.toBeNull();
 		await expect(towerL1).not.toBeNull();
 		await expect(towerMax).not.toBeNull();
+		await expect(outsideArena).not.toBeNull();
 		await expect(camera).not.toBeNull();
 		await expect(stale).not.toBeNull();
-		if (!exact || !occupied || !protectedCore || !towerL1 || !towerMax || !camera || !stale) return;
+		if (
+			!exact ||
+			!underCost ||
+			!occupied ||
+			!protectedCore ||
+			!towerL1 ||
+			!towerMax ||
+			!outsideArena ||
+			!camera ||
+			!stale
+		) return;
 
 		await expect(exact.dataset.disposition).toBe(
 			args.affordabilityRule === "inclusive" ? "allowed" : "rejected"
 		);
+		await expect(underCost.dataset.disposition).toBe("rejected");
+		await expect(underCost.dataset.reason).toBe("unaffordable");
 		await expect(occupied.dataset.reason).toBe("occupied");
 		await expect(protectedCore.dataset.reason).toBe("protected-core");
 		await expect(towerL1.dataset.intent).toBe("upgrade");
+		await expect(outsideArena.dataset.reason).toBe("outside-arena");
 		await expect(camera.dataset.disposition).toBe("ignored");
 		await expect(camera.dataset.reason).toBe("camera-gesture");
 		await expect(stale.dataset.reason).toBe("stale-target");

--- a/experiments/storybook/src/Arena/Interaction/TowerIntent.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/TowerIntent.stories.ts
@@ -1,0 +1,239 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	classifyTowerInteraction,
+	type TowerAffordabilityRule,
+	type TowerInteractionPreview,
+	type TowerInteractionRequest,
+	type TowerMaxLevelBehavior
+} from "@defend/gameplay/towerInteraction";
+import { createLabShell } from "../../labTheme";
+
+type TowerIntentArgs = {
+	balance: number;
+	affordabilityRule: TowerAffordabilityRule;
+	maxLevelBehavior: TowerMaxLevelBehavior;
+};
+
+interface Scenario {
+	id: string;
+	label: string;
+	description: string;
+	request: TowerInteractionRequest;
+}
+
+const BASE_COST = 3000;
+const MAX_LEVEL = 3;
+
+function request(
+	args: TowerIntentArgs,
+	overrides: Partial<TowerInteractionRequest>
+): TowerInteractionRequest {
+	return {
+		inputOwner: "world",
+		targetKind: "ground",
+		occupied: false,
+		balance: args.balance,
+		requestedCost: BASE_COST,
+		currentLevel: 0,
+		maximumLevel: MAX_LEVEL,
+		affordabilityRule: args.affordabilityRule,
+		maxLevelBehavior: args.maxLevelBehavior,
+		...overrides
+	};
+}
+
+function scenarios(args: TowerIntentArgs): Scenario[] {
+	return [
+		{
+			id: "open-ground",
+			label: "Open ground",
+			description: "A normal placement candidate with the current reserve.",
+			request: request(args, {})
+		},
+		{
+			id: "exact-cost",
+			label: "Exact cost",
+			description: "Makes the legacy `>` versus future `>=` affordability boundary explicit.",
+			request: request(args, { balance: BASE_COST })
+		},
+		{
+			id: "occupied",
+			label: "Occupied cell",
+			description: "Affordability must not hide an independent spatial rejection.",
+			request: request(args, { occupied: true })
+		},
+		{
+			id: "protected",
+			label: "Protected core",
+			description: "Core/protected space is a distinct rejection, not a silent tap.",
+			request: request(args, { targetKind: "protected-core" })
+		},
+		{
+			id: "tower-l1",
+			label: "Tower 1",
+			description: "Existing lower-tier tower resolves to an upgrade intent.",
+			request: request(args, {
+				targetKind: "tower",
+				currentLevel: 1,
+				requestedCost: BASE_COST * 2
+			})
+		},
+		{
+			id: "tower-max",
+			label: "Tower 3",
+			description: "Max-tier behavior remains an explicit caller-owned policy.",
+			request: request(args, {
+				targetKind: "tower",
+				currentLevel: 3,
+				requestedCost: BASE_COST * 4
+			})
+		},
+		{
+			id: "invalid-terrain",
+			label: "Invalid terrain",
+			description: "Unsupported/non-buildable terrain has its own causal feedback state.",
+			request: request(args, { targetKind: "invalid-terrain" })
+		},
+		{
+			id: "camera-gesture",
+			label: "Camera owns gesture",
+			description: "Input arbitration is ignored by world placement rather than reported as an economic failure.",
+			request: request(args, { inputOwner: "camera" })
+		},
+		{
+			id: "stale-target",
+			label: "Stale target",
+			description: "Disposed/outdated pick state remains distinguishable from invalid terrain.",
+			request: request(args, { targetKind: "stale-target" })
+		}
+	];
+}
+
+function statusLabel(result: TowerInteractionPreview): string {
+	if (result.disposition === "allowed") return result.intent.toUpper();
+	if (result.disposition === "ignored") return "CAMERA";
+	return result.reason.replace(/-/g, " ").toUpperCase();
+}
+
+const meta = {
+	title: "Arena/Interaction/Tower Intent",
+	tags: ["test", "visual"],
+	args: {
+		balance: 15000,
+		affordabilityRule: "legacy-strict",
+		maxLevelBehavior: "legacy-rebuild"
+	},
+	argTypes: {
+		balance: { control: { type: "range", min: 0, max: 30000, step: 500 } },
+		affordabilityRule: {
+			control: "radio",
+			options: ["legacy-strict", "inclusive"]
+		},
+		maxLevelBehavior: {
+			control: "radio",
+			options: ["legacy-rebuild", "maintenance", "no-op"]
+		}
+	},
+	render: (args: TowerIntentArgs) => {
+		const rows = scenarios(args).map(scenario => ({
+			...scenario,
+			result: classifyTowerInteraction(scenario.request)
+		}));
+		const shell = createLabShell(
+			"Arena / interaction",
+			"Tower intent and rejection grammar",
+			"A pointer/touch candidate should be classifiable before the scene mutates. The playground keeps current exact-cost and level-3 behavior visible as explicit policies while exposing occupied, protected, terrain, stale-target and camera-arbitration reasons that production currently collapses into silent or ambiguous feedback."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.intent-summary { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:10px; margin-bottom:14px; }
+				.intent-summary > div { padding:10px 12px; border:1px solid rgba(244,237,247,.12); border-radius:8px; background:rgba(255,255,255,.025); }
+				.intent-summary dt { color:rgba(244,237,247,.5); font-size:10px; text-transform:uppercase; letter-spacing:.07em; }
+				.intent-summary dd { margin:5px 0 0; font-size:13px; }
+				.intent-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:10px; }
+				.intent-card { min-height:150px; padding:13px; border:1px solid rgba(244,237,247,.12); border-radius:9px; background:rgba(8,10,18,.48); }
+				.intent-card[data-disposition="allowed"] { box-shadow:inset 3px 0 0 rgba(73,215,209,.78); }
+				.intent-card[data-disposition="rejected"] { box-shadow:inset 3px 0 0 rgba(228,185,128,.76); }
+				.intent-card[data-disposition="ignored"] { box-shadow:inset 3px 0 0 rgba(180,107,211,.72); }
+				.intent-card h3 { margin:0 0 5px; font-size:13px; }
+				.intent-card p { min-height:34px; margin:0 0 10px; color:rgba(244,237,247,.54); font-size:11px; line-height:1.45; }
+				.intent-state { display:flex; justify-content:space-between; gap:8px; align-items:center; margin-bottom:9px; }
+				.intent-chip { padding:4px 7px; border:1px solid rgba(244,237,247,.16); border-radius:999px; font-size:10px; letter-spacing:.04em; }
+				.intent-metrics { display:grid; grid-template-columns:1fr auto; gap:4px 10px; font-size:10px; color:rgba(244,237,247,.48); }
+				.intent-metrics strong { color:rgba(244,237,247,.74); font-weight:500; }
+			</style>
+			<dl class="intent-summary">
+				<div><dt>Reserve</dt><dd>${Math.max(0, args.balance).toFixed(0)}</dd></div>
+				<div><dt>Affordability</dt><dd>${args.affordabilityRule}</dd></div>
+				<div><dt>Max-tier policy</dt><dd>${args.maxLevelBehavior}</dd></div>
+			</dl>
+			<div class="intent-grid">
+				${rows
+					.map(
+						row => `
+						<article class="intent-card" data-scenario="${row.id}" data-disposition="${row.result.disposition}" data-reason="${row.result.reason}" data-intent="${row.result.intent}">
+							<h3>${row.label}</h3>
+							<p>${row.description}</p>
+							<div class="intent-state"><span class="intent-chip">${statusLabel(row.result)}</span><span>${row.result.disposition}</span></div>
+							<div class="intent-metrics">
+								<span>intent</span><strong>${row.result.intent}</strong>
+								<span>reason</span><strong>${row.result.reason}</strong>
+								<span>cost</span><strong>${row.result.requestedCost.toFixed(0)}</strong>
+								<span>projected reserve</span><strong>${row.result.balanceAfter.toFixed(0)}</strong>
+								<span>level</span><strong>${row.result.fromLevel} → ${row.result.toLevel}</strong>
+							</div>
+						</article>`
+					)
+					.join("")}
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<TowerIntentArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const IntentMatrix: Story = {
+	play: async ({ canvasElement, args }) => {
+		const cards = canvasElement.querySelectorAll<HTMLElement>("[data-scenario]");
+		await expect(cards.length).toBe(9);
+
+		const exact = canvasElement.querySelector<HTMLElement>("[data-scenario='exact-cost']");
+		const occupied = canvasElement.querySelector<HTMLElement>("[data-scenario='occupied']");
+		const protectedCore = canvasElement.querySelector<HTMLElement>("[data-scenario='protected']");
+		const towerL1 = canvasElement.querySelector<HTMLElement>("[data-scenario='tower-l1']");
+		const towerMax = canvasElement.querySelector<HTMLElement>("[data-scenario='tower-max']");
+		const camera = canvasElement.querySelector<HTMLElement>("[data-scenario='camera-gesture']");
+		const stale = canvasElement.querySelector<HTMLElement>("[data-scenario='stale-target']");
+
+		await expect(exact).not.toBeNull();
+		await expect(occupied).not.toBeNull();
+		await expect(protectedCore).not.toBeNull();
+		await expect(towerL1).not.toBeNull();
+		await expect(towerMax).not.toBeNull();
+		await expect(camera).not.toBeNull();
+		await expect(stale).not.toBeNull();
+		if (!exact || !occupied || !protectedCore || !towerL1 || !towerMax || !camera || !stale) return;
+
+		await expect(exact.dataset.disposition).toBe(
+			args.affordabilityRule === "inclusive" ? "allowed" : "rejected"
+		);
+		await expect(occupied.dataset.reason).toBe("occupied");
+		await expect(protectedCore.dataset.reason).toBe("protected-core");
+		await expect(towerL1.dataset.intent).toBe("upgrade");
+		await expect(camera.dataset.disposition).toBe("ignored");
+		await expect(camera.dataset.reason).toBe("camera-gesture");
+		await expect(stale.dataset.reason).toBe("stale-target");
+
+		if (args.maxLevelBehavior === "legacy-rebuild") {
+			await expect(towerMax.dataset.intent).toBe("rebuild");
+		} else if (args.maxLevelBehavior === "maintenance") {
+			await expect(towerMax.dataset.intent).toBe("maintain");
+		} else {
+			await expect(towerMax.dataset.reason).toBe("max-level");
+		}
+	}
+};

--- a/src/js/gameplay/towerInteraction.ts
+++ b/src/js/gameplay/towerInteraction.ts
@@ -1,0 +1,251 @@
+export type TowerInteractionTargetKind =
+	| "ground"
+	| "tower"
+	| "protected-core"
+	| "invalid-terrain"
+	| "outside-arena"
+	| "stale-target";
+
+export type TowerInteractionInputOwner = "world" | "camera";
+
+/**
+ * `legacy-strict` mirrors the current production `balance > cost` behavior.
+ * `inclusive` expresses ordinary exact-cost affordability (`balance >= cost`)
+ * for the separately tracked post-baseline fix. The caller chooses explicitly;
+ * this module does not silently change live economics.
+ */
+export type TowerAffordabilityRule = "legacy-strict" | "inclusive";
+
+/**
+ * Current production reconstructs level 3 when it is tapped and affordable.
+ * Maintenance/no-op semantics remain design decisions, so the caller selects
+ * which interpretation is being previewed or certified.
+ */
+export type TowerMaxLevelBehavior =
+	| "legacy-rebuild"
+	| "maintenance"
+	| "no-op";
+
+export type TowerInteractionIntent =
+	| "place"
+	| "upgrade"
+	| "rebuild"
+	| "maintain"
+	| "none";
+
+export type TowerInteractionDisposition = "allowed" | "rejected" | "ignored";
+
+export type TowerInteractionReason =
+	| "none"
+	| "camera-gesture"
+	| "occupied"
+	| "unaffordable"
+	| "protected-core"
+	| "invalid-terrain"
+	| "outside-arena"
+	| "stale-target"
+	| "max-level"
+	| "invalid-tower-level";
+
+export interface TowerInteractionRequest {
+	inputOwner: TowerInteractionInputOwner;
+	targetKind: TowerInteractionTargetKind;
+	occupied: boolean;
+	balance: number;
+	requestedCost: number;
+	currentLevel: number;
+	maximumLevel: number;
+	affordabilityRule: TowerAffordabilityRule;
+	maxLevelBehavior: TowerMaxLevelBehavior;
+}
+
+export interface TowerInteractionPreview {
+	intent: TowerInteractionIntent;
+	disposition: TowerInteractionDisposition;
+	reason: TowerInteractionReason;
+	requestedCost: number;
+	balanceBefore: number;
+	balanceAfter: number;
+	fromLevel: number;
+	toLevel: number;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function nonnegative(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function towerLevel(value: number): number {
+	return Math.max(0, Math.floor(nonnegative(value)));
+}
+
+export function towerInteractionCanAfford(
+	balance: number,
+	cost: number,
+	rule: TowerAffordabilityRule
+): boolean {
+	const available = nonnegative(balance);
+	const requested = nonnegative(cost);
+	return rule === "inclusive"
+		? available >= requested
+		: available > requested;
+}
+
+function preview(
+	request: TowerInteractionRequest,
+	intent: TowerInteractionIntent,
+	disposition: TowerInteractionDisposition,
+	reason: TowerInteractionReason,
+	fromLevel: number,
+	toLevel: number,
+	charge: boolean
+): TowerInteractionPreview {
+	const balance = nonnegative(request.balance);
+	const cost = nonnegative(request.requestedCost);
+	return {
+		intent,
+		disposition,
+		reason,
+		requestedCost: cost,
+		balanceBefore: balance,
+		balanceAfter: charge ? Math.max(0, balance - cost) : balance,
+		fromLevel,
+		toLevel
+	};
+}
+
+function rejected(
+	request: TowerInteractionRequest,
+	reason: TowerInteractionReason,
+	intent: TowerInteractionIntent,
+	fromLevel: number,
+	toLevel: number
+): TowerInteractionPreview {
+	return preview(request, intent, "rejected", reason, fromLevel, toLevel, false);
+}
+
+function permitted(
+	request: TowerInteractionRequest,
+	intent: TowerInteractionIntent,
+	fromLevel: number,
+	toLevel: number
+): TowerInteractionPreview {
+	if (
+		!towerInteractionCanAfford(
+			request.balance,
+			request.requestedCost,
+			request.affordabilityRule
+		)
+	) {
+		return rejected(request, "unaffordable", intent, fromLevel, toLevel);
+	}
+	return preview(request, intent, "allowed", "none", fromLevel, toLevel, true);
+}
+
+/**
+ * Classify a pointer/touch candidate before Babylon presentation or mutation.
+ *
+ * Geometry/picking owns target classification and requested cost. This function
+ * owns only the semantic result: what the user appears to be asking for, whether
+ * that request is actionable under the selected legacy/future policy, and the
+ * reason a world interaction should communicate when it is not.
+ *
+ * It intentionally performs no scene mutation, audio, color change, placement,
+ * disposal, construction, upgrade, maintenance or reserve mutation.
+ */
+export function classifyTowerInteraction(
+	request: TowerInteractionRequest
+): TowerInteractionPreview {
+	const currentLevel = towerLevel(request.currentLevel);
+	const maximumLevel = Math.max(1, towerLevel(request.maximumLevel));
+
+	if (request.inputOwner === "camera") {
+		return preview(
+			request,
+			"none",
+			"ignored",
+			"camera-gesture",
+			currentLevel,
+			currentLevel,
+			false
+		);
+	}
+
+	if (request.targetKind === "protected-core") {
+		return rejected(
+			request,
+			"protected-core",
+			"none",
+			currentLevel,
+			currentLevel
+		);
+	}
+	if (request.targetKind === "invalid-terrain") {
+		return rejected(
+			request,
+			"invalid-terrain",
+			"none",
+			currentLevel,
+			currentLevel
+		);
+	}
+	if (request.targetKind === "outside-arena") {
+		return rejected(
+			request,
+			"outside-arena",
+			"none",
+			currentLevel,
+			currentLevel
+		);
+	}
+	if (request.targetKind === "stale-target") {
+		return rejected(
+			request,
+			"stale-target",
+			"none",
+			currentLevel,
+			currentLevel
+		);
+	}
+
+	if (request.targetKind === "ground") {
+		if (request.occupied) {
+			return rejected(request, "occupied", "place", 0, 1);
+		}
+		return permitted(request, "place", 0, 1);
+	}
+
+	if (currentLevel <= 0 || currentLevel > maximumLevel) {
+		return rejected(
+			request,
+			"invalid-tower-level",
+			"none",
+			currentLevel,
+			currentLevel
+		);
+	}
+
+	if (currentLevel < maximumLevel) {
+		return permitted(request, "upgrade", currentLevel, currentLevel + 1);
+	}
+
+	if (request.maxLevelBehavior === "legacy-rebuild") {
+		return permitted(request, "rebuild", currentLevel, currentLevel);
+	}
+	if (request.maxLevelBehavior === "maintenance") {
+		return permitted(request, "maintain", currentLevel, currentLevel);
+	}
+	return rejected(
+		request,
+		"max-level",
+		"none",
+		currentLevel,
+		currentLevel
+	);
+}


### PR DESCRIPTION
Refs #108
Related: #109, #95, #92

## Purpose

Introduce the pure interaction-state seam requested by #108 before changing Babylon pointer handlers or player-facing presentation.

Current production interaction has several semantically different outcomes that are either silent or coupled directly to scene/audio/color mutation. This PR makes the intended action and rejection cause explicit without changing live gameplay.

## `src/js/gameplay/towerInteraction.ts`

Adds an engine-free classifier for a pointer/touch candidate.

It distinguishes:

- placement;
- upgrade;
- max-tier rebuild;
- future maintenance;
- no-op;
- camera-owned gesture;
- occupied cell;
- unaffordable action;
- protected/core space;
- invalid terrain;
- outside arena;
- stale/disposed target;
- invalid tower level;
- max-level rejection.

The result contains semantic intent, allowed/rejected/ignored disposition, explicit reason, requested cost, balance before/projected balance after, and source/resulting tower level.

The module performs no Babylon picking, scene mutation, audio, color feedback, tower construction/disposal, maintenance, or authoritative reserve mutation.

## Deliberately unresolved legacy boundaries

This PR does **not** silently fix behavior that #95/#109 still need to characterize.

### Exact-cost affordability

Current production placement/upgrade requires `balance > cost`, so a balance exactly equal to the displayed cost is rejected.

The classifier therefore makes affordability caller-owned:

- `legacy-strict` → `balance > cost`;
- `inclusive` → `balance >= cost`.

The default Storybook fixture uses `legacy-strict`. #109 can switch a later production adapter to `inclusive` only after the #95 baseline is recorded.

### Level-3 tap semantics

Current production reconstructs level 3 when an affordable level-3 tower is tapped. Whether that should remain a rebuild, become maintenance/renovation, or become a no-op is a separate design decision.

The classifier therefore exposes `legacy-rebuild`, `maintenance`, and `no-op`. No canonical change is made here.

## Storybook playground

Adds `Arena/Interaction/Tower Intent` with a deterministic eleven-state matrix:

1. open ground;
2. exact-cost placement;
3. below-cost placement;
4. occupied cell;
5. protected core;
6. level-1 tower upgrade;
7. level-3 tower policy;
8. invalid terrain;
9. outside arena;
10. camera-owned gesture;
11. stale/disposed target.

Controls expose reserve, affordability policy and max-tier policy. Cards show classified intent, reason, cost, projected reserve and level transition.

The interaction test verifies the exact-cost policy boundary, true under-cost rejection under both policies, occupied/protected attribution, outside-arena attribution, lower-tier upgrade intent, camera arbitration, stale-target classification and all three max-tier policies.

The story creates no RAF, Worker, AudioContext, Babylon scene, timer, or global listener.

## Scope

Base: current `master` `206dc028500f10614504ec0a07b381e5320204ca`.

Compared with `master`:

- exactly 2 added files;
- no package/dependency changes;
- no live pointer/input call-site changes;
- no tower/economy/balance mutation;
- no changes to #95/#97/#105 frozen certification heads.

Current head after Storybook coverage hardening: `bb78ef4132b467c21983fd43ecd3cd619e829f8a`.

## Local certification

Keep draft until a later post-freeze campaign can run.

### Root compatibility

- TypeScript 3.2 accepts `towerInteraction.ts`;
- NaN/Infinity/negative numeric inputs remain finite/non-negative in returned previews;
- `legacy-strict` preserves exact-cost rejection;
- `inclusive` permits exact-cost and projects reserve to zero;
- a true under-cost request remains rejected under both rules;
- occupied/protected/invalid/outside/stale reasons remain independent of affordability;
- lower-tier tower resolves to one-step upgrade;
- max-tier behavior follows the selected explicit policy;
- camera-owned input never becomes a world rejection or charge.

### Storybook

```sh
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Exercise `Arena/Interaction/Tower Intent` across low/exact/high reserve and all max-tier modes.

## Follow-up

After #95 records legacy interaction behavior:

1. #109 may use this seam/helper to implement ordinary exact-cost affordability without duplicating comparison operators;
2. a Babylon adapter can classify protected/occupied/terrain/outside/stale/camera states before mutation and map each reason to world-grounded multimodal feedback;
3. max-tier rebuild versus maintenance/no-op should be decided explicitly, with #96/#105 maintenance semantics available as a future integration reference;
4. only then should the first-contact/browser interaction fixture from #108 exercise real pointer/touch arbitration.

This PR is post-freeze work and must not be inserted into the current #92 campaign.