### PR TITLE
Fix tower interaction malformed-cost authorization

### DIFF
--- a/experiments/storybook/src/Arena/Interaction/TowerInvalidCost.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/TowerInvalidCost.stories.ts
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	classifyTowerInteraction,
+	towerInteractionCanAfford,
+	type TowerInteractionRequest
+} from "@defend/gameplay/towerInteraction";
+import { createLabShell } from "../../labTheme";
+
+interface CostCase {
+	id: string;
+	label: string;
+	cost: number;
+	valid: boolean;
+}
+
+const COST_CASES: CostCase[] = [
+	{ id: "negative", label: "negative", cost: -1, valid: false },
+	{ id: "nan", label: "NaN", cost: NaN, valid: false },
+	{ id: "positive-infinity", label: "+Infinity", cost: Infinity, valid: false },
+	{ id: "negative-infinity", label: "-Infinity", cost: -Infinity, valid: false },
+	{ id: "explicit-zero", label: "explicit zero", cost: 0, valid: true }
+];
+
+function request(cost: number): TowerInteractionRequest {
+	return {
+		inputOwner: "world",
+		targetKind: "ground",
+		occupied: false,
+		balance: 15000,
+		requestedCost: cost,
+		currentLevel: 0,
+		maximumLevel: 3,
+		affordabilityRule: "legacy-strict",
+		maxLevelBehavior: "legacy-rebuild"
+	};
+}
+
+const meta = {
+	title: "Arena/Interaction/Tower Invalid Cost",
+	tags: ["test", "visual"],
+	render: () => {
+		const cases = COST_CASES.map(testCase => ({
+			...testCase,
+			result: classifyTowerInteraction(request(testCase.cost))
+		}));
+		const shell = createLabShell(
+			"Arena / interaction",
+			"Malformed cost rejection",
+			"Economic authority fails closed. Negative and non-finite action costs remain finite in diagnostics but can never become free placement permission. A literal zero cost remains distinguishable as an explicit caller value."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.cost-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:10px; }
+				.cost-card { padding:13px; border:1px solid rgba(244,237,247,.12); border-radius:9px; background:rgba(8,10,18,.48); }
+				.cost-card[data-disposition="rejected"] { box-shadow:inset 3px 0 0 rgba(228,185,128,.76); }
+				.cost-card[data-disposition="allowed"] { box-shadow:inset 3px 0 0 rgba(73,215,209,.78); }
+				.cost-card h3 { margin:0 0 10px; font-size:13px; }
+				.cost-card dl { display:grid; grid-template-columns:1fr auto; gap:5px 10px; margin:0; font-size:10px; }
+				.cost-card dt { color:rgba(244,237,247,.48); }
+				.cost-card dd { margin:0; color:rgba(244,237,247,.78); }
+			</style>
+			<div class="cost-grid">
+				${cases
+					.map(
+						entry => `
+						<article class="cost-card" data-case="${entry.id}" data-valid="${entry.valid}" data-disposition="${entry.result.disposition}" data-reason="${entry.result.reason}" data-cost="${entry.result.requestedCost}" data-balance-after="${entry.result.balanceAfter}">
+							<h3>${entry.label}</h3>
+							<dl>
+								<dt>input</dt><dd>${entry.label}</dd>
+								<dt>disposition</dt><dd>${entry.result.disposition}</dd>
+								<dt>reason</dt><dd>${entry.result.reason}</dd>
+								<dt>diagnostic cost</dt><dd>${entry.result.requestedCost}</dd>
+								<dt>reserve after</dt><dd>${entry.result.balanceAfter}</dd>
+							</dl>
+						</article>`
+					)
+					.join("")}
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FailClosed: Story = {
+	play: async ({ canvasElement }) => {
+		for (let index = 0; index < COST_CASES.length; index += 1) {
+			const testCase = COST_CASES[index];
+			const card = canvasElement.querySelector<HTMLElement>(
+				`[data-case='${testCase.id}']`
+			);
+			await expect(card).not.toBeNull();
+			if (!card) continue;
+
+			const classified = classifyTowerInteraction(request(testCase.cost));
+			if (!testCase.valid) {
+				await expect(
+					towerInteractionCanAfford(15000, testCase.cost, "legacy-strict")
+				).toBe(false);
+				await expect(
+					towerInteractionCanAfford(15000, testCase.cost, "inclusive")
+				).toBe(false);
+				await expect(classified.disposition).toBe("rejected");
+				await expect(classified.reason).toBe("invalid-cost");
+				await expect(classified.balanceAfter).toBe(15000);
+				await expect(Number.isFinite(classified.requestedCost)).toBe(true);
+				await expect(Number.isFinite(classified.balanceAfter)).toBe(true);
+				await expect(card.dataset.reason).toBe("invalid-cost");
+			} else {
+				await expect(classified.disposition).toBe("allowed");
+				await expect(classified.reason).toBe("none");
+				await expect(classified.requestedCost).toBe(0);
+			}
+		}
+	}
+};

--- a/src/js/gameplay/towerInteraction.ts
+++ b/src/js/gameplay/towerInteraction.ts
@@ -40,6 +40,7 @@ export type TowerInteractionReason =
 	| "camera-gesture"
 	| "occupied"
 	| "unaffordable"
+	| "invalid-cost"
 	| "protected-core"
 	| "invalid-terrain"
 	| "outside-arena"
@@ -81,6 +82,15 @@ function nonnegative(value: number): number {
 	return Math.max(0, finite(value));
 }
 
+function isFiniteNonnegative(value: number): boolean {
+	return (
+		value === value &&
+		value !== Infinity &&
+		value !== -Infinity &&
+		value >= 0
+	);
+}
+
 function towerLevel(value: number): number {
 	return Math.max(0, Math.floor(nonnegative(value)));
 }
@@ -90,11 +100,9 @@ export function towerInteractionCanAfford(
 	cost: number,
 	rule: TowerAffordabilityRule
 ): boolean {
+	if (!isFiniteNonnegative(cost)) return false;
 	const available = nonnegative(balance);
-	const requested = nonnegative(cost);
-	return rule === "inclusive"
-		? available >= requested
-		: available > requested;
+	return rule === "inclusive" ? available >= cost : available > cost;
 }
 
 function preview(
@@ -136,6 +144,9 @@ function permitted(
 	fromLevel: number,
 	toLevel: number
 ): TowerInteractionPreview {
+	if (!isFiniteNonnegative(request.requestedCost)) {
+		return rejected(request, "invalid-cost", intent, fromLevel, toLevel);
+	}
 	if (
 		!towerInteractionCanAfford(
 			request.balance,


### PR DESCRIPTION
Refs #108, #109
Parent PR: #112

## Purpose

Close one fail-open edge found during static review of #112 without modifying the parent executor's branch or any frozen certification head.

`requestedCost` was previously normalized through the diagnostic `nonnegative()` sanitizer before affordability. Negative, NaN, or infinite costs therefore became `0`, which could make an invalid placement/upgrade/rebuild/maintenance request appear affordable as a free action.

## Change

Relative to #112 head `bb78ef4132b467c21983fd43ecd3cd619e829f8a`:

- add `invalid-cost` as an explicit interaction rejection reason;
- require an action cost to be finite and non-negative before affordability can authorize it;
- make `towerInteractionCanAfford()` fail closed for malformed costs;
- keep preview values finite/non-negative for diagnostics without converting malformed authority into permission;
- preserve literal `0` as a distinguishable explicit caller value rather than conflating it with sanitized bad input;
- add a deterministic Storybook fixture covering negative, NaN, +Infinity, -Infinity and explicit-zero costs.

Spatial/input precedence is preserved: camera-owned gestures remain ignored, and occupied/protected/invalid/outside/stale targets retain their own causal rejection rather than being overwritten by an economic validation error.

## Scope

Two-file child delta only:

- `src/js/gameplay/towerInteraction.ts`;
- `experiments/storybook/src/Arena/Interaction/TowerInvalidCost.stories.ts`.

No live Babylon pointer handlers, tower costs, balance semantics, exact-cost policy, level-3 semantics, dependencies, or frozen #95/#97/#105 heads change.

## Certification

Keep draft until post-freeze local/root + Storybook validation can confirm:

- historical TypeScript accepts the added guard;
- negative/NaN/±Infinity requested cost => rejected with `invalid-cost`, no projected charge, finite diagnostics;
- both affordability policies return false for malformed costs;
- an explicit literal zero remains a valid caller value under the selected affordability policy;
- existing #112 interaction matrix remains healthy;
- `pnpm typecheck`, `pnpm build`, and `pnpm test` pass in `experiments/storybook`.

If accepted, this child can be folded into #112 or merged after #112. It remains outside the frozen #92 campaign.