### PR TITLE
Add deterministic direct-manipulation outcome and rejection contract

### DIFF
--- a/experiments/storybook/src/Foundations/Interaction/DirectManipulation.stories.ts
+++ b/experiments/storybook/src/Foundations/Interaction/DirectManipulation.stories.ts
@@ -1,0 +1,201 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	classifyDirectManipulation,
+	type DirectManipulationCandidate,
+	type DirectManipulationOutcome
+} from "@defend/gameplay/directManipulation";
+import { createLabShell } from "../../labTheme";
+
+type Scenario = {
+	id: string;
+	label: string;
+	candidate: DirectManipulationCandidate;
+};
+
+function baseCandidate(): DirectManipulationCandidate {
+	return {
+		targetKind: "ground",
+		gestureOwner: "world",
+		targetStale: false,
+		terrainValid: true,
+		occupied: false,
+		protected: false,
+		affordable: true,
+		requiredEnergy: 3000,
+		currentTowerLevel: null,
+		maximumTowerLevel: 3,
+		requestedTowerAction: "upgrade",
+		maintenanceAvailable: false
+	};
+}
+
+function scenarios(): Scenario[] {
+	const validPlace = baseCandidate();
+	const unaffordable = { ...baseCandidate(), affordable: false };
+	const occupied = { ...baseCandidate(), occupied: true };
+	const protectedCell = { ...baseCandidate(), protected: true };
+	const invalidTerrain = { ...baseCandidate(), terrainValid: false };
+	const cameraOwned = { ...baseCandidate(), gestureOwner: "camera" as const };
+	const stale = { ...baseCandidate(), targetStale: true };
+	const validUpgrade = {
+		...baseCandidate(),
+		targetKind: "tower" as const,
+		currentTowerLevel: 2,
+		requiredEnergy: 9000
+	};
+	const maximum = {
+		...validUpgrade,
+		currentTowerLevel: 3,
+		affordable: false
+	};
+	const service = {
+		...validUpgrade,
+		requestedTowerAction: "maintenance" as const,
+		maintenanceAvailable: true,
+		requiredEnergy: 1200
+	};
+	const noService = {
+		...service,
+		maintenanceAvailable: false
+	};
+
+	return [
+		{ id: "place", label: "Valid placement", candidate: validPlace },
+		{ id: "resource", label: "Unaffordable", candidate: unaffordable },
+		{ id: "occupied", label: "Occupied cell", candidate: occupied },
+		{ id: "protected", label: "Protected/core cell", candidate: protectedCell },
+		{ id: "terrain", label: "Invalid terrain", candidate: invalidTerrain },
+		{ id: "camera", label: "Camera gesture owns input", candidate: cameraOwned },
+		{ id: "stale", label: "Stale/disposed target", candidate: stale },
+		{ id: "upgrade", label: "Valid upgrade", candidate: validUpgrade },
+		{ id: "maximum", label: "Maximum tower state", candidate: maximum },
+		{ id: "service", label: "Maintenance available", candidate: service },
+		{ id: "no-service", label: "No service needed", candidate: noService }
+	];
+}
+
+function glyph(outcome: DirectManipulationOutcome): string {
+	if (outcome.accepted && outcome.action === "place") return "+";
+	if (outcome.accepted && outcome.action === "upgrade") return "↑";
+	if (outcome.accepted && outcome.action === "maintenance") return "↻";
+	if (outcome.rejectionReason === "unaffordable") return "$";
+	if (outcome.rejectionReason === "occupied") return "■";
+	if (outcome.rejectionReason === "protected") return "×";
+	if (outcome.rejectionReason === "invalid-terrain") return "∿";
+	if (outcome.rejectionReason === "maximum-state") return "III";
+	if (outcome.rejectionReason === "no-service-needed") return "=";
+	if (outcome.rejectionReason === "camera-owned") return "↔";
+	if (outcome.rejectionReason === "stale-target") return "…";
+	return "?";
+}
+
+function card(scenario: Scenario): string {
+	const outcome = classifyDirectManipulation(scenario.candidate);
+	const status = outcome.accepted ? "accepted" : "rejected";
+	const reason = outcome.rejectionReason;
+	const resultLevel =
+		outcome.resultingTowerLevel === null ? "—" : String(outcome.resultingTowerLevel);
+	return `
+		<article class="dm-card dm-card--${outcome.cueFamily}"
+			data-scenario="${scenario.id}"
+			data-status="${status}"
+			data-action="${outcome.action}"
+			data-reason="${reason}"
+			data-cue="${outcome.cueFamily}"
+			aria-label="${scenario.label}: ${status}${reason === "none" ? "" : `, ${reason}`}"
+		>
+			<div class="dm-footprint"><span aria-hidden="true">${glyph(outcome)}</span></div>
+			<div class="dm-copy">
+				<strong>${scenario.label}</strong>
+				<small>${outcome.accepted ? `${outcome.action} accepted` : reason.replace(/-/g, " ")}</small>
+			</div>
+			<dl>
+				<div><dt>energy</dt><dd>${outcome.requiredEnergy}</dd></div>
+				<div><dt>result tier</dt><dd>${resultLevel}</dd></div>
+				<div><dt>residue</dt><dd>${outcome.residue.replace(/-/g, " ")}</dd></div>
+			</dl>
+		</article>`;
+}
+
+const meta = {
+	title: "Foundations/Interaction/Direct Manipulation",
+	tags: ["test", "visual"],
+	render: () => {
+		const matrix = scenarios();
+		const shell = createLabShell(
+			"Foundations / interaction",
+			"Direct-manipulation feedforward and rejection",
+			"The gameplay layer classifies authoritative pick, occupancy, terrain, economy and gesture facts into one expected action or rejection. The visual matrix intentionally uses glyph, border/pattern, wording and geometry together so color or sound is never the only explanation."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.dm-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:11px; }
+				.dm-card { min-height:172px; padding:12px; border:2px solid rgba(244,237,247,.2); background:rgba(10,3,17,.42); display:grid; grid-template-columns:54px 1fr; grid-template-rows:auto 1fr; gap:10px; }
+				.dm-footprint { width:48px; height:48px; display:grid; place-items:center; border:2px solid currentColor; font-weight:700; font-size:17px; }
+				.dm-copy { display:grid; align-content:center; gap:4px; }
+				.dm-copy small { opacity:.62; text-transform:uppercase; letter-spacing:.06em; font-size:9px; }
+				.dm-card dl { grid-column:1 / -1; display:grid; grid-template-columns:repeat(3,1fr); gap:6px; margin:0; }
+				.dm-card dl div { border-top:1px solid rgba(244,237,247,.09); padding-top:6px; min-width:0; }
+				.dm-card dt { opacity:.45; font-size:9px; text-transform:uppercase; }
+				.dm-card dd { margin:3px 0 0; font-size:10px; overflow-wrap:anywhere; }
+				.dm-card--commit { border-style:solid; }
+				.dm-card--resource { border-style:dashed; background-image:repeating-linear-gradient(45deg,transparent,transparent 8px,rgba(244,237,247,.035) 8px,rgba(244,237,247,.035) 10px); }
+				.dm-card--occupancy { border-style:double; }
+				.dm-card--protected { outline:2px solid rgba(244,237,247,.18); outline-offset:-7px; }
+				.dm-card--terrain { border-style:dotted; transform:skewX(-1deg); }
+				.dm-card--maximum .dm-footprint { border-width:4px; }
+				.dm-card--service .dm-footprint { border-radius:50%; }
+				.dm-card--gesture { border-left-width:8px; }
+				.dm-card--stale { opacity:.58; }
+				.dm-card--unsupported { border-style:dotted; opacity:.65; }
+				.dm-note { margin-top:13px; padding:11px; border:1px solid rgba(244,237,247,.1); font-size:10px; line-height:1.5; opacity:.67; }
+			</style>
+			<div class="dm-grid">${matrix.map(card).join("")}</div>
+			<div class="dm-note">Affordability is supplied as a fact. This fixture does not choose the legacy strict-&gt; rule or the later #109 exact-cost correction. Likewise, camera arbitration and occupancy remain caller-owned; this seam only prevents their outcomes from collapsing into an unexplained tap.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OutcomeMatrix: Story = {
+	play: async ({ canvasElement }) => {
+		const cards = Array.from(
+			canvasElement.querySelectorAll<HTMLElement>("[data-scenario]")
+		);
+		await expect(cards.length).toBe(11);
+
+		const expectedReasons = [
+			"unaffordable",
+			"occupied",
+			"protected",
+			"invalid-terrain",
+			"camera-owned",
+			"stale-target",
+			"maximum-state",
+			"no-service-needed"
+		];
+		for (let index = 0; index < expectedReasons.length; index += 1) {
+			const reason = expectedReasons[index];
+			const match = cards.find(cardElement => cardElement.dataset.reason === reason);
+			await expect(match).not.toBeUndefined();
+		}
+
+		const accepted = cards.filter(cardElement => cardElement.dataset.status === "accepted");
+		await expect(accepted.length).toBe(3);
+		for (let index = 0; index < accepted.length; index += 1) {
+			await expect(accepted[index].dataset.reason).toBe("none");
+		}
+
+		const maximum = cards.find(cardElement => cardElement.dataset.scenario === "maximum");
+		await expect(maximum).not.toBeUndefined();
+		if (maximum) {
+			await expect(maximum.dataset.reason).toBe("maximum-state");
+			await expect(maximum.dataset.cue).toBe("maximum");
+		}
+	}
+};

--- a/src/js/gameplay/directManipulation.ts
+++ b/src/js/gameplay/directManipulation.ts
@@ -1,0 +1,234 @@
+export type DirectManipulationTargetKind =
+	| "ground"
+	| "tower"
+	| "other"
+	| "none";
+
+export type DirectManipulationGestureOwner = "world" | "camera" | "none";
+
+export type TowerDirectAction = "upgrade" | "maintenance";
+
+export type DirectManipulationAction =
+	| "place"
+	| "upgrade"
+	| "maintenance"
+	| "none";
+
+export type DirectManipulationRejectionReason =
+	| "none"
+	| "unaffordable"
+	| "occupied"
+	| "protected"
+	| "invalid-terrain"
+	| "maximum-state"
+	| "no-service-needed"
+	| "camera-owned"
+	| "stale-target"
+	| "unsupported-target";
+
+export type DirectManipulationCueFamily =
+	| "commit"
+	| "resource"
+	| "occupancy"
+	| "protected"
+	| "terrain"
+	| "maximum"
+	| "service"
+	| "gesture"
+	| "stale"
+	| "unsupported";
+
+export type DirectManipulationResidue =
+	| "new-tower"
+	| "higher-tier"
+	| "serviced"
+	| "unchanged";
+
+export interface DirectManipulationCandidate {
+	targetKind: DirectManipulationTargetKind;
+	gestureOwner: DirectManipulationGestureOwner;
+	targetStale: boolean;
+	terrainValid: boolean;
+	occupied: boolean;
+	protected: boolean;
+	/** Caller-owned economy verdict. This module does not encode `>` vs `>=`. */
+	affordable: boolean;
+	requiredEnergy: number;
+	currentTowerLevel: number | null;
+	maximumTowerLevel: number;
+	requestedTowerAction: TowerDirectAction;
+	maintenanceAvailable: boolean;
+}
+
+export interface DirectManipulationOutcome {
+	action: DirectManipulationAction;
+	accepted: boolean;
+	rejectionReason: DirectManipulationRejectionReason;
+	cueFamily: DirectManipulationCueFamily;
+	requiredEnergy: number;
+	currentTowerLevel: number | null;
+	resultingTowerLevel: number | null;
+	residue: DirectManipulationResidue;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function nonNegative(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function normalizedLevel(value: number | null): number | null {
+	if (value === null) return null;
+	return Math.max(1, Math.floor(finite(value, 1)));
+}
+
+function reject(
+	reason: DirectManipulationRejectionReason,
+	cueFamily: DirectManipulationCueFamily,
+	candidate: DirectManipulationCandidate,
+	action: DirectManipulationAction = "none"
+): DirectManipulationOutcome {
+	const currentTowerLevel = normalizedLevel(candidate.currentTowerLevel);
+	return {
+		action,
+		accepted: false,
+		rejectionReason: reason,
+		cueFamily,
+		requiredEnergy: nonNegative(candidate.requiredEnergy),
+		currentTowerLevel,
+		resultingTowerLevel: currentTowerLevel,
+		residue: "unchanged"
+	};
+}
+
+/**
+ * Classify a direct-world manipulation attempt before presentation or mutation.
+ *
+ * The caller remains authoritative for:
+ * - pointer/pick resolution;
+ * - grid/topology occupancy;
+ * - protected/core-cell policy;
+ * - terrain validity;
+ * - economy affordability semantics;
+ * - whether maintenance is currently meaningful.
+ *
+ * This contract only makes those facts legible as one deterministic action or
+ * rejection reason. It intentionally does not reproduce the legacy strict-`>`
+ * affordability rule tracked by #109.
+ */
+export function classifyDirectManipulation(
+	candidate: DirectManipulationCandidate
+): DirectManipulationOutcome {
+	if (candidate.gestureOwner === "camera") {
+		return reject("camera-owned", "gesture", candidate);
+	}
+
+	if (candidate.targetStale) {
+		return reject("stale-target", "stale", candidate);
+	}
+
+	if (candidate.targetKind === "ground") {
+		if (!candidate.terrainValid) {
+			return reject("invalid-terrain", "terrain", candidate, "place");
+		}
+		if (candidate.protected) {
+			return reject("protected", "protected", candidate, "place");
+		}
+		if (candidate.occupied) {
+			return reject("occupied", "occupancy", candidate, "place");
+		}
+		if (!candidate.affordable) {
+			return reject("unaffordable", "resource", candidate, "place");
+		}
+		return {
+			action: "place",
+			accepted: true,
+			rejectionReason: "none",
+			cueFamily: "commit",
+			requiredEnergy: nonNegative(candidate.requiredEnergy),
+			currentTowerLevel: null,
+			resultingTowerLevel: 1,
+			residue: "new-tower"
+		};
+	}
+
+	if (candidate.targetKind === "tower") {
+		const currentTowerLevel = normalizedLevel(candidate.currentTowerLevel);
+		if (currentTowerLevel === null) {
+			return reject("stale-target", "stale", candidate);
+		}
+
+		if (candidate.requestedTowerAction === "maintenance") {
+			if (!candidate.maintenanceAvailable) {
+				return reject(
+					"no-service-needed",
+					"service",
+					candidate,
+					"maintenance"
+				);
+			}
+			if (!candidate.affordable) {
+				return reject(
+					"unaffordable",
+					"resource",
+					candidate,
+					"maintenance"
+				);
+			}
+			return {
+				action: "maintenance",
+				accepted: true,
+				rejectionReason: "none",
+				cueFamily: "commit",
+				requiredEnergy: nonNegative(candidate.requiredEnergy),
+				currentTowerLevel,
+				resultingTowerLevel: currentTowerLevel,
+				residue: "serviced"
+			};
+		}
+
+		const maximumTowerLevel = Math.max(
+			1,
+			Math.floor(finite(candidate.maximumTowerLevel, 1))
+		);
+		if (currentTowerLevel >= maximumTowerLevel) {
+			return reject(
+				"maximum-state",
+				"maximum",
+				candidate,
+				"upgrade"
+			);
+		}
+		if (!candidate.affordable) {
+			return reject(
+				"unaffordable",
+				"resource",
+				candidate,
+				"upgrade"
+			);
+		}
+		return {
+			action: "upgrade",
+			accepted: true,
+			rejectionReason: "none",
+			cueFamily: "commit",
+			requiredEnergy: nonNegative(candidate.requiredEnergy),
+			currentTowerLevel,
+			resultingTowerLevel: currentTowerLevel + 1,
+			residue: "higher-tier"
+		};
+	}
+
+	return reject("unsupported-target", "unsupported", candidate);
+}
+
+export function directManipulationIsRejected(
+	outcome: DirectManipulationOutcome
+): boolean {
+	return !outcome.accepted && outcome.rejectionReason !== "none";
+}


### PR DESCRIPTION
Refs #108, #103
Related: #30, #33, #95, #109

## Purpose

Operationalize the defensive direct-manipulation findings without changing the legacy placement/upgrade runtime yet.

Current `master` shows an important asymmetry:

- unaffordable placement/upgrade already produces some sound/indicator/currency response;
- occupied/protected placement collapses into no mutation with no semantic rejection result;
- non-ground/non-tower taps are simply ignored;
- max-tier upgrade currently reconstructs T3;
- affordability still uses the legacy strict-`>` rule that #95 must characterize before #109 intentionally changes it.

This PR adds a pure classifier so presentation can eventually explain authoritative outcomes without moving ownership for picking, occupancy, economy, gesture arbitration, or tower mutation.

## `src/js/gameplay/directManipulation.ts`

Adds an engine-free direct-world interaction contract.

Caller-owned facts:

- target kind (`ground / tower / other / none`);
- whether camera or world action won gesture arbitration;
- stale/disposed target state;
- terrain validity;
- occupancy;
- protected/core status;
- **affordability verdict supplied by the economy authority**;
- required energy for feedforward;
- current/max tower level;
- upgrade vs maintenance intent;
- whether maintenance is meaningful.

The classifier returns exactly one:

- accepted placement;
- accepted upgrade;
- accepted maintenance;
- unaffordable;
- occupied;
- protected;
- invalid terrain;
- maximum semantic state;
- no service needed;
- camera-owned gesture;
- stale target;
- unsupported target.

Each outcome also carries:

- semantic action;
- accepted/rejected state;
- cue family;
- current/resulting tower level;
- required energy;
- durable residue (`new-tower / higher-tier / serviced / unchanged`).

### Economy boundary

The module **does not calculate affordability**. It receives `affordable: boolean` from the caller. Therefore it does not encode the current strict `>` comparison and does not pre-empt #109's eventual exact-cost correction.

### Rejection precedence

The contract favors the most causally useful explanation. For example, an already-max-tier tower reports `maximum-state` even if the supplied affordability fact is false; the player should not be told that more energy would make an impossible upgrade valid.

## Storybook playground

Adds `Foundations/Interaction/Direct Manipulation`.

The matrix renders eleven representative cases:

1. valid placement;
2. unaffordable placement;
3. occupied cell;
4. protected/core cell;
5. invalid terrain;
6. camera gesture ownership;
7. stale/disposed target;
8. valid upgrade;
9. maximum tower state;
10. maintenance available;
11. no service needed.

Feedback is deliberately redundant:

- glyph;
- border/pattern/shape treatment;
- explicit wording;
- action/reason/residue facts.

Color and sound are therefore not required to distinguish critical states.

The Storybook assertion pins all major rejection classes, exactly three accepted actions in the default matrix, and max-tier precedence.

No RAF, timer, Babylon scene, Worker, AudioContext, gameplay mutation or global listener is created.

## Scope

Relative to current `master` `206dc028500f10614504ec0a07b381e5320204ca`:

- 2 commits ahead / 0 behind;
- 2 added files;
- no dependency/package changes;
- no live `pick.ts` / `upgradeTower.ts` changes;
- no affordability-semantic change;
- no camera/input ownership change;
- no balance constants.

## Validation

Post-freeze draft. Later root + Storybook checks:

```sh
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Also add focused root fixtures for every rejection reason, priority collisions (protected+occupied, maximum+unaffordable, stale+otherwise-valid), malformed numeric input, and maintenance outcomes.

## Follow-up

After #95 captures current behavior and this contract is certified:

1. adapt placement/upgrade preview/presentation to call the classifier before mutation;
2. keep #109's affordability policy as a separate intentional behavior change;
3. give each rejection cue a world-grounded accessible presentation;
4. record attempts/rejections/camera conflicts for #108's first-build and attribution gates;
5. integrate certified conserved-energy transfer visuals for construction/recovery rather than inventing a UI-only economy explanation.

This PR is post-freeze and must not change #92's active exact-SHA campaign.