### PR TITLE
experiment: make raid commitment respond to perceived target value

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/RaidExpectedValue.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/RaidExpectedValue.stories.ts
@@ -1,0 +1,194 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	estimateRaidExpectedValue,
+	raidExpectedValueIsAdmissible,
+	selectRaidTierByExpectedNetReturn,
+	type RaidExpectedValueEstimate,
+	type RaidExpectedValueTier
+} from "@defend/gameplay/raidExpectedValue";
+import { createLabShell } from "../../labTheme";
+
+type ExpectedValueArgs = {
+	richTargetEnergy: number;
+	poorTargetEnergy: number;
+	emptyTargetEnergy: number;
+	expectedBreachProbability: number;
+	expectedArrivalViability: number;
+	travelAndOperatingCost: number;
+	minimumExpectedNetReturn: number;
+};
+
+type TierProfile = {
+	tier: RaidExpectedValueTier;
+	committedEnergy: number;
+	extractionPotential: number;
+};
+
+const PROFILES: TierProfile[] = [
+	{ tier: 1, committedEnergy: 3000, extractionPotential: 7720 },
+	{ tier: 2, committedEnergy: 12000, extractionPotential: 30440 },
+	{ tier: 3, committedEnergy: 27000, extractionPotential: 68160 }
+];
+
+function estimatesFor(
+	perceivedTargetEnergy: number,
+	args: ExpectedValueArgs
+): RaidExpectedValueEstimate[] {
+	return PROFILES.map(profile =>
+		estimateRaidExpectedValue({
+			tier: profile.tier,
+			committedEnergy: profile.committedEnergy,
+			extractionPotential: profile.extractionPotential,
+			perceivedTargetEnergy,
+			expectedBreachProbability: args.expectedBreachProbability,
+			expectedArrivalViability: args.expectedArrivalViability,
+			travelAndOperatingCost: args.travelAndOperatingCost
+		})
+	);
+}
+
+function fixed(value: number, digits = 0): string {
+	if (value !== value || value === Infinity || value === -Infinity) return "0";
+	return value.toFixed(digits);
+}
+
+function targetCard(
+	label: string,
+	targetEnergy: number,
+	estimates: RaidExpectedValueEstimate[],
+	minimumExpectedNetReturn: number
+): string {
+	const selected = selectRaidTierByExpectedNetReturn(
+		estimates,
+		minimumExpectedNetReturn
+	);
+	const rows = estimates
+		.map(estimate => {
+			const admissible = raidExpectedValueIsAdmissible(
+				estimate,
+				minimumExpectedNetReturn
+			);
+			return `
+				<tr data-tier="${estimate.tier}" data-admissible="${admissible}" data-net="${estimate.expectedNetReturn}">
+					<th>R${estimate.tier}</th>
+					<td>${fixed(estimate.committedEnergy)}</td>
+					<td>${fixed(estimate.expectedExtractedEnergy)}</td>
+					<td>${fixed(estimate.expectedNetReturn)}</td>
+					<td>${admissible ? "admissible" : "decline"}</td>
+				</tr>`;
+		})
+		.join("");
+	return `
+		<article class="ev-card" data-target="${label}" data-selected="${selected ?? "none"}">
+			<header><div><small>perceived target</small><strong>${label}</strong></div><span>${fixed(targetEnergy)} energy</span></header>
+			<div class="ev-selection">highest admissible absolute net: <strong>${selected === null ? "no raid" : `R${selected}`}</strong></div>
+			<table>
+				<thead><tr><th>tier</th><th>commit</th><th>expected extract</th><th>expected net</th><th>gate</th></tr></thead>
+				<tbody>${rows}</tbody>
+			</table>
+		</article>`;
+}
+
+const meta = {
+	title: "Foundations/Strategy/Raid Expected Value",
+	tags: ["test", "visual"],
+	args: {
+		richTargetEnergy: 30000,
+		poorTargetEnergy: 5000,
+		emptyTargetEnergy: 1000,
+		expectedBreachProbability: 0.96,
+		expectedArrivalViability: 0.95,
+		travelAndOperatingCost: 500,
+		minimumExpectedNetReturn: 0
+	},
+	argTypes: {
+		richTargetEnergy: { control: { type: "range", min: 0, max: 60000, step: 500 } },
+		poorTargetEnergy: { control: { type: "range", min: 0, max: 30000, step: 500 } },
+		emptyTargetEnergy: { control: { type: "range", min: 0, max: 10000, step: 250 } },
+		expectedBreachProbability: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
+		expectedArrivalViability: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
+		travelAndOperatingCost: { control: { type: "range", min: 0, max: 5000, step: 100 } },
+		minimumExpectedNetReturn: { control: { type: "range", min: -5000, max: 10000, step: 250 } }
+	},
+	render: (args: ExpectedValueArgs) => {
+		const orderedTargets = [
+			Math.max(args.richTargetEnergy, args.poorTargetEnergy, args.emptyTargetEnergy),
+			Math.max(
+				Math.min(args.richTargetEnergy, args.poorTargetEnergy),
+				args.emptyTargetEnergy
+			),
+			Math.min(args.richTargetEnergy, args.poorTargetEnergy, args.emptyTargetEnergy)
+		];
+		const rich = estimatesFor(orderedTargets[0], args);
+		const poor = estimatesFor(orderedTargets[1], args);
+		const empty = estimatesFor(orderedTargets[2], args);
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Pre-commit raid expected value",
+			"Attackers evaluate a perceived/lossy target-energy signal before commitment. Expected extraction is target-limited before launch; authoritative energy transfer still belongs to #114 after a physical breach. This lets commitment taper emerge as targets become less valuable."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.ev-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(320px,1fr)); gap:12px; }
+				.ev-card { padding:13px; border:1px solid rgba(228,185,128,.2); background:rgba(10,3,17,.42); overflow:auto; }
+				.ev-card header { display:flex; justify-content:space-between; align-items:baseline; gap:12px; }
+				.ev-card header div { display:grid; gap:3px; }
+				.ev-card small { opacity:.45; text-transform:uppercase; letter-spacing:.08em; font-size:9px; }
+				.ev-card header span { opacity:.58; font-size:10px; }
+				.ev-selection { margin:10px 0; padding:7px 9px; border-left:3px solid rgba(73,215,209,.55); font-size:10px; }
+				.ev-card table { width:100%; border-collapse:collapse; font-size:9px; }
+				.ev-card th, .ev-card td { padding:6px 5px; text-align:right; border-top:1px solid rgba(244,237,247,.08); white-space:nowrap; }
+				.ev-card th:first-child { text-align:left; }
+				.ev-note { margin-top:13px; padding:11px; border:1px dashed rgba(244,237,247,.15); font-size:10px; line-height:1.55; opacity:.68; }
+			</style>
+			<div class="ev-grid">
+				${targetCard("rich", orderedTargets[0], rich, args.minimumExpectedNetReturn)}
+				${targetCard("poor", orderedTargets[1], poor, args.minimumExpectedNetReturn)}
+				${targetCard("nearly empty", orderedTargets[2], empty, args.minimumExpectedNetReturn)}
+			</div>
+			<div class="ev-note">The selector is a diagnostic witness, not final AI. Cheap probes may intentionally use a negative admissibility threshold under uncertainty; #107 should test that policy separately. Tier numbers receive no bonus and ties prefer the lower-energy commitment.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<ExpectedValueArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TargetRichnessTaper: Story = {
+	play: async () => {
+		const witness: ExpectedValueArgs = {
+			richTargetEnergy: 30000,
+			poorTargetEnergy: 5000,
+			emptyTargetEnergy: 1000,
+			expectedBreachProbability: 0.96,
+			expectedArrivalViability: 0.95,
+			travelAndOperatingCost: 500,
+			minimumExpectedNetReturn: 0
+		};
+		const rich = estimatesFor(30000, witness);
+		const poor = estimatesFor(5000, witness);
+		const empty = estimatesFor(1000, witness);
+
+		for (const estimates of [rich, poor, empty]) {
+			for (let index = 0; index < estimates.length; index += 1) {
+				const estimate = estimates[index];
+				await expect(estimate.expectedExtractedEnergy).toBeLessThanOrEqual(
+					estimate.perceivedTargetEnergy *
+						witness.expectedBreachProbability +
+						1e-9
+				);
+			}
+		}
+
+		await expect(selectRaidTierByExpectedNetReturn(rich, 0)).toBe(2);
+		await expect(selectRaidTierByExpectedNetReturn(poor, 0)).toBe(1);
+		await expect(selectRaidTierByExpectedNetReturn(empty, 0)).toBeNull();
+
+		await expect(poor[0].expectedNetReturn).toBeGreaterThan(0);
+		await expect(poor[1].expectedNetReturn).toBeLessThan(0);
+		await expect(poor[2].expectedNetReturn).toBeLessThan(0);
+	}
+};

--- a/src/js/gameplay/raidExpectedValue.ts
+++ b/src/js/gameplay/raidExpectedValue.ts
@@ -1,0 +1,122 @@
+export type RaidExpectedValueTier = 1 | 2 | 3;
+
+export interface RaidExpectedValueInput {
+	tier: RaidExpectedValueTier;
+	committedEnergy: number;
+	extractionPotential: number;
+	perceivedTargetEnergy: number;
+	expectedBreachProbability: number;
+	expectedArrivalViability: number;
+	travelAndOperatingCost: number;
+}
+
+export interface RaidExpectedValueEstimate {
+	tier: RaidExpectedValueTier;
+	committedEnergy: number;
+	perceivedTargetEnergy: number;
+	potentialExtractionAtArrival: number;
+	targetLimitedExtractionOnBreach: number;
+	expectedExtractedEnergy: number;
+	expectedNetReturn: number;
+	expectedReturnOnCommitment: number;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function clamp01(value: number): number {
+	return Math.max(0, Math.min(1, finite(value)));
+}
+
+/**
+ * Estimate raid value before commitment using a lossy/perceived target-energy
+ * quantity rather than authoritative silo state.
+ *
+ * This is deliberately not settlement authority. #114 owns the conserved
+ * after-the-fact exchange. This estimate exists so deterrence can react before
+ * launch: an apparently poor target should make expensive commitments
+ * unattractive even if its defenses are weak.
+ */
+export function estimateRaidExpectedValue(
+	input: RaidExpectedValueInput
+): RaidExpectedValueEstimate {
+	const committedEnergy = positive(input.committedEnergy);
+	const extractionPotential = positive(input.extractionPotential);
+	const perceivedTargetEnergy = positive(input.perceivedTargetEnergy);
+	const breachProbability = clamp01(input.expectedBreachProbability);
+	const arrivalViability = clamp01(input.expectedArrivalViability);
+	const travelAndOperatingCost = positive(input.travelAndOperatingCost);
+
+	const potentialExtractionAtArrival = extractionPotential * arrivalViability;
+	const targetLimitedExtractionOnBreach = Math.min(
+		perceivedTargetEnergy,
+		potentialExtractionAtArrival
+	);
+	const expectedExtractedEnergy =
+		targetLimitedExtractionOnBreach * breachProbability;
+	const expectedNetReturn =
+		expectedExtractedEnergy - committedEnergy - travelAndOperatingCost;
+	const expectedReturnOnCommitment =
+		committedEnergy <= 0 ? 0 : expectedNetReturn / committedEnergy;
+
+	return {
+		tier: input.tier,
+		committedEnergy,
+		perceivedTargetEnergy,
+		potentialExtractionAtArrival,
+		targetLimitedExtractionOnBreach,
+		expectedExtractedEnergy,
+		expectedNetReturn,
+		expectedReturnOnCommitment
+	};
+}
+
+/**
+ * Caller-owned threshold for deciding whether a commitment is economically
+ * admissible. A negative threshold can represent deliberate scouting/probing;
+ * zero or positive thresholds express stricter economic discipline.
+ */
+export function raidExpectedValueIsAdmissible(
+	estimate: RaidExpectedValueEstimate,
+	minimumExpectedNetReturn: number
+): boolean {
+	return estimate.expectedNetReturn >= finite(minimumExpectedNetReturn);
+}
+
+/**
+ * Diagnostic selector for experiments: among economically admissible tiers,
+ * choose the highest expected absolute net return. Ties prefer the lower-energy
+ * commitment so tier number alone never wins a tie.
+ *
+ * This is not a production AI recommendation; #107 should compare multiple
+ * commitment policies and preserve explicit probe behavior under uncertainty.
+ */
+export function selectRaidTierByExpectedNetReturn(
+	estimates: RaidExpectedValueEstimate[],
+	minimumExpectedNetReturn: number
+): RaidExpectedValueTier | null {
+	let best: RaidExpectedValueEstimate | null = null;
+	for (let index = 0; index < estimates.length; index += 1) {
+		const candidate = estimates[index];
+		if (!raidExpectedValueIsAdmissible(candidate, minimumExpectedNetReturn)) {
+			continue;
+		}
+		if (
+			best === null ||
+			candidate.expectedNetReturn > best.expectedNetReturn ||
+			(candidate.expectedNetReturn === best.expectedNetReturn &&
+				candidate.committedEnergy < best.committedEnergy)
+		) {
+			best = candidate;
+		}
+	}
+	return best === null ? null : best.tier;
+}


### PR DESCRIPTION
Refs #107, #103
Parent: #114
Related: #111, #74, #76, #86

## Purpose

Move target richness one step earlier in the deterrence causal chain: before a raider is committed, estimate whether the perceived target contains enough recoverable value to justify that tier's embodied/launch energy and travel/operating cost.

#114 corrects conserved settlement **after** a raid reaches the target. This child adds the complementary pre-commit estimate so a poor target can reduce expensive commitment before the breach is attempted.

## `src/js/gameplay/raidExpectedValue.ts`

Adds an engine-free expected-value model with explicit inputs:

- raider tier;
- committed/embodied energy;
- extraction potential;
- **perceived target energy**;
- expected breach probability;
- expected arrival viability;
- travel/operating cost.

It derives:

- viability-limited extraction potential on arrival;
- target-limited extraction if a breach succeeds;
- probability-weighted expected extraction;
- expected net return;
- expected return on commitment.

### Perception boundary

`perceivedTargetEnergy` is intentionally not authoritative silo state. It may later come from the lossy brightness/throughput/reachability signature discussed in #107/#103.

The important invariant is economic: even a weakly defended target should not appear capable of yielding more energy than the attacker believes is present.

Authoritative after-the-fact transfer remains #114's responsibility.

## Admission / diagnostic selection

`raidExpectedValueIsAdmissible()` accepts a caller-supplied minimum expected-net threshold.

- zero/positive can model strict economic discipline;
- a modest negative threshold can model deliberate scouting/probing under uncertainty.

`selectRaidTierByExpectedNetReturn()` is explicitly a **diagnostic experiment helper**, not final AI. Among admissible options it picks highest expected absolute net, with ties favoring lower committed energy so tier number itself never wins a tie.

#107 should still compare multiple commitment/probe policies rather than making this selector canonical.

## Storybook playground

Adds `Foundations/Strategy/Raid Expected Value`.

It compares three ordered perceived target values across R1/R2/R3 with controls for breach probability, arrival viability, travel cost, target values and admission threshold.

The fixed deterministic witness uses current economy-hypothesis scales:

- R1: commit 3000 / extraction potential 7720;
- R2: 12000 / 30440;
- R3: 27000 / 68160;
- expected breach 0.96;
- expected arrival viability 0.95;
- travel/operating cost 500.

Under that witness:

- perceived 30000 → diagnostic selector favors R2;
- perceived 5000 → only R1 remains positive-EV;
- perceived 1000 → no tier is positive-EV.

This is **not balance certification**. It is a structural witness that target richness can naturally cause `expensive commitment → probe → no economically rational raid` as value disappears.

The story also asserts expected extracted energy never exceeds perceived target energy × breach probability.

No RAF, timer, Babylon scene, Worker, AudioContext or production AI is introduced.

## Scope

Relative to #114 head `11fa4384bd3a3e5c8d475a9da0311918d8d0f6cd`:

- 2 commits ahead / 0 behind;
- 2 added files;
- no edits to #111's current scenario runner;
- no production wave/AI changes;
- no dependency/package changes;
- no final confidence, launch-cost or target-signature constants.

## Integration into #111

After #114 conservation semantics are adopted, #111 should replace state-only raid frequency/tier selection with a model that also consumes perceived target value and expected physical outcomes.

At minimum test:

1. rich + vulnerable target can restore attacker interest;
2. poor target suppresses expensive bodies even if vulnerable;
3. cheap probes persist longer under uncertainty than expensive bodies;
4. repeated unprofitable probes eventually go quiet;
5. one lucky probe does not instantly restore maximum commitment;
6. no tier gets a hidden ROI bonus from tier number.

## Validation

Post-freeze draft. Later root + Storybook gate:

```sh
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Add sweeps across target energy, breach probability, viability, travel cost and admission threshold. Compare against measured physical outcomes once #72/#86 fixtures are available.

This does not alter #92's frozen certification campaign.