### PR TITLE
Fail closed on invalid mothership spend authority

### DIFF
--- a/experiments/storybook/src/Foundations/Physics/MothershipEnergyAuthorization.stories.ts
+++ b/experiments/storybook/src/Foundations/Physics/MothershipEnergyAuthorization.stories.ts
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	authorizeDiscreteMothershipSpend,
+	fundContinuousMothershipSpend,
+	mothershipFundingFraction
+} from "@defend/gameplay/mothershipEnergyAuthorization";
+import type {
+	MothershipEnergyLiftState,
+	MothershipLiftPhase
+} from "@defend/gameplay/mothershipEnergyLift";
+import { createLabShell } from "../../labTheme";
+
+function state(
+	reserve: number,
+	phase: MothershipLiftPhase = "stable"
+): MothershipEnergyLiftState {
+	return {
+		reserve,
+		phase,
+		altitude: 56,
+		verticalVelocity: 0,
+		elapsedSeconds: 0,
+		impactCount: 0
+	};
+}
+
+const meta = {
+	title: "Foundations/Physics/Mothership Energy Authorization",
+	tags: ["test", "visual"],
+	render: () => {
+		const healthy = state(10);
+		const hulk = state(10, "hulk");
+		const rows = [
+			{
+				id: "valid",
+				label: "valid spend",
+				discrete: authorizeDiscreteMothershipSpend(healthy, 6),
+				continuous: fundContinuousMothershipSpend(healthy, 6)
+			},
+			{
+				id: "overdraw",
+				label: "overdraw",
+				discrete: authorizeDiscreteMothershipSpend(healthy, 12),
+				continuous: fundContinuousMothershipSpend(healthy, 12)
+			},
+			{
+				id: "invalid-request",
+				label: "NaN request",
+				discrete: authorizeDiscreteMothershipSpend(healthy, NaN),
+				continuous: fundContinuousMothershipSpend(healthy, NaN)
+			},
+			{
+				id: "invalid-protected",
+				label: "invalid protected reserve",
+				discrete: authorizeDiscreteMothershipSpend(healthy, 6, Infinity),
+				continuous: fundContinuousMothershipSpend(healthy, 6, Infinity)
+			},
+			{
+				id: "hulk-zero",
+				label: "hulk / zero request",
+				discrete: authorizeDiscreteMothershipSpend(hulk, 0),
+				continuous: fundContinuousMothershipSpend(hulk, 0)
+			}
+		];
+		const shell = createLabShell(
+			"Foundations / physics",
+			"Mothership spend authorization",
+			"Physical authority fails closed when spend inputs or authoritative reserve state are malformed. A hulk exposes zero launch/propulsion authority even when requested spend is zero; an intact mothership may still represent an explicit zero-cost action without conflating it with invalid input."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.auth-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:10px; }
+				.auth-card { padding:13px; border:1px solid rgba(244,237,247,.12); border-radius:9px; background:rgba(8,10,18,.48); }
+				.auth-card[data-authorized="true"] { box-shadow:inset 3px 0 0 rgba(73,215,209,.78); }
+				.auth-card[data-authorized="false"] { box-shadow:inset 3px 0 0 rgba(228,185,128,.76); }
+				.auth-card h3 { margin:0 0 10px; font-size:13px; }
+				.auth-card dl { display:grid; grid-template-columns:1fr auto; gap:5px 10px; margin:0; font-size:10px; }
+				.auth-card dt { color:rgba(244,237,247,.48); }
+				.auth-card dd { margin:0; color:rgba(244,237,247,.78); }
+			</style>
+			<div class="auth-grid">
+				${rows
+					.map(
+						row => `
+						<article class="auth-card" data-case="${row.id}" data-authorized="${row.discrete.authorized}" data-valid="${row.discrete.inputValid}" data-authority="${row.continuous.authorityAvailable}" data-fraction="${mothershipFundingFraction(row.continuous)}">
+							<h3>${row.label}</h3>
+							<dl>
+								<dt>discrete</dt><dd>${row.discrete.authorized ? "authorized" : "rejected"}</dd>
+								<dt>input valid</dt><dd>${row.discrete.inputValid}</dd>
+								<dt>available</dt><dd>${row.discrete.availableEnergy.toFixed(2)}</dd>
+								<dt>continuous funded</dt><dd>${row.continuous.fundedEnergy.toFixed(2)}</dd>
+								<dt>funding fraction</dt><dd>${mothershipFundingFraction(row.continuous).toFixed(3)}</dd>
+							</dl>
+						</article>`
+					)
+					.join("")}
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FailClosedAuthority: Story = {
+	play: async ({ canvasElement }) => {
+		const healthy = state(10);
+		const hulk = state(10, "hulk");
+
+		const valid = authorizeDiscreteMothershipSpend(healthy, 6);
+		await expect(valid.inputValid).toBe(true);
+		await expect(valid.authorized).toBe(true);
+
+		const overdraw = authorizeDiscreteMothershipSpend(healthy, 12);
+		await expect(overdraw.authorized).toBe(false);
+		const partial = fundContinuousMothershipSpend(healthy, 12);
+		await expect(partial.fundedEnergy).toBe(10);
+		await expect(partial.unmetEnergy).toBe(2);
+		await expect(mothershipFundingFraction(partial)).toBeCloseTo(10 / 12);
+
+		const malformedValues = [-1, NaN, Infinity, -Infinity];
+		for (let index = 0; index < malformedValues.length; index += 1) {
+			const malformed = authorizeDiscreteMothershipSpend(
+				healthy,
+				malformedValues[index]
+			);
+			await expect(malformed.inputValid).toBe(false);
+			await expect(malformed.authorized).toBe(false);
+			await expect(Number.isFinite(malformed.requestedEnergy)).toBe(true);
+
+			const funding = fundContinuousMothershipSpend(
+				healthy,
+				malformedValues[index]
+			);
+			await expect(funding.inputValid).toBe(false);
+			await expect(funding.authorityAvailable).toBe(false);
+			await expect(mothershipFundingFraction(funding)).toBe(0);
+		}
+
+		const invalidProtected = authorizeDiscreteMothershipSpend(healthy, 6, NaN);
+		await expect(invalidProtected.inputValid).toBe(false);
+		await expect(invalidProtected.authorized).toBe(false);
+		const invalidProtectedFunding = fundContinuousMothershipSpend(
+			healthy,
+			6,
+			Infinity
+		);
+		await expect(invalidProtectedFunding.inputValid).toBe(false);
+		await expect(mothershipFundingFraction(invalidProtectedFunding)).toBe(0);
+
+		const invalidReserve = authorizeDiscreteMothershipSpend(state(NaN), 0);
+		await expect(invalidReserve.inputValid).toBe(false);
+		await expect(invalidReserve.authorized).toBe(false);
+
+		const hulkZero = authorizeDiscreteMothershipSpend(hulk, 0);
+		await expect(hulkZero.inputValid).toBe(true);
+		await expect(hulkZero.authorized).toBe(false);
+		const hulkFunding = fundContinuousMothershipSpend(hulk, 0);
+		await expect(hulkFunding.authorityAvailable).toBe(false);
+		await expect(mothershipFundingFraction(hulkFunding)).toBe(0);
+
+		const explicitZero = authorizeDiscreteMothershipSpend(healthy, 0);
+		await expect(explicitZero.inputValid).toBe(true);
+		await expect(explicitZero.authorized).toBe(true);
+		const zeroFunding = fundContinuousMothershipSpend(healthy, 0);
+		await expect(mothershipFundingFraction(zeroFunding)).toBe(1);
+
+		const hulkCard = canvasElement.querySelector<HTMLElement>(
+			"[data-case='hulk-zero']"
+		);
+		await expect(hulkCard).not.toBeNull();
+		await expect(hulkCard?.dataset.authorized).toBe("false");
+		await expect(hulkCard?.dataset.fraction).toBe("0");
+	}
+};

--- a/src/js/gameplay/mothershipEnergyAuthorization.ts
+++ b/src/js/gameplay/mothershipEnergyAuthorization.ts
@@ -2,12 +2,15 @@ import type { MothershipEnergyLiftState } from "./mothershipEnergyLift";
 
 export interface MothershipDiscreteSpendAuthorization {
 	authorized: boolean;
+	inputValid: boolean;
 	requestedEnergy: number;
 	availableEnergy: number;
 	shortfallEnergy: number;
 }
 
 export interface MothershipContinuousSpendFunding {
+	inputValid: boolean;
+	authorityAvailable: boolean;
 	requestedEnergy: number;
 	fundedEnergy: number;
 	unmetEnergy: number;
@@ -24,6 +27,15 @@ function positive(value: number): number {
 	return Math.max(0, finite(value));
 }
 
+function isFiniteNonnegative(value: number): boolean {
+	return (
+		value === value &&
+		value !== Infinity &&
+		value !== -Infinity &&
+		value >= 0
+	);
+}
+
 /**
  * Check an all-or-nothing action before committing its physical side effect.
  *
@@ -33,19 +45,31 @@ function positive(value: number): number {
  *
  * `protectedReserve` is optional policy: zero allows spending down to empty;
  * a caller may reserve a survival/hover buffer without changing core physics.
+ * Malformed authority inputs fail closed instead of being sanitized into free
+ * physical permission.
  */
 export function authorizeDiscreteMothershipSpend(
 	state: MothershipEnergyLiftState,
 	requestedEnergy: number,
 	protectedReserve = 0
 ): MothershipDiscreteSpendAuthorization {
-	const requested = positive(requestedEnergy);
-	const reserve = positive(state.reserve);
-	const protectedAmount = Math.min(reserve, positive(protectedReserve));
-	const available = state.phase === "hulk" ? 0 : Math.max(0, reserve - protectedAmount);
+	const requestedValid = isFiniteNonnegative(requestedEnergy);
+	const protectedValid = isFiniteNonnegative(protectedReserve);
+	const reserveValid = isFiniteNonnegative(state.reserve);
+	const inputValid = requestedValid && protectedValid && reserveValid;
+	const requested = requestedValid ? requestedEnergy : 0;
+	const reserve = reserveValid ? state.reserve : 0;
+	const protectedAmount = protectedValid
+		? Math.min(reserve, protectedReserve)
+		: reserve;
+	const authorityAvailable = inputValid && state.phase !== "hulk";
+	const available = authorityAvailable
+		? Math.max(0, reserve - protectedAmount)
+		: 0;
 	const shortfall = Math.max(0, requested - available);
 	return {
-		authorized: shortfall <= 0,
+		authorized: authorityAvailable && shortfall <= 0,
+		inputValid,
 		requestedEnergy: requested,
 		availableEnergy: available,
 		shortfallEnergy: shortfall
@@ -60,18 +84,31 @@ export function authorizeDiscreteMothershipSpend(
  * This helper also does not mutate reserve. The funded amount is intended to be
  * submitted to the single reserve authority while the calling motion/actuator
  * layer scales its commanded authority by `funded / requested`.
+ *
+ * Invalid numeric authority inputs and hulk state expose zero actuator authority.
  */
 export function fundContinuousMothershipSpend(
 	state: MothershipEnergyLiftState,
 	requestedEnergy: number,
 	protectedReserve = 0
 ): MothershipContinuousSpendFunding {
-	const requested = positive(requestedEnergy);
-	const reserve = positive(state.reserve);
-	const protectedAmount = Math.min(reserve, positive(protectedReserve));
-	const available = state.phase === "hulk" ? 0 : Math.max(0, reserve - protectedAmount);
+	const requestedValid = isFiniteNonnegative(requestedEnergy);
+	const protectedValid = isFiniteNonnegative(protectedReserve);
+	const reserveValid = isFiniteNonnegative(state.reserve);
+	const inputValid = requestedValid && protectedValid && reserveValid;
+	const requested = requestedValid ? requestedEnergy : 0;
+	const reserve = reserveValid ? state.reserve : 0;
+	const protectedAmount = protectedValid
+		? Math.min(reserve, protectedReserve)
+		: reserve;
+	const authorityAvailable = inputValid && state.phase !== "hulk";
+	const available = authorityAvailable
+		? Math.max(0, reserve - protectedAmount)
+		: 0;
 	const funded = Math.min(requested, available);
 	return {
+		inputValid,
+		authorityAvailable,
 		requestedEnergy: requested,
 		fundedEnergy: funded,
 		unmetEnergy: Math.max(0, requested - funded)
@@ -81,6 +118,9 @@ export function fundContinuousMothershipSpend(
 export function mothershipFundingFraction(
 	funding: MothershipContinuousSpendFunding
 ): number {
+	if (!funding.inputValid || !funding.authorityAvailable) {
+		return 0;
+	}
 	if (funding.requestedEnergy <= 0) {
 		return 1;
 	}

--- a/src/js/gameplay/mothershipEnergyAuthorization.ts
+++ b/src/js/gameplay/mothershipEnergyAuthorization.ts
@@ -16,17 +16,6 @@ export interface MothershipContinuousSpendFunding {
 	unmetEnergy: number;
 }
 
-function finite(value: number, fallback = 0): number {
-	if (value !== value || value === Infinity || value === -Infinity) {
-		return fallback;
-	}
-	return value;
-}
-
-function positive(value: number): number {
-	return Math.max(0, finite(value));
-}
-
 function isFiniteNonnegative(value: number): boolean {
 	return (
 		value === value &&


### PR DESCRIPTION
Refs #79, #83
Parent PR: #102

## Purpose

Close two authorization-boundary failures found during static review of #102 without modifying the parent executor's branch.

The existing helpers sanitize negative/non-finite spend inputs to zero. For discrete actions that can convert malformed cost into an authorized free physical action. Separately, a hulk asked to spend zero currently returns discrete authorization success, and continuous zero demand produces funding fraction `1`, despite #102's explicit rule that a hulk has zero spend authority.

## Change

Relative to #102 head `1c363ec385fb65e7f53188bd8545f1e00dc4e537`:

- require requested spend, protected reserve, and authoritative reserve to be finite/non-negative before granting authority;
- expose `inputValid` in discrete and continuous authorization results;
- expose `authorityAvailable` for continuous funding;
- malformed authority state/input yields zero available/funded authority rather than sanitized permission;
- hulk state always rejects discrete authority, including literal zero-cost requests;
- hulk/invalid continuous funding produces actuator fraction `0`;
- an intact valid mothership still permits an explicit literal zero-cost action and reports continuous zero demand as fraction `1`;
- add a deterministic Storybook authorization fixture covering valid spend, overdraw, malformed spend/protected reserve/reserve state, and hulk-zero authority.

## Important non-goal

This child does **not** solve the already-recorded multi-demand transaction/overcommit issue on #102. Independent launch/propulsion callers can still authorize against one state snapshot unless the later integration adopts sequential reservation or aggregate authorization. That remains a separate required parent/integration fix.

## Scope

Two-file child delta only:

- `src/js/gameplay/mothershipEnergyAuthorization.ts`;
- `experiments/storybook/src/Foundations/Physics/MothershipEnergyAuthorization.stories.ts`.

No reserve/lift dynamics, Babylon prototype wiring, navigation math, launch costs, package metadata, or frozen certification heads change.

## Certification

Keep draft until a later post-freeze root + Storybook campaign can verify:

- historical TypeScript accepts the result-shape additions and guards;
- negative/NaN/±Infinity spend => `inputValid=false`, discrete rejected, continuous fraction 0;
- malformed protected reserve or authoritative reserve => no authority;
- hulk rejects a zero-cost discrete request and yields continuous funding fraction 0;
- intact explicit-zero semantics remain valid;
- normal discrete overdraw and proportional continuous funding remain unchanged;
- `pnpm typecheck`, `pnpm build`, and `pnpm test` pass in `experiments/storybook`.

If accepted, fold into #102 or merge after it; do not insert this child into the frozen #92/#105 campaign.