### PR TITLE
Add passive direct-manipulation comprehension metrics

### DIFF
--- a/experiments/storybook/src/Foundations/Interaction/DirectManipulationObservation.stories.ts
+++ b/experiments/storybook/src/Foundations/Interaction/DirectManipulationObservation.stories.ts
@@ -1,0 +1,222 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	classifyDirectManipulation,
+	type DirectManipulationCandidate
+} from "@defend/gameplay/directManipulation";
+import {
+	createDirectManipulationObservationState,
+	recordDirectManipulationObservation,
+	summarizeDirectManipulationObservations,
+	type DirectManipulationInterventionKind,
+	type DirectManipulationObservation,
+	type DirectManipulationObservationSummary
+} from "@defend/gameplay/directManipulationObservation";
+import { createLabShell } from "../../labTheme";
+
+function candidate(
+	overrides: Partial<DirectManipulationCandidate> = {}
+): DirectManipulationCandidate {
+	return {
+		targetKind: "ground",
+		gestureOwner: "world",
+		targetStale: false,
+		terrainValid: true,
+		occupied: false,
+		protected: false,
+		affordable: true,
+		requiredEnergy: 3000,
+		currentTowerLevel: null,
+		maximumTowerLevel: 3,
+		requestedTowerAction: "upgrade",
+		maintenanceAvailable: false,
+		...overrides
+	};
+}
+
+function observation(
+	atSeconds: number,
+	input: DirectManipulationCandidate,
+	interventionKind: DirectManipulationInterventionKind,
+	cellKey: string | null,
+	roleKey: string | null,
+	tacticalContextKey: string
+): DirectManipulationObservation {
+	return {
+		atSeconds,
+		cellKey,
+		roleKey,
+		tacticalContextKey,
+		interventionKind,
+		outcome: classifyDirectManipulation(input)
+	};
+}
+
+function summarizeSession(
+	events: DirectManipulationObservation[]
+): DirectManipulationObservationSummary {
+	let state = createDirectManipulationObservationState(0);
+	for (let index = 0; index < events.length; index += 1) {
+		state = recordDirectManipulationObservation(state, events[index]);
+	}
+	return summarizeDirectManipulationObservations(state);
+}
+
+function legibleSession(): DirectManipulationObservationSummary {
+	return summarizeSession([
+		observation(
+			1.2,
+			candidate({ occupied: true }),
+			"new-build",
+			"cell-a",
+			"barrier",
+			"opening"
+		),
+		observation(
+			2,
+			candidate({ gestureOwner: "camera" }),
+			"other",
+			null,
+			null,
+			"opening"
+		),
+		observation(4.2, candidate(), "new-build", "cell-b", "barrier", "opening"),
+		observation(26, candidate(), "replacement", "cell-b", "barrier", "opening"),
+		observation(
+			44,
+			candidate(),
+			"replacement",
+			"cell-b",
+			"barrier",
+			"mixed-heavy-threat"
+		),
+		observation(
+			48,
+			candidate({
+				targetKind: "tower",
+				currentTowerLevel: 1,
+				requiredEnergy: 6000
+			}),
+			"upgrade",
+			"cell-b",
+			"interceptor",
+			"mixed-heavy-threat"
+		)
+	]);
+}
+
+function opaqueSession(): DirectManipulationObservationSummary {
+	return summarizeSession([
+		observation(1, candidate({ occupied: true }), "new-build", "cell-a", "barrier", "opening"),
+		observation(3, candidate({ protected: true }), "new-build", "core", "barrier", "opening"),
+		observation(5, candidate({ affordable: false }), "new-build", "cell-b", "barrier", "opening"),
+		observation(8, candidate({ gestureOwner: "camera" }), "other", null, null, "opening"),
+		observation(13, candidate(), "new-build", "cell-c", "barrier", "opening"),
+		observation(30, candidate(), "replacement", "cell-c", "barrier", "opening"),
+		observation(46, candidate(), "replacement", "cell-c", "barrier", "opening"),
+		observation(62, candidate(), "replacement", "cell-c", "barrier", "opening")
+	]);
+}
+
+function fixed(value: number | null, digits = 1): string {
+	if (value === null || value !== value || value === Infinity || value === -Infinity) {
+		return "—";
+	}
+	return value.toFixed(digits);
+}
+
+function sessionCard(
+	id: string,
+	label: string,
+	summary: DirectManipulationObservationSummary
+): string {
+	return `
+		<article class="obs-card" data-session="${id}"
+			data-first-build="${summary.timeToFirstBuildSeconds ?? -1}"
+			data-rejections-before-build="${summary.rejectedBeforeFirstBuild}"
+			data-camera-conflicts="${summary.cameraConflicts}"
+			data-repeated="${summary.repeatedSameContextReplacements}"
+			data-repetition-rate="${summary.repetitionRate}">
+			<header><small>observation fixture</small><strong>${label}</strong></header>
+			<div class="obs-metrics">
+				<div><span>attempts</span><strong>${summary.attempts}</strong></div>
+				<div><span>accepted</span><strong>${summary.acceptedActions}</strong></div>
+				<div><span>rejected</span><strong>${summary.rejectedActions}</strong></div>
+				<div><span>first build</span><strong>${fixed(summary.timeToFirstBuildSeconds)} s</strong></div>
+				<div><span>rejects before build</span><strong>${summary.rejectedBeforeFirstBuild}</strong></div>
+				<div><span>camera conflicts</span><strong>${summary.cameraConflicts}</strong></div>
+				<div><span>same-context replacements</span><strong>${summary.repeatedSameContextReplacements} / ${summary.acceptedReplacements}</strong></div>
+				<div><span>replacement repetition</span><strong>${fixed(summary.repetitionRate * 100, 0)}%</strong></div>
+			</div>
+			<footer>
+				Rejections: occupied ${summary.rejectionCounts.occupied} · protected ${summary.rejectionCounts.protected} · resource ${summary.rejectionCounts.unaffordable} · camera ${summary.rejectionCounts.cameraOwned}
+			</footer>
+		</article>`;
+}
+
+const meta = {
+	title: "Foundations/Interaction/Direct Manipulation Observation",
+	tags: ["test", "visual"],
+	render: () => {
+		const legible = legibleSession();
+		const opaque = opaqueSession();
+		const shell = createLabShell(
+			"Foundations / interaction",
+			"First-build and maintenance observation",
+			"Passive deterministic metrics for #108. The observer records already-resolved interaction outcomes plus coarse caller-owned cell/role/context identities. It never changes affordability, placement, camera arbitration, combat, or tower lifecycle."
+		);
+		shell.frame.innerHTML = `
+			<style>
+				.obs-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:14px; }
+				.obs-card { padding:14px; border:1px solid rgba(228,185,128,.2); background:rgba(10,3,17,.42); }
+				.obs-card header { display:grid; gap:3px; margin-bottom:12px; }
+				.obs-card header small { opacity:.45; text-transform:uppercase; letter-spacing:.08em; font-size:9px; }
+				.obs-metrics { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+				.obs-metrics div { border-top:1px solid rgba(244,237,247,.08); padding-top:7px; }
+				.obs-metrics span { display:block; font-size:9px; opacity:.48; text-transform:uppercase; }
+				.obs-metrics strong { display:block; margin-top:3px; font-size:13px; }
+				.obs-card footer { margin-top:12px; font-size:10px; opacity:.58; line-height:1.5; }
+				.obs-note { margin-top:13px; border:1px dashed rgba(244,237,247,.16); padding:11px; font-size:10px; line-height:1.55; opacity:.68; }
+			</style>
+			<div class="obs-grid">
+				${sessionCard("legible", "Legible first contact", legible)}
+				${sessionCard("opaque", "High-friction / rote maintenance", opaque)}
+			</div>
+			<div class="obs-note">The comparison is illustrative, not a production target. It demonstrates the evidence shape needed for first-build discoverability and the “input tax” maintenance gate: repeated replacement only counts as rote when cell, role, and caller-defined tactical context remain the same.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ComprehensionMetrics: Story = {
+	play: async ({ canvasElement }) => {
+		const legible = canvasElement.querySelector<HTMLElement>(
+			'[data-session="legible"]'
+		);
+		const opaque = canvasElement.querySelector<HTMLElement>(
+			'[data-session="opaque"]'
+		);
+		await expect(legible).not.toBeNull();
+		await expect(opaque).not.toBeNull();
+		if (!legible || !opaque) return;
+
+		await expect(Number(legible.dataset.firstBuild)).toBeCloseTo(4.2, 8);
+		await expect(Number(legible.dataset.rejectionsBeforeBuild)).toBe(2);
+		await expect(Number(legible.dataset.cameraConflicts)).toBe(1);
+		await expect(Number(legible.dataset.repeated)).toBe(1);
+		await expect(Number(legible.dataset.repetitionRate)).toBeCloseTo(0.5, 8);
+
+		await expect(Number(opaque.dataset.firstBuild)).toBeGreaterThan(
+			Number(legible.dataset.firstBuild)
+		);
+		await expect(Number(opaque.dataset.rejectionsBeforeBuild)).toBeGreaterThan(
+			Number(legible.dataset.rejectionsBeforeBuild)
+		);
+		await expect(Number(opaque.dataset.repetitionRate)).toBeGreaterThan(
+			Number(legible.dataset.repetitionRate)
+		);
+	}
+};

--- a/src/js/gameplay/directManipulationObservation.ts
+++ b/src/js/gameplay/directManipulationObservation.ts
@@ -207,7 +207,7 @@ export function recordDirectManipulationObservation(
 		rejectionCounts: copyRejectionCounts(state.rejectionCounts),
 		lastAcceptedContexts: copyContexts(state.lastAcceptedContexts)
 	};
-	const atSeconds = Math.max(next.startedAtSeconds, nonNegative(observation.atSeconds));
+	const atSeconds = next.lastObservedAtSeconds;
 
 	if (!observation.outcome.accepted) {
 		next.rejectedActions += 1;

--- a/src/js/gameplay/directManipulationObservation.ts
+++ b/src/js/gameplay/directManipulationObservation.ts
@@ -1,0 +1,308 @@
+import type {
+	DirectManipulationOutcome,
+	DirectManipulationRejectionReason
+} from "./directManipulation";
+
+export type DirectManipulationInterventionKind =
+	| "new-build"
+	| "replacement"
+	| "upgrade"
+	| "maintenance"
+	| "other";
+
+export interface DirectManipulationObservation {
+	/** Monotonic session-relative time. */
+	atSeconds: number;
+	/** Stable topology/cell identity when the attempt resolves to one. */
+	cellKey: string | null;
+	/** Stable semantic role, e.g. barrier/interceptor/siege. */
+	roleKey: string | null;
+	/** Caller-owned tactical-context fingerprint; no gameplay authority implied. */
+	tacticalContextKey: string;
+	interventionKind: DirectManipulationInterventionKind;
+	outcome: DirectManipulationOutcome;
+}
+
+export interface DirectManipulationRejectionCounts {
+	unaffordable: number;
+	occupied: number;
+	protected: number;
+	invalidTerrain: number;
+	maximumState: number;
+	noServiceNeeded: number;
+	cameraOwned: number;
+	staleTarget: number;
+	unsupportedTarget: number;
+}
+
+export interface DirectManipulationAcceptedContext {
+	cellKey: string;
+	roleKey: string;
+	tacticalContextKey: string;
+}
+
+export interface DirectManipulationObservationState {
+	startedAtSeconds: number;
+	lastObservedAtSeconds: number;
+	attempts: number;
+	acceptedActions: number;
+	rejectedActions: number;
+	cameraConflicts: number;
+	rejectedBeforeFirstBuild: number;
+	firstAcceptedAtSeconds: number | null;
+	firstBuildAtSeconds: number | null;
+	acceptedReplacements: number;
+	repeatedSameContextReplacements: number;
+	rejectionCounts: DirectManipulationRejectionCounts;
+	lastAcceptedContexts: DirectManipulationAcceptedContext[];
+}
+
+export interface DirectManipulationObservationSummary {
+	attempts: number;
+	acceptedActions: number;
+	rejectedActions: number;
+	acceptanceRate: number;
+	cameraConflicts: number;
+	rejectedBeforeFirstBuild: number;
+	timeToFirstAcceptedSeconds: number | null;
+	timeToFirstBuildSeconds: number | null;
+	acceptedReplacements: number;
+	repeatedSameContextReplacements: number;
+	repetitionRate: number;
+	rejectionCounts: DirectManipulationRejectionCounts;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function nonNegative(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function emptyRejectionCounts(): DirectManipulationRejectionCounts {
+	return {
+		unaffordable: 0,
+		occupied: 0,
+		protected: 0,
+		invalidTerrain: 0,
+		maximumState: 0,
+		noServiceNeeded: 0,
+		cameraOwned: 0,
+		staleTarget: 0,
+		unsupportedTarget: 0
+	};
+}
+
+function copyRejectionCounts(
+	counts: DirectManipulationRejectionCounts
+): DirectManipulationRejectionCounts {
+	return {
+		unaffordable: counts.unaffordable,
+		occupied: counts.occupied,
+		protected: counts.protected,
+		invalidTerrain: counts.invalidTerrain,
+		maximumState: counts.maximumState,
+		noServiceNeeded: counts.noServiceNeeded,
+		cameraOwned: counts.cameraOwned,
+		staleTarget: counts.staleTarget,
+		unsupportedTarget: counts.unsupportedTarget
+	};
+}
+
+function copyContexts(
+	contexts: DirectManipulationAcceptedContext[]
+): DirectManipulationAcceptedContext[] {
+	return contexts.map(context => ({
+		cellKey: context.cellKey,
+		roleKey: context.roleKey,
+		tacticalContextKey: context.tacticalContextKey
+	}));
+}
+
+export function createDirectManipulationObservationState(
+	startedAtSeconds = 0
+): DirectManipulationObservationState {
+	const start = nonNegative(startedAtSeconds);
+	return {
+		startedAtSeconds: start,
+		lastObservedAtSeconds: start,
+		attempts: 0,
+		acceptedActions: 0,
+		rejectedActions: 0,
+		cameraConflicts: 0,
+		rejectedBeforeFirstBuild: 0,
+		firstAcceptedAtSeconds: null,
+		firstBuildAtSeconds: null,
+		acceptedReplacements: 0,
+		repeatedSameContextReplacements: 0,
+		rejectionCounts: emptyRejectionCounts(),
+		lastAcceptedContexts: []
+	};
+}
+
+function incrementReason(
+	counts: DirectManipulationRejectionCounts,
+	reason: DirectManipulationRejectionReason
+): void {
+	if (reason === "unaffordable") counts.unaffordable += 1;
+	else if (reason === "occupied") counts.occupied += 1;
+	else if (reason === "protected") counts.protected += 1;
+	else if (reason === "invalid-terrain") counts.invalidTerrain += 1;
+	else if (reason === "maximum-state") counts.maximumState += 1;
+	else if (reason === "no-service-needed") counts.noServiceNeeded += 1;
+	else if (reason === "camera-owned") counts.cameraOwned += 1;
+	else if (reason === "stale-target") counts.staleTarget += 1;
+	else if (reason === "unsupported-target") counts.unsupportedTarget += 1;
+}
+
+function contextIndex(
+	contexts: DirectManipulationAcceptedContext[],
+	cellKey: string,
+	roleKey: string
+): number {
+	for (let index = 0; index < contexts.length; index += 1) {
+		if (
+			contexts[index].cellKey === cellKey &&
+			contexts[index].roleKey === roleKey
+		) {
+			return index;
+		}
+	}
+	return -1;
+}
+
+/**
+ * Append one observational event without changing gameplay state.
+ *
+ * `tacticalContextKey` is deliberately caller-owned. It should represent only
+ * the coarse facts needed to decide whether a same-cell/same-role replacement
+ * occurred under materially unchanged circumstances. The observer never reads
+ * or mutates combat simulation state directly.
+ */
+export function recordDirectManipulationObservation(
+	state: DirectManipulationObservationState,
+	observation: DirectManipulationObservation
+): DirectManipulationObservationState {
+	const next: DirectManipulationObservationState = {
+		startedAtSeconds: nonNegative(state.startedAtSeconds),
+		lastObservedAtSeconds: Math.max(
+			nonNegative(state.lastObservedAtSeconds),
+			nonNegative(observation.atSeconds)
+		),
+		attempts: nonNegative(state.attempts) + 1,
+		acceptedActions: nonNegative(state.acceptedActions),
+		rejectedActions: nonNegative(state.rejectedActions),
+		cameraConflicts: nonNegative(state.cameraConflicts),
+		rejectedBeforeFirstBuild: nonNegative(state.rejectedBeforeFirstBuild),
+		firstAcceptedAtSeconds: state.firstAcceptedAtSeconds,
+		firstBuildAtSeconds: state.firstBuildAtSeconds,
+		acceptedReplacements: nonNegative(state.acceptedReplacements),
+		repeatedSameContextReplacements: nonNegative(
+			state.repeatedSameContextReplacements
+		),
+		rejectionCounts: copyRejectionCounts(state.rejectionCounts),
+		lastAcceptedContexts: copyContexts(state.lastAcceptedContexts)
+	};
+	const atSeconds = Math.max(next.startedAtSeconds, nonNegative(observation.atSeconds));
+
+	if (!observation.outcome.accepted) {
+		next.rejectedActions += 1;
+		incrementReason(next.rejectionCounts, observation.outcome.rejectionReason);
+		if (observation.outcome.rejectionReason === "camera-owned") {
+			next.cameraConflicts += 1;
+		}
+		if (next.firstBuildAtSeconds === null) {
+			next.rejectedBeforeFirstBuild += 1;
+		}
+		return next;
+	}
+
+	next.acceptedActions += 1;
+	if (next.firstAcceptedAtSeconds === null) {
+		next.firstAcceptedAtSeconds = atSeconds;
+	}
+	if (
+		next.firstBuildAtSeconds === null &&
+		observation.interventionKind === "new-build" &&
+		observation.outcome.action === "place"
+	) {
+		next.firstBuildAtSeconds = atSeconds;
+	}
+
+	if (
+		observation.cellKey !== null &&
+		observation.roleKey !== null
+	) {
+		const index = contextIndex(
+			next.lastAcceptedContexts,
+			observation.cellKey,
+			observation.roleKey
+		);
+		if (observation.interventionKind === "replacement") {
+			next.acceptedReplacements += 1;
+			if (
+				index >= 0 &&
+				next.lastAcceptedContexts[index].tacticalContextKey ===
+					observation.tacticalContextKey
+			) {
+				next.repeatedSameContextReplacements += 1;
+			}
+		}
+
+		const context = {
+			cellKey: observation.cellKey,
+			roleKey: observation.roleKey,
+			tacticalContextKey: observation.tacticalContextKey
+		};
+		if (index >= 0) next.lastAcceptedContexts[index] = context;
+		else next.lastAcceptedContexts.push(context);
+	}
+
+	return next;
+}
+
+export function summarizeDirectManipulationObservations(
+	state: DirectManipulationObservationState
+): DirectManipulationObservationSummary {
+	const attempts = nonNegative(state.attempts);
+	const acceptedActions = nonNegative(state.acceptedActions);
+	const acceptedReplacements = nonNegative(state.acceptedReplacements);
+	const repeatedSameContextReplacements = nonNegative(
+		state.repeatedSameContextReplacements
+	);
+	return {
+		attempts,
+		acceptedActions,
+		rejectedActions: nonNegative(state.rejectedActions),
+		acceptanceRate: attempts <= 0 ? 0 : acceptedActions / attempts,
+		cameraConflicts: nonNegative(state.cameraConflicts),
+		rejectedBeforeFirstBuild: nonNegative(state.rejectedBeforeFirstBuild),
+		timeToFirstAcceptedSeconds:
+			state.firstAcceptedAtSeconds === null
+				? null
+				: Math.max(
+					0,
+					finite(state.firstAcceptedAtSeconds) -
+						nonNegative(state.startedAtSeconds)
+				),
+		timeToFirstBuildSeconds:
+			state.firstBuildAtSeconds === null
+				? null
+				: Math.max(
+					0,
+					finite(state.firstBuildAtSeconds) -
+						nonNegative(state.startedAtSeconds)
+				),
+		acceptedReplacements,
+		repeatedSameContextReplacements,
+		repetitionRate:
+			acceptedReplacements <= 0
+				? 0
+				: repeatedSameContextReplacements / acceptedReplacements,
+		rejectionCounts: copyRejectionCounts(state.rejectionCounts)
+	};
+}


### PR DESCRIPTION
Refs #108, #103
Parent: #115
Related: #92, #95, #109

## Purpose

Add the passive measurement layer required by #108's first-build/rejection-attribution and maintenance-repetition gates without instrumenting or changing the production runtime yet.

This PR is stacked on #115 so it consumes the already-classified direct-manipulation outcome rather than rediscovering placement, camera, occupancy or economy semantics.

## `src/js/gameplay/directManipulationObservation.ts`

Adds an engine-free append-only observation contract.

Each observation supplies:

- session-relative timestamp;
- optional cell identity;
- optional semantic role identity;
- caller-owned coarse tactical-context fingerprint;
- intervention kind (`new-build / replacement / upgrade / maintenance / other`);
- the authoritative #115 classified outcome.

The observer derives only evidence:

- total attempts;
- accepted/rejected actions;
- acceptance rate;
- rejection counts by semantic reason;
- camera/placement conflicts;
- rejected attempts before first successful build;
- time to first accepted action;
- time to first successful build;
- accepted replacement count;
- same-cell/same-role replacements made under unchanged tactical context;
- repetition rate for those replacements.

### Tactical-context boundary

The observer never reads gameplay state. `tacticalContextKey` is supplied by the caller as a deliberately coarse fingerprint describing whether the tactical situation materially changed.

A replacement is counted as rote/input-tax only when:

- it is an accepted `replacement` intervention;
- the same cell and role had a prior accepted action;
- the caller's tactical-context fingerprint is unchanged.

If enemy mix, topology, reserve pressure, breach state, or another meaningful factor changes and the caller changes the fingerprint, the replacement is not counted as rote merely because it happens on the same cell.

### Timing robustness

Session time is monotonic inside the observer. An out-of-order observation cannot move first-success timing backward.

## Storybook playground

Adds `Foundations/Interaction/Direct Manipulation Observation`.

It compares two deterministic illustrative sessions:

### Legible first contact
- one occupied-cell rejection;
- one camera arbitration conflict;
- successful first build at 4.2 s;
- two later replacements, only one under unchanged context;
- later upgrade after threat context changes.

### High-friction / rote maintenance
- four rejected attempts before first build;
- first build later;
- repeated same-cell/same-role replacements under unchanged context.

The fixture does **not** assert those illustrative numbers as final UX targets. It verifies the measurement semantics: first-build timing, pre-build rejection count, camera conflict count, and same-context repetition discrimination.

No telemetry transport, persistence, RAF, timer, Babylon scene, Worker, AudioContext, global listener, gameplay mutation, or player-identifying data is introduced.

## Scope

Relative to #115 head `a61e77673b0a510807342face455917a935f450c`:

- 3 commits ahead / 0 behind;
- 2 added files;
- no production call-site changes;
- no network/analytics backend;
- no affordability change;
- no input/camera behavior change;
- no balance constants.

## Validation

Post-freeze draft. Later root + Storybook gate:

```sh
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Additional pure fixtures should cover empty sessions, no successful build, non-monotonic timestamps, all rejection reasons, replacements with missing cell/role identity, changed-context replacements, and malformed numeric state.

## Follow-up

After #95 characterization and #115 certification, a small runtime adapter can record these events locally during certification/user-study fixtures. Keep the observer downstream of authoritative gameplay outcomes; it must never become a decision or economy owner.

This is post-freeze work and must not alter #92's active exact-SHA certification campaign.