### PR TITLE
Add passive tower-interaction comprehension metrics

### DIFF
--- a/experiments/storybook/src/Arena/Interaction/TowerInteractionObservation.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/TowerInteractionObservation.stories.ts
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	classifyTowerInteraction,
+	type TowerInteractionRequest
+} from "@defend/gameplay/towerInteraction";
+import {
+	createTowerInteractionObservationState,
+	recordTowerInteractionObservation,
+	summarizeTowerInteractionObservations,
+	type TowerInteractionInterventionKind,
+	type TowerInteractionObservation,
+	type TowerInteractionObservationSummary
+} from "@defend/gameplay/towerInteractionObservation";
+import { createLabShell } from "../../labTheme";
+
+function request(
+	overrides: Partial<TowerInteractionRequest> = {}
+): TowerInteractionRequest {
+	return {
+		inputOwner: "world",
+		targetKind: "ground",
+		occupied: false,
+		balance: 10000,
+		requestedCost: 3000,
+		currentLevel: 0,
+		maximumLevel: 3,
+		affordabilityRule: "legacy-strict",
+		maxLevelBehavior: "no-op",
+		...overrides
+	};
+}
+
+function observation(
+	atSeconds: number,
+	input: TowerInteractionRequest,
+	interventionKind: TowerInteractionInterventionKind,
+	cellKey: string | null,
+	roleKey: string | null,
+	tacticalContextKey: string
+): TowerInteractionObservation {
+	return {
+		atSeconds,
+		cellKey,
+		roleKey,
+		tacticalContextKey,
+		interventionKind,
+		preview: classifyTowerInteraction(input)
+	};
+}
+
+function summarizeSession(
+	events: TowerInteractionObservation[]
+): TowerInteractionObservationSummary {
+	let state = createTowerInteractionObservationState(0);
+	for (let index = 0; index < events.length; index += 1) {
+		state = recordTowerInteractionObservation(state, events[index]);
+	}
+	return summarizeTowerInteractionObservations(state);
+}
+
+function legibleSession(): TowerInteractionObservationSummary {
+	return summarizeSession([
+		observation(
+			1.2,
+			request({ occupied: true }),
+			"new-build",
+			"cell-a",
+			"barrier",
+			"opening"
+		),
+		observation(
+			2,
+			request({ inputOwner: "camera" }),
+			"other",
+			null,
+			null,
+			"opening"
+		),
+		observation(4.2, request(), "new-build", "cell-b", "barrier", "opening"),
+		observation(26, request(), "replacement", "cell-b", "barrier", "opening"),
+		observation(
+			44,
+			request(),
+			"replacement",
+			"cell-b",
+			"barrier",
+			"mixed-heavy-threat"
+		),
+		observation(
+			48,
+			request({
+				targetKind: "tower",
+				currentLevel: 1,
+				requestedCost: 6000
+			}),
+			"upgrade",
+			"cell-b",
+			"interceptor",
+			"mixed-heavy-threat"
+		)
+	]);
+}
+
+function opaqueSession(): TowerInteractionObservationSummary {
+	return summarizeSession([
+		observation(1, request({ occupied: true }), "new-build", "cell-a", "barrier", "opening"),
+		observation(
+			3,
+			request({ targetKind: "protected-core" }),
+			"new-build",
+			"core",
+			"barrier",
+			"opening"
+		),
+		observation(5, request({ balance: 1000 }), "new-build", "cell-b", "barrier", "opening"),
+		observation(8, request({ inputOwner: "camera" }), "other", null, null, "opening"),
+		observation(13, request(), "new-build", "cell-c", "barrier", "opening"),
+		observation(30, request(), "replacement", "cell-c", "barrier", "opening"),
+		observation(46, request(), "replacement", "cell-c", "barrier", "opening"),
+		observation(62, request(), "replacement", "cell-c", "barrier", "opening")
+	]);
+}
+
+function fixed(value: number | null, digits = 1): string {
+	if (value === null || value !== value || value === Infinity || value === -Infinity) {
+		return "—";
+	}
+	return value.toFixed(digits);
+}
+
+function sessionCard(
+	id: string,
+	label: string,
+	summary: TowerInteractionObservationSummary
+): string {
+	return `
+		<article class="obs-card" data-session="${id}"
+			data-first-build="${summary.timeToFirstBuildSeconds ?? -1}"
+			data-rejections-before-build="${summary.rejectedBeforeFirstBuild}"
+			data-ignored-before-build="${summary.ignoredBeforeFirstBuild}"
+			data-camera-conflicts="${summary.cameraConflicts}"
+			data-repeated="${summary.repeatedSameContextReplacements}"
+			data-repetition-rate="${summary.repetitionRate}">
+			<header><small>observation fixture</small><strong>${label}</strong></header>
+			<div class="obs-metrics">
+				<div><span>attempts</span><strong>${summary.attempts}</strong></div>
+				<div><span>allowed</span><strong>${summary.allowedActions}</strong></div>
+				<div><span>rejected</span><strong>${summary.rejectedActions}</strong></div>
+				<div><span>ignored</span><strong>${summary.ignoredActions}</strong></div>
+				<div><span>first build</span><strong>${fixed(summary.timeToFirstBuildSeconds)} s</strong></div>
+				<div><span>rejects before build</span><strong>${summary.rejectedBeforeFirstBuild}</strong></div>
+				<div><span>camera conflicts</span><strong>${summary.cameraConflicts}</strong></div>
+				<div><span>same-context replacements</span><strong>${summary.repeatedSameContextReplacements} / ${summary.acceptedReplacements}</strong></div>
+				<div><span>replacement repetition</span><strong>${fixed(summary.repetitionRate * 100, 0)}%</strong></div>
+			</div>
+			<footer>
+				Reasons: occupied ${summary.reasonCounts.occupied} · protected ${summary.reasonCounts.protectedCore} · resource ${summary.reasonCounts.unaffordable} · camera ${summary.reasonCounts.cameraGesture}
+			</footer>
+		</article>`;
+}
+
+const meta = {
+	title: "Arena/Interaction/Tower Observation",
+	tags: ["test", "visual"],
+	render: () => {
+		const legible = legibleSession();
+		const opaque = opaqueSession();
+		const shell = createLabShell(
+			"Arena / interaction",
+			"First-build and maintenance observation",
+			"Passive metrics downstream of #117's explicit interaction preview. Camera-owned gestures remain ignored rather than being mislabeled as gameplay rejections; all attempts still contribute to first-build discoverability evidence."
+		);
+		shell.frame.innerHTML = `
+			<style>
+				.obs-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:14px; }
+				.obs-card { padding:14px; border:1px solid rgba(228,185,128,.2); background:rgba(10,3,17,.42); }
+				.obs-card header { display:grid; gap:3px; margin-bottom:12px; }
+				.obs-card header small { opacity:.45; text-transform:uppercase; letter-spacing:.08em; font-size:9px; }
+				.obs-metrics { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+				.obs-metrics div { border-top:1px solid rgba(244,237,247,.08); padding-top:7px; }
+				.obs-metrics span { display:block; font-size:9px; opacity:.48; text-transform:uppercase; }
+				.obs-metrics strong { display:block; margin-top:3px; font-size:13px; }
+				.obs-card footer { margin-top:12px; font-size:10px; opacity:.58; line-height:1.5; }
+				.obs-note { margin-top:13px; border:1px dashed rgba(244,237,247,.16); padding:11px; font-size:10px; line-height:1.55; opacity:.68; }
+			</style>
+			<div class="obs-grid">
+				${sessionCard("legible", "Legible first contact", legible)}
+				${sessionCard("opaque", "High-friction / rote maintenance", opaque)}
+			</div>
+			<div class="obs-note">These are evidence-shape examples, not UX targets. Same-cell replacement only becomes an input-tax signal when the semantic role and caller-owned tactical-context fingerprint also remain unchanged.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ComprehensionMetrics: Story = {
+	play: async ({ canvasElement }) => {
+		const legible = canvasElement.querySelector<HTMLElement>(
+			'[data-session="legible"]'
+		);
+		const opaque = canvasElement.querySelector<HTMLElement>(
+			'[data-session="opaque"]'
+		);
+		await expect(legible).not.toBeNull();
+		await expect(opaque).not.toBeNull();
+		if (!legible || !opaque) return;
+
+		await expect(Number(legible.dataset.firstBuild)).toBeCloseTo(4.2, 8);
+		await expect(Number(legible.dataset.rejectionsBeforeBuild)).toBe(1);
+		await expect(Number(legible.dataset.ignoredBeforeBuild)).toBe(1);
+		await expect(Number(legible.dataset.cameraConflicts)).toBe(1);
+		await expect(Number(legible.dataset.repeated)).toBe(1);
+		await expect(Number(legible.dataset.repetitionRate)).toBeCloseTo(0.5, 8);
+
+		await expect(Number(opaque.dataset.firstBuild)).toBeGreaterThan(
+			Number(legible.dataset.firstBuild)
+		);
+		await expect(Number(opaque.dataset.rejectionsBeforeBuild)).toBeGreaterThan(
+			Number(legible.dataset.rejectionsBeforeBuild)
+		);
+		await expect(Number(opaque.dataset.repetitionRate)).toBeGreaterThan(
+			Number(legible.dataset.repetitionRate)
+		);
+	}
+};

--- a/src/js/gameplay/towerInteractionObservation.ts
+++ b/src/js/gameplay/towerInteractionObservation.ts
@@ -1,0 +1,320 @@
+import type {
+	TowerInteractionPreview,
+	TowerInteractionReason
+} from "./towerInteraction";
+
+export type TowerInteractionInterventionKind =
+	| "new-build"
+	| "replacement"
+	| "upgrade"
+	| "maintenance"
+	| "other";
+
+export interface TowerInteractionObservation {
+	atSeconds: number;
+	cellKey: string | null;
+	roleKey: string | null;
+	/** Caller-owned coarse fingerprint for materially relevant tactical context. */
+	tacticalContextKey: string;
+	interventionKind: TowerInteractionInterventionKind;
+	preview: TowerInteractionPreview;
+}
+
+export interface TowerInteractionReasonCounts {
+	occupied: number;
+	unaffordable: number;
+	invalidCost: number;
+	protectedCore: number;
+	invalidTerrain: number;
+	outsideArena: number;
+	staleTarget: number;
+	maxLevel: number;
+	invalidTowerLevel: number;
+	cameraGesture: number;
+}
+
+export interface TowerInteractionAcceptedContext {
+	cellKey: string;
+	roleKey: string;
+	tacticalContextKey: string;
+}
+
+export interface TowerInteractionObservationState {
+	startedAtSeconds: number;
+	lastObservedAtSeconds: number;
+	attempts: number;
+	allowedActions: number;
+	rejectedActions: number;
+	ignoredActions: number;
+	cameraConflicts: number;
+	rejectedBeforeFirstBuild: number;
+	ignoredBeforeFirstBuild: number;
+	firstAllowedAtSeconds: number | null;
+	firstBuildAtSeconds: number | null;
+	acceptedReplacements: number;
+	repeatedSameContextReplacements: number;
+	reasonCounts: TowerInteractionReasonCounts;
+	lastAcceptedContexts: TowerInteractionAcceptedContext[];
+}
+
+export interface TowerInteractionObservationSummary {
+	attempts: number;
+	allowedActions: number;
+	rejectedActions: number;
+	ignoredActions: number;
+	allowanceRate: number;
+	cameraConflicts: number;
+	rejectedBeforeFirstBuild: number;
+	ignoredBeforeFirstBuild: number;
+	timeToFirstAllowedSeconds: number | null;
+	timeToFirstBuildSeconds: number | null;
+	acceptedReplacements: number;
+	repeatedSameContextReplacements: number;
+	repetitionRate: number;
+	reasonCounts: TowerInteractionReasonCounts;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) {
+		return fallback;
+	}
+	return value;
+}
+
+function nonNegative(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function emptyReasonCounts(): TowerInteractionReasonCounts {
+	return {
+		occupied: 0,
+		unaffordable: 0,
+		invalidCost: 0,
+		protectedCore: 0,
+		invalidTerrain: 0,
+		outsideArena: 0,
+		staleTarget: 0,
+		maxLevel: 0,
+		invalidTowerLevel: 0,
+		cameraGesture: 0
+	};
+}
+
+function copyReasonCounts(
+	counts: TowerInteractionReasonCounts
+): TowerInteractionReasonCounts {
+	return {
+		occupied: counts.occupied,
+		unaffordable: counts.unaffordable,
+		invalidCost: counts.invalidCost,
+		protectedCore: counts.protectedCore,
+		invalidTerrain: counts.invalidTerrain,
+		outsideArena: counts.outsideArena,
+		staleTarget: counts.staleTarget,
+		maxLevel: counts.maxLevel,
+		invalidTowerLevel: counts.invalidTowerLevel,
+		cameraGesture: counts.cameraGesture
+	};
+}
+
+function copyContexts(
+	contexts: TowerInteractionAcceptedContext[]
+): TowerInteractionAcceptedContext[] {
+	return contexts.map(context => ({
+		cellKey: context.cellKey,
+		roleKey: context.roleKey,
+		tacticalContextKey: context.tacticalContextKey
+	}));
+}
+
+function incrementReason(
+	counts: TowerInteractionReasonCounts,
+	reason: TowerInteractionReason
+): void {
+	if (reason === "occupied") counts.occupied += 1;
+	else if (reason === "unaffordable") counts.unaffordable += 1;
+	else if (reason === "invalid-cost") counts.invalidCost += 1;
+	else if (reason === "protected-core") counts.protectedCore += 1;
+	else if (reason === "invalid-terrain") counts.invalidTerrain += 1;
+	else if (reason === "outside-arena") counts.outsideArena += 1;
+	else if (reason === "stale-target") counts.staleTarget += 1;
+	else if (reason === "max-level") counts.maxLevel += 1;
+	else if (reason === "invalid-tower-level") counts.invalidTowerLevel += 1;
+	else if (reason === "camera-gesture") counts.cameraGesture += 1;
+}
+
+function contextIndex(
+	contexts: TowerInteractionAcceptedContext[],
+	cellKey: string,
+	roleKey: string
+): number {
+	for (let index = 0; index < contexts.length; index += 1) {
+		if (
+			contexts[index].cellKey === cellKey &&
+			contexts[index].roleKey === roleKey
+		) {
+			return index;
+		}
+	}
+	return -1;
+}
+
+export function createTowerInteractionObservationState(
+	startedAtSeconds = 0
+): TowerInteractionObservationState {
+	const start = nonNegative(startedAtSeconds);
+	return {
+		startedAtSeconds: start,
+		lastObservedAtSeconds: start,
+		attempts: 0,
+		allowedActions: 0,
+		rejectedActions: 0,
+		ignoredActions: 0,
+		cameraConflicts: 0,
+		rejectedBeforeFirstBuild: 0,
+		ignoredBeforeFirstBuild: 0,
+		firstAllowedAtSeconds: null,
+		firstBuildAtSeconds: null,
+		acceptedReplacements: 0,
+		repeatedSameContextReplacements: 0,
+		reasonCounts: emptyReasonCounts(),
+		lastAcceptedContexts: []
+	};
+}
+
+/**
+ * Append one passive observation downstream of #117's authoritative preview.
+ * This function never changes whether an action is allowed or how much it costs.
+ */
+export function recordTowerInteractionObservation(
+	state: TowerInteractionObservationState,
+	observation: TowerInteractionObservation
+): TowerInteractionObservationState {
+	const next: TowerInteractionObservationState = {
+		startedAtSeconds: nonNegative(state.startedAtSeconds),
+		lastObservedAtSeconds: Math.max(
+			nonNegative(state.lastObservedAtSeconds),
+			nonNegative(observation.atSeconds)
+		),
+		attempts: nonNegative(state.attempts) + 1,
+		allowedActions: nonNegative(state.allowedActions),
+		rejectedActions: nonNegative(state.rejectedActions),
+		ignoredActions: nonNegative(state.ignoredActions),
+		cameraConflicts: nonNegative(state.cameraConflicts),
+		rejectedBeforeFirstBuild: nonNegative(state.rejectedBeforeFirstBuild),
+		ignoredBeforeFirstBuild: nonNegative(state.ignoredBeforeFirstBuild),
+		firstAllowedAtSeconds: state.firstAllowedAtSeconds,
+		firstBuildAtSeconds: state.firstBuildAtSeconds,
+		acceptedReplacements: nonNegative(state.acceptedReplacements),
+		repeatedSameContextReplacements: nonNegative(
+			state.repeatedSameContextReplacements
+		),
+		reasonCounts: copyReasonCounts(state.reasonCounts),
+		lastAcceptedContexts: copyContexts(state.lastAcceptedContexts)
+	};
+	const atSeconds = next.lastObservedAtSeconds;
+	incrementReason(next.reasonCounts, observation.preview.reason);
+
+	if (observation.preview.disposition === "ignored") {
+		next.ignoredActions += 1;
+		if (observation.preview.reason === "camera-gesture") {
+			next.cameraConflicts += 1;
+		}
+		if (next.firstBuildAtSeconds === null) {
+			next.ignoredBeforeFirstBuild += 1;
+		}
+		return next;
+	}
+
+	if (observation.preview.disposition === "rejected") {
+		next.rejectedActions += 1;
+		if (next.firstBuildAtSeconds === null) {
+			next.rejectedBeforeFirstBuild += 1;
+		}
+		return next;
+	}
+
+	next.allowedActions += 1;
+	if (next.firstAllowedAtSeconds === null) {
+		next.firstAllowedAtSeconds = atSeconds;
+	}
+	if (
+		next.firstBuildAtSeconds === null &&
+		observation.interventionKind === "new-build" &&
+		observation.preview.intent === "place"
+	) {
+		next.firstBuildAtSeconds = atSeconds;
+	}
+
+	if (observation.cellKey !== null && observation.roleKey !== null) {
+		const index = contextIndex(
+			next.lastAcceptedContexts,
+			observation.cellKey,
+			observation.roleKey
+		);
+		if (observation.interventionKind === "replacement") {
+			next.acceptedReplacements += 1;
+			if (
+				index >= 0 &&
+				next.lastAcceptedContexts[index].tacticalContextKey ===
+					observation.tacticalContextKey
+			) {
+				next.repeatedSameContextReplacements += 1;
+			}
+		}
+
+		const context = {
+			cellKey: observation.cellKey,
+			roleKey: observation.roleKey,
+			tacticalContextKey: observation.tacticalContextKey
+		};
+		if (index >= 0) next.lastAcceptedContexts[index] = context;
+		else next.lastAcceptedContexts.push(context);
+	}
+
+	return next;
+}
+
+export function summarizeTowerInteractionObservations(
+	state: TowerInteractionObservationState
+): TowerInteractionObservationSummary {
+	const attempts = nonNegative(state.attempts);
+	const allowedActions = nonNegative(state.allowedActions);
+	const acceptedReplacements = nonNegative(state.acceptedReplacements);
+	const repeatedSameContextReplacements = nonNegative(
+		state.repeatedSameContextReplacements
+	);
+	return {
+		attempts,
+		allowedActions,
+		rejectedActions: nonNegative(state.rejectedActions),
+		ignoredActions: nonNegative(state.ignoredActions),
+		allowanceRate: attempts <= 0 ? 0 : allowedActions / attempts,
+		cameraConflicts: nonNegative(state.cameraConflicts),
+		rejectedBeforeFirstBuild: nonNegative(state.rejectedBeforeFirstBuild),
+		ignoredBeforeFirstBuild: nonNegative(state.ignoredBeforeFirstBuild),
+		timeToFirstAllowedSeconds:
+			state.firstAllowedAtSeconds === null
+				? null
+				: Math.max(
+					0,
+					finite(state.firstAllowedAtSeconds) -
+						nonNegative(state.startedAtSeconds)
+				),
+		timeToFirstBuildSeconds:
+			state.firstBuildAtSeconds === null
+				? null
+				: Math.max(
+					0,
+					finite(state.firstBuildAtSeconds) -
+						nonNegative(state.startedAtSeconds)
+				),
+		acceptedReplacements,
+		repeatedSameContextReplacements,
+		repetitionRate:
+			acceptedReplacements <= 0
+				? 0
+				: repeatedSameContextReplacements / acceptedReplacements,
+		reasonCounts: copyReasonCounts(state.reasonCounts)
+	};
+}


### PR DESCRIPTION
Refs #108, #103
Parent chain: #112 → #117
Related: #92, #95, #109

## Purpose

Provide the passive evidence layer for #108's first-build discoverability, rejection attribution, camera/placement arbitration, and maintenance-repetition gates while reusing the authoritative concurrent interaction classifier instead of maintaining a duplicate seam.

This replaces/supersedes #116, which was originally stacked on the now-closed duplicate classifier #115.

## `src/js/gameplay/towerInteractionObservation.ts`

Consumes #117's `TowerInteractionPreview` downstream of classification. It never changes intent, disposition, reason, cost, affordability or tower state.

Each observation supplies:

- session-relative timestamp;
- optional stable cell identity;
- optional semantic role identity;
- caller-owned coarse tactical-context fingerprint;
- intervention kind (`new-build / replacement / upgrade / maintenance / other`);
- authoritative interaction preview.

The observer derives:

- total attempts;
- allowed actions;
- rejected actions;
- ignored actions;
- allowance rate;
- rejection counts for occupied, unaffordable, invalid-cost, protected-core, invalid-terrain, outside-arena, stale-target, max-level and invalid-level states;
- camera-gesture count;
- rejected attempts before first build;
- ignored attempts before first build;
- time to first allowed action;
- time to first successful build;
- accepted replacements;
- same-cell/same-role replacements under unchanged tactical context;
- repetition rate.

### Camera semantics

#112/#117 classify camera-owned gestures as `ignored`, not rejected. This observer preserves that distinction. A camera conflict still counts as an attempt and is surfaced separately for the first-build gate, but does not inflate gameplay rejection counts.

### Maintenance/input-tax boundary

`tacticalContextKey` is caller-owned and coarse. Same-cell/same-role replacement is counted as rote only if the last accepted context fingerprint for that cell+role is unchanged.

A replacement after a material change in enemy mix, topology, reserve pressure, breach state or another relevant factor should receive a changed fingerprint and therefore not be mislabeled as busywork.

## Storybook playground

Adds `Arena/Interaction/Tower Observation`.

Two deterministic evidence-shape fixtures are shown:

### Legible first contact
- occupied rejection;
- camera-owned ignored gesture;
- first build at 4.2 s;
- two replacements, one before and one after tactical context changes;
- later upgrade.

### High-friction / rote maintenance
- occupied/protected/resource rejections;
- camera conflict;
- later first build;
- three same-cell/same-role replacements under unchanged context.

The story verifies:

- camera ignored vs rejection separation;
- first-build timing;
- rejected/ignored attempts before first build;
- camera conflict counting;
- unchanged-context replacement discrimination.

The illustrative numbers are not UX targets.

No analytics transport, persistence, player-identifying information, RAF, timer, Babylon scene, Worker, AudioContext, global listener or gameplay mutation is introduced.

## Scope

Relative to #117 head `0de9606e2bbdf1e917a28bca3a1e0487520cece0`:

- 2 commits ahead / 0 behind;
- 2 added files;
- no production call-site changes;
- no input/economy/tower mutation;
- no package/dependency changes;
- no frozen certification-head changes.

## Validation

Post-freeze draft. Later root + Storybook campaign should cover empty sessions, no successful build, non-monotonic timestamps, every #117 reason, ignored camera attempts, replacements with missing identities, changed-context replacements, malformed observer state, plus:

```sh
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

## Follow-up

After #95 characterization and the #112/#117 chain is certified, a minimal Babylon adapter may record local certification/user-study observations. Keep this observer downstream of authoritative interaction decisions; metrics must never feed back into gameplay authority.

This remains outside the frozen #92 campaign.