### PR TITLE
experiment: enforce conserved raid exchange against target richness

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/ConservedRaidExchange.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/ConservedRaidExchange.stories.ts
@@ -54,8 +54,10 @@ const meta = {
 		travelCost: { control: { type: "range", min: 0, max: 5000, step: 100 } }
 	},
 	render: (args: ExchangeArgs) => {
+		const richReserve = Math.max(args.richReserve, args.poorReserve);
+		const poorReserve = Math.min(args.richReserve, args.poorReserve);
 		const rich = settleConservedRaidExchange({
-			defenderReserve: args.richReserve,
+			defenderReserve: richReserve,
 			defenderCapacity: args.capacity,
 			requestedExtractionEnergy: args.requestedExtraction,
 			attackerEmbodiedEnergy: args.attackerEmbodiedEnergy,
@@ -63,7 +65,7 @@ const meta = {
 			collateralDissipationRatio: args.collateralDissipationRatio
 		});
 		const poor = settleConservedRaidExchange({
-			defenderReserve: args.poorReserve,
+			defenderReserve: poorReserve,
 			defenderCapacity: args.capacity,
 			requestedExtractionEnergy: args.requestedExtraction,
 			attackerEmbodiedEnergy: args.attackerEmbodiedEnergy,
@@ -138,8 +140,8 @@ const meta = {
 				.exchange-note { margin-top:14px; padding:12px; border:1px solid rgba(73,215,209,.18); font-size:11px; line-height:1.55; opacity:.76; }
 			</style>
 			<div class="exchange-grid">
-				${card("rich target", args.richReserve, rich.extractedEnergy, rich.unmetExtractionEnergy, rich.recoveredEnergy, rich.reserveAfter, richReturn)}
-				${card("poor target", args.poorReserve, poor.extractedEnergy, poor.unmetExtractionEnergy, poor.recoveredEnergy, poor.reserveAfter, poorReturn)}
+				${card("rich target", richReserve, rich.extractedEnergy, rich.unmetExtractionEnergy, rich.recoveredEnergy, rich.reserveAfter, richReturn)}
+				${card("poor target", poorReserve, poor.extractedEnergy, poor.unmetExtractionEnergy, poor.recoveredEnergy, poor.reserveAfter, poorReturn)}
 			</div>
 			<div class="exchange-note"
 				data-rich-extracted="${rich.extractedEnergy}"

--- a/experiments/storybook/src/Foundations/Strategy/ConservedRaidExchange.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/ConservedRaidExchange.stories.ts
@@ -1,0 +1,198 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	raidAttackerNetReturn,
+	raidTargetRichness,
+	settleConservedRaidExchange
+} from "@defend/gameplay/conservedRaidExchange";
+import { createLabShell } from "../../labTheme";
+
+type ExchangeArgs = {
+	capacity: number;
+	richReserve: number;
+	poorReserve: number;
+	requestedExtraction: number;
+	attackerEmbodiedEnergy: number;
+	requestedRecovery: number;
+	collateralDissipationRatio: number;
+	committedEnergy: number;
+	travelCost: number;
+};
+
+function fixed(value: number, digits = 0): string {
+	if (value !== value || value === Infinity || value === -Infinity) return "0";
+	return value.toFixed(digits);
+}
+
+function percent(value: number): string {
+	return `${fixed(value * 100, 0)}%`;
+}
+
+const meta = {
+	title: "Foundations/Strategy/Conserved Raid Exchange",
+	tags: ["test", "visual"],
+	args: {
+		capacity: 30000,
+		richReserve: 30000,
+		poorReserve: 5000,
+		requestedExtraction: 18000,
+		attackerEmbodiedEnergy: 12000,
+		requestedRecovery: 4500,
+		collateralDissipationRatio: 0.1,
+		committedEnergy: 12000,
+		travelCost: 500
+	},
+	argTypes: {
+		capacity: { control: { type: "range", min: 1000, max: 60000, step: 1000 } },
+		richReserve: { control: { type: "range", min: 0, max: 60000, step: 500 } },
+		poorReserve: { control: { type: "range", min: 0, max: 30000, step: 500 } },
+		requestedExtraction: { control: { type: "range", min: 0, max: 70000, step: 500 } },
+		attackerEmbodiedEnergy: { control: { type: "range", min: 0, max: 30000, step: 500 } },
+		requestedRecovery: { control: { type: "range", min: 0, max: 30000, step: 500 } },
+		collateralDissipationRatio: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
+		committedEnergy: { control: { type: "range", min: 0, max: 30000, step: 500 } },
+		travelCost: { control: { type: "range", min: 0, max: 5000, step: 100 } }
+	},
+	render: (args: ExchangeArgs) => {
+		const rich = settleConservedRaidExchange({
+			defenderReserve: args.richReserve,
+			defenderCapacity: args.capacity,
+			requestedExtractionEnergy: args.requestedExtraction,
+			attackerEmbodiedEnergy: args.attackerEmbodiedEnergy,
+			requestedRecoveryEnergy: args.requestedRecovery,
+			collateralDissipationRatio: args.collateralDissipationRatio
+		});
+		const poor = settleConservedRaidExchange({
+			defenderReserve: args.poorReserve,
+			defenderCapacity: args.capacity,
+			requestedExtractionEnergy: args.requestedExtraction,
+			attackerEmbodiedEnergy: args.attackerEmbodiedEnergy,
+			requestedRecoveryEnergy: args.requestedRecovery,
+			collateralDissipationRatio: args.collateralDissipationRatio
+		});
+		const richReturn = raidAttackerNetReturn(
+			rich.extractedEnergy,
+			args.committedEnergy,
+			args.travelCost
+		);
+		const poorReturn = raidAttackerNetReturn(
+			poor.extractedEnergy,
+			args.committedEnergy,
+			args.travelCost
+		);
+
+		const storageLimited = settleConservedRaidExchange({
+			defenderReserve: Math.max(0, args.capacity - 100),
+			defenderCapacity: args.capacity,
+			requestedExtractionEnergy: 0,
+			attackerEmbodiedEnergy: 1000,
+			requestedRecoveryEnergy: 1000,
+			collateralDissipationRatio: 0
+		});
+		const sourceLimited = settleConservedRaidExchange({
+			defenderReserve: 0,
+			defenderCapacity: args.capacity,
+			requestedExtractionEnergy: 0,
+			attackerEmbodiedEnergy: 3000,
+			requestedRecoveryEnergy: 10000,
+			collateralDissipationRatio: 0
+		});
+
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Conserved raid exchange",
+			"A raider can only extract energy that is physically stored in the target. Combat recovery is separately bounded by attacker embodied energy and by remaining defender storage. Any extra breach harm is dissipative loss, never additional attacker income."
+		);
+
+		const card = (
+			label: string,
+			reserve: number,
+			extracted: number,
+			unmet: number,
+			recovered: number,
+			endReserve: number,
+			attackerReturn: number
+		) => `
+			<article class="exchange-card">
+				<header><small>${label}</small><strong>${percent(raidTargetRichness(reserve, args.capacity))} target richness</strong></header>
+				<div class="exchange-flow">
+					<div><span>stored</span><strong>${fixed(Math.min(args.capacity, Math.max(0, reserve)))}</strong></div>
+					<div><span>actual extraction</span><strong>${fixed(extracted)}</strong></div>
+					<div><span>unmet extraction</span><strong>${fixed(unmet)}</strong></div>
+					<div><span>collected recovery</span><strong>${fixed(recovered)}</strong></div>
+					<div><span>end reserve</span><strong>${fixed(endReserve)}</strong></div>
+					<div><span>attacker net</span><strong>${fixed(attackerReturn)}</strong></div>
+				</div>
+			</article>`;
+
+		shell.frame.innerHTML = `
+			<style>
+				.exchange-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(270px,1fr)); gap:14px; }
+				.exchange-card { border:1px solid rgba(228,185,128,.22); background:rgba(10,3,17,.44); padding:14px; }
+				.exchange-card header { display:flex; justify-content:space-between; gap:12px; align-items:baseline; margin-bottom:12px; }
+				.exchange-card small { text-transform:uppercase; letter-spacing:.08em; opacity:.5; }
+				.exchange-flow { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+				.exchange-flow div { border-top:1px solid rgba(244,237,247,.08); padding-top:7px; }
+				.exchange-flow span { display:block; font-size:10px; opacity:.48; }
+				.exchange-flow strong { display:block; margin-top:3px; font-size:14px; }
+				.exchange-note { margin-top:14px; padding:12px; border:1px solid rgba(73,215,209,.18); font-size:11px; line-height:1.55; opacity:.76; }
+			</style>
+			<div class="exchange-grid">
+				${card("rich target", args.richReserve, rich.extractedEnergy, rich.unmetExtractionEnergy, rich.recoveredEnergy, rich.reserveAfter, richReturn)}
+				${card("poor target", args.poorReserve, poor.extractedEnergy, poor.unmetExtractionEnergy, poor.recoveredEnergy, poor.reserveAfter, poorReturn)}
+			</div>
+			<div class="exchange-note"
+				data-rich-extracted="${rich.extractedEnergy}"
+				data-poor-extracted="${poor.extractedEnergy}"
+				data-rich-return="${richReturn}"
+				data-poor-return="${poorReturn}"
+				data-poor-reserve="${poor.reserveBefore}"
+				data-poor-end="${poor.reserveAfter}"
+				data-poor-loss="${poor.defenderEnergyLost}"
+				data-poor-recovery="${poor.recoveredEnergy}"
+				data-storage-recovery="${storageLimited.recoveredEnergy}"
+				data-storage-uncollected="${storageLimited.uncollectedRecoveryEnergy}"
+				data-source-recovery="${sourceLimited.recoveredEnergy}"
+				data-source-shortfall="${sourceLimited.recoverySourceShortfall}">
+				Same requested raid, different physical reward: an emptying silo reduces actual attacker return automatically. Separate stress fixtures verify that a nearly-full silo cannot report discarded recovery as collected, and that defender recovery cannot exceed attacker embodied energy.
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<ExchangeArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RichVersusPoorTarget: Story = {
+	play: async ({ canvasElement }) => {
+		const evidence = canvasElement.querySelector<HTMLElement>(".exchange-note");
+		await expect(evidence).not.toBeNull();
+		if (!evidence) return;
+
+		const richExtracted = Number(evidence.dataset.richExtracted);
+		const poorExtracted = Number(evidence.dataset.poorExtracted);
+		const richReturn = Number(evidence.dataset.richReturn);
+		const poorReturn = Number(evidence.dataset.poorReturn);
+		const poorReserve = Number(evidence.dataset.poorReserve);
+		const poorEnd = Number(evidence.dataset.poorEnd);
+		const poorLoss = Number(evidence.dataset.poorLoss);
+		const poorRecovery = Number(evidence.dataset.poorRecovery);
+		const storageRecovery = Number(evidence.dataset.storageRecovery);
+		const storageUncollected = Number(evidence.dataset.storageUncollected);
+		const sourceRecovery = Number(evidence.dataset.sourceRecovery);
+		const sourceShortfall = Number(evidence.dataset.sourceShortfall);
+
+		await expect(poorExtracted).toBeLessThanOrEqual(poorReserve + 1e-9);
+		await expect(richExtracted).toBeGreaterThanOrEqual(poorExtracted);
+		await expect(richReturn).toBeGreaterThanOrEqual(poorReturn);
+		await expect(poorEnd).toBeCloseTo(
+			poorReserve - poorLoss + poorRecovery,
+			8
+		);
+		await expect(storageRecovery).toBeLessThanOrEqual(100 + 1e-9);
+		await expect(storageUncollected).toBeGreaterThanOrEqual(900 - 1e-9);
+		await expect(sourceRecovery).toBeLessThanOrEqual(3000 + 1e-9);
+		await expect(sourceShortfall).toBeGreaterThanOrEqual(7000 - 1e-9);
+	}
+};

--- a/src/js/gameplay/conservedRaidExchange.ts
+++ b/src/js/gameplay/conservedRaidExchange.ts
@@ -66,7 +66,7 @@ function clamp(value: number, minimum: number, maximum: number): number {
 export function settleConservedRaidExchange(
 	input: ConservedRaidExchangeInput
 ): ConservedRaidExchangeResult {
-	const capacity = Math.max(0, positive(input.defenderCapacity));
+	const capacity = positive(input.defenderCapacity);
 	const reserveBefore = clamp(input.defenderReserve, 0, capacity);
 
 	const requestedExtractionEnergy = positive(input.requestedExtractionEnergy);
@@ -75,7 +75,7 @@ export function settleConservedRaidExchange(
 		0,
 		requestedExtractionEnergy - extractedEnergy
 	);
-	const reserveAfterExtraction = reserveBefore - defenderEnergySafe(extractedEnergy);
+	const reserveAfterExtraction = reserveBefore - extractedEnergy;
 
 	const requestedCollateralDissipation =
 		extractedEnergy * positive(input.collateralDissipationRatio);
@@ -90,19 +90,17 @@ export function settleConservedRaidExchange(
 	const reserveAfterLoss = reserveAfterExtraction - collateralDissipation;
 
 	const requestedRecoveryEnergy = positive(input.requestedRecoveryEnergy);
-	const attackerEmbodiedEnergy = positive(input.attackerEmbodiedEnergy);
 	const sourceAvailableRecoveryEnergy = Math.min(
 		requestedRecoveryEnergy,
-		attackerEmbodiedEnergy
+		positive(input.attackerEmbodiedEnergy)
 	);
 	const recoverySourceShortfall = Math.max(
 		0,
 		requestedRecoveryEnergy - sourceAvailableRecoveryEnergy
 	);
-	const storageHeadroom = Math.max(0, capacity - reserveAfterLoss);
 	const recoveredEnergy = Math.min(
 		sourceAvailableRecoveryEnergy,
-		storageHeadroom
+		Math.max(0, capacity - reserveAfterLoss)
 	);
 	const uncollectedRecoveryEnergy = Math.max(
 		0,
@@ -130,10 +128,6 @@ export function settleConservedRaidExchange(
 	};
 }
 
-function defenderEnergySafe(value: number): number {
-	return positive(value);
-}
-
 /**
  * Actual attacker return must use energy that was physically extracted rather
  * than the raider's theoretical extraction potential.
@@ -146,8 +140,7 @@ export function raidAttackerNetReturn(
 	return (
 		positive(extractedEnergy) -
 		positive(committedEnergy) -
-		positive
-		(travelCost)
+		positive(travelCost)
 	);
 }
 

--- a/src/js/gameplay/conservedRaidExchange.ts
+++ b/src/js/gameplay/conservedRaidExchange.ts
@@ -70,15 +70,12 @@ export function settleConservedRaidExchange(
 	const reserveBefore = clamp(input.defenderReserve, 0, capacity);
 
 	const requestedExtractionEnergy = positive(input.requestedExtractionEnergy);
-	const extractedEnergy = Math.min(
-		reserveBefore,
-		requestedExtractionEnergy
-	);
+	const extractedEnergy = Math.min(reserveBefore, requestedExtractionEnergy);
 	const unmetExtractionEnergy = Math.max(
 		0,
 		requestedExtractionEnergy - extractedEnergy
 	);
-	const reserveAfterExtraction = reserveBefore - extractedEnergy;
+	const reserveAfterExtraction = reserveBefore - defenderEnergySafe(extractedEnergy);
 
 	const requestedCollateralDissipation =
 		extractedEnergy * positive(input.collateralDissipationRatio);
@@ -93,7 +90,7 @@ export function settleConservedRaidExchange(
 	const reserveAfterLoss = reserveAfterExtraction - collateralDissipation;
 
 	const requestedRecoveryEnergy = positive(input.requestedRecoveryEnergy);
-	const attackerEmbodiedEnergy = positive(input.attackerEnergy ?? input.attackerEmbodiedEnergy);
+	const attackerEmbodiedEnergy = positive(input.attackerEmbodiedEnergy);
 	const sourceAvailableRecoveryEnergy = Math.min(
 		requestedRecoveryEnergy,
 		attackerEmbodiedEnergy
@@ -133,6 +130,10 @@ export function settleConservedRaidExchange(
 	};
 }
 
+function defenderEnergySafe(value: number): number {
+	return positive(value);
+}
+
 /**
  * Actual attacker return must use energy that was physically extracted rather
  * than the raider's theoretical extraction potential.
@@ -145,7 +146,8 @@ export function raidAttackerNetReturn(
 	return (
 		positive(extractedEnergy) -
 		positive(committedEnergy) -
-		positive(travelCost)
+		positive
+		(travelCost)
 	);
 }
 

--- a/src/js/gameplay/conservedRaidExchange.ts
+++ b/src/js/gameplay/conservedRaidExchange.ts
@@ -1,0 +1,163 @@
+export interface ConservedRaidExchangeInput {
+	/** Defender energy physically stored before this exchange. */
+	defenderReserve: number;
+	/** Maximum defender storage capacity. */
+	defenderCapacity: number;
+	/** Energy the breaching raider would extract if the target were rich enough. */
+	requestedExtractionEnergy: number;
+	/** Raider energy physically embodied/committed and available to be captured. */
+	attackerEmbodiedEnergy: number;
+	/** Defender collection demand derived from physical combat outcomes. */
+	requestedRecoveryEnergy: number;
+	/** Additional dissipative defender loss per unit actually extracted. */
+	collateralDissipationRatio: number;
+}
+
+export interface ConservedRaidExchangeResult {
+	reserveBefore: number;
+	reserveAfterExtraction: number;
+	reserveAfterLoss: number;
+	reserveAfter: number;
+	requestedExtractionEnergy: number;
+	extractedEnergy: number;
+	unmetExtractionEnergy: number;
+	requestedCollateralDissipation: number;
+	collateralDissipation: number;
+	unmetCollateralDissipation: number;
+	requestedRecoveryEnergy: number;
+	sourceAvailableRecoveryEnergy: number;
+	recoverySourceShortfall: number;
+	recoveredEnergy: number;
+	uncollectedRecoveryEnergy: number;
+	defenderEnergyLost: number;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
+}
+
+/**
+ * Settle one abstract raid exchange without allowing either side to manufacture
+ * energy through cap clipping.
+ *
+ * Event order is intentionally explicit:
+ *
+ * 1. a breaching body extracts from energy already stored in the defender silo;
+ * 2. optional collateral loss may dissipate additional defender energy, but can
+ *    never increase the attacker's extraction;
+ * 3. defender recovery from damaged/destroyed attacker bodies is collected into
+ *    the remaining storage headroom.
+ *
+ * Production event timing may later call the individual physical transitions at
+ * different moments. This helper exists for headless deterrence/economy models
+ * where those events are summarized into one opportunity.
+ */
+export function settleConservedRaidExchange(
+	input: ConservedRaidExchangeInput
+): ConservedRaidExchangeResult {
+	const capacity = Math.max(0, positive(input.defenderCapacity));
+	const reserveBefore = clamp(input.defenderReserve, 0, capacity);
+
+	const requestedExtractionEnergy = positive(input.requestedExtractionEnergy);
+	const extractedEnergy = Math.min(
+		reserveBefore,
+		requestedExtractionEnergy
+	);
+	const unmetExtractionEnergy = Math.max(
+		0,
+		requestedExtractionEnergy - extractedEnergy
+	);
+	const reserveAfterExtraction = reserveBefore - extractedEnergy;
+
+	const requestedCollateralDissipation =
+		extractedEnergy * positive(input.collateralDissipationRatio);
+	const collateralDissipation = Math.min(
+		reserveAfterExtraction,
+		requestedCollateralDissipation
+	);
+	const unmetCollateralDissipation = Math.max(
+		0,
+		requestedCollateralDissipation - collateralDissipation
+	);
+	const reserveAfterLoss = reserveAfterExtraction - collateralDissipation;
+
+	const requestedRecoveryEnergy = positive(input.requestedRecoveryEnergy);
+	const attackerEmbodiedEnergy = positive(input.attackerEnergy ?? input.attackerEmbodiedEnergy);
+	const sourceAvailableRecoveryEnergy = Math.min(
+		requestedRecoveryEnergy,
+		attackerEmbodiedEnergy
+	);
+	const recoverySourceShortfall = Math.max(
+		0,
+		requestedRecoveryEnergy - sourceAvailableRecoveryEnergy
+	);
+	const storageHeadroom = Math.max(0, capacity - reserveAfterLoss);
+	const recoveredEnergy = Math.min(
+		sourceAvailableRecoveryEnergy,
+		storageHeadroom
+	);
+	const uncollectedRecoveryEnergy = Math.max(
+		0,
+		sourceAvailableRecoveryEnergy - recoveredEnergy
+	);
+	const reserveAfter = reserveAfterLoss + recoveredEnergy;
+
+	return {
+		reserveBefore,
+		reserveAfterExtraction,
+		reserveAfterLoss,
+		reserveAfter,
+		requestedExtractionEnergy,
+		extractedEnergy,
+		unmetExtractionEnergy,
+		requestedCollateralDissipation,
+		collateralDissipation,
+		unmetCollateralDissipation,
+		requestedRecoveryEnergy,
+		sourceAvailableRecoveryEnergy,
+		recoverySourceShortfall,
+		recoveredEnergy,
+		uncollectedRecoveryEnergy,
+		defenderEnergyLost: extractedEnergy + collateralDissipation
+	};
+}
+
+/**
+ * Actual attacker return must use energy that was physically extracted rather
+ * than the raider's theoretical extraction potential.
+ */
+export function raidAttackerNetReturn(
+	extractedEnergy: number,
+	committedEnergy: number,
+	travelCost: number
+): number {
+	return (
+		positive(extractedEnergy) -
+		positive(committedEnergy) -
+		positive(travelCost)
+	);
+}
+
+/**
+ * Readable target richness for experiments/signatures. This is deliberately a
+ * lossy ratio, not authoritative defender state and not a difficulty level.
+ */
+export function raidTargetRichness(
+	defenderReserve: number,
+	defenderCapacity: number
+): number {
+	const capacity = positive(defenderCapacity);
+	if (capacity <= 0) return 0;
+	return clamp(positive(defenderReserve) / capacity, 0, 1);
+}


### PR DESCRIPTION
Refs #107, #103
Parent experiment: #111
Related: #74, #76, #86, #102

## Purpose

Add a narrow conserved-energy settlement seam underneath the deterrence experiment before #111's attacker ROI is treated as meaningful.

Review of #111 found a structural issue: theoretical extraction potential is currently credited to the attacker even when the defender silo contains less energy, while defender recovery/breach totals can describe amounts later clipped by a reserve clamp. That weakens the required `rich target -> more attractive / poor target -> less attractive` loop and can manufacture apparent energy in the headless model.

This child deliberately does **not** rewrite #111's scenario runner yet. It adds the reusable settlement contract and a deterministic witness fixture so the parent can adopt the semantics in one focused follow-up.

## `src/js/gameplay/conservedRaidExchange.ts`

Adds an engine-free exchange contract with explicit event ordering for opportunity-level modeling:

1. breach extraction draws only from energy already stored in the defender silo;
2. optional additional breach harm is dissipative collateral and never becomes attacker income;
3. combat recovery is then collected into remaining defender storage.

The result exposes:

- requested vs actual extraction;
- unmet extraction caused by insufficient target energy;
- requested vs actual dissipative collateral loss;
- requested recovery vs attacker embodied/source-available recovery;
- source shortfall when recovery demand exceeds attacker embodied energy;
- actually collected recovery vs storage-limited uncollected recovery;
- actual defender energy lost;
- before/after reserve states.

`raidAttackerNetReturn()` explicitly uses **actual extracted energy**, not theoretical extraction potential.

`raidTargetRichness()` exposes a lossy reserve/capacity ratio for experiments/signatures. It is not authoritative state and not a difficulty level.

## Why collateral is dissipative

A breach may eventually have effects beyond transferred energy, but a scalar multiplier below 1 must not let an attacker receive more energy than the defender loses. This child therefore represents any extra breach severity as non-negative dissipation after actual extraction. Final production consequences remain an open balance/design question.

## Storybook playground

Adds `Foundations/Strategy/Conserved Raid Exchange`.

The default fixture applies the same requested raid to:

- a rich/full target;
- a poor 5,000-energy target.

The poor target cannot yield the same 18,000 requested extraction, so actual attacker return falls automatically as target richness falls.

Additional deterministic stress cases verify:

- a nearly-full silo reports only recovery that actually fits, with the remainder explicitly uncollected;
- requested recovery cannot exceed attacker embodied energy even when defender storage is empty.

The story asserts conservation identities and creates no RAF, timer, Babylon scene, Worker or AudioContext.

## Integration requirement for #111

Before #111 is considered a credible anti-farming/deterrence model, its raid settlement should consume these semantics (or an equivalent conservation-preserving implementation):

- use actual target-bounded extraction for attacker ROI/confidence;
- use actually applied recovery/loss in summaries rather than pre-clamp nominal values;
- record unmet extraction and uncollected/source-limited recovery;
- make low reserve naturally reduce raid value instead of relying on an abstract starvation-state switch alone.

That directly satisfies #107's requirement that visibly rich targets recover interest more readily and poor targets do not receive irrationally valuable commitments.

## Scope

Relative to #111 head `79a260e45bc70126bdd2ea9975101b09214a55a2`:

- 2 added files;
- no edits to #111's existing scenario runner;
- no production call-site changes;
- no package/dependency changes;
- no final balance constants.

## Validation

Keep draft until a later Storybook/root campaign can run:

```sh
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Also test zero capacity/reserve, extraction greater than reserve, recovery greater than embodied attacker energy, recovery greater than storage headroom, and non-finite inputs.

This remains post-freeze work and must not alter the active #92 exact-SHA campaign.