### PR TITLE
Add asymmetric victory evidence diagnostics

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/AsymmetricVictoryEvidence.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/AsymmetricVictoryEvidence.stories.ts
@@ -10,6 +10,7 @@ import { createLabShell } from "../../labTheme";
 type EvidenceArgs = {
   minimumCommitmentDisadvantage: number;
   minimumEconomicLeverage: number;
+  minimumEjectionShare: number;
   minimumNonDestructiveResolutionShare: number;
   minimumRouteDistanceAdded: number;
   minimumDelaySeconds: number;
@@ -130,6 +131,7 @@ function thresholdsFromArgs(args: EvidenceArgs): AsymmetricVictoryThresholds {
   return {
     minimumCommitmentDisadvantage: args.minimumCommitmentDisadvantage,
     minimumEconomicLeverage: args.minimumEconomicLeverage,
+    minimumEjectionShare: args.minimumEjectionShare,
     minimumNonDestructiveResolutionShare: args.minimumNonDestructiveResolutionShare,
     minimumRouteDistanceAdded: args.minimumRouteDistanceAdded,
     minimumDelaySeconds: args.minimumDelaySeconds,
@@ -170,6 +172,7 @@ function caseMarkup(testCase: EvidenceCase, thresholds: AsymmetricVictoryThresho
         <div><dt>Economic leverage</dt><dd>${formatRatio(result.economicLeverage)}</dd></div>
         <div><dt>Player net cost</dt><dd>${formatEnergy(result.playerNetCost)}</dd></div>
         <div><dt>Opponent net cost</dt><dd>${formatEnergy(result.opponentNetCost)}</dd></div>
+        <div><dt>Ejection share</dt><dd>${Math.round(result.ejectionShare * 100)}%</dd></div>
         <div><dt>Non-destructive share</dt><dd>${Math.round(result.nonDestructiveResolutionShare * 100)}%</dd></div>
         <div><dt>Breach rate</dt><dd>${Math.round(result.breachRate * 100)}%</dd></div>
         <div><dt>Route distance added</dt><dd>${Math.round(testCase.evidence.routeDistanceAdded)}</dd></div>
@@ -186,6 +189,7 @@ const meta = {
   args: {
     minimumCommitmentDisadvantage: 2,
     minimumEconomicLeverage: 2,
+    minimumEjectionShare: 0.3,
     minimumNonDestructiveResolutionShare: 0.5,
     minimumRouteDistanceAdded: 40,
     minimumDelaySeconds: 8,
@@ -197,6 +201,9 @@ const meta = {
     },
     minimumEconomicLeverage: {
       control: { type: "range", min: 1, max: 10, step: 0.25 }
+    },
+    minimumEjectionShare: {
+      control: { type: "range", min: 0, max: 1, step: 0.05 }
     },
     minimumNonDestructiveResolutionShare: {
       control: { type: "range", min: 0, max: 1, step: 0.05 }
@@ -314,6 +321,7 @@ const meta = {
       <dl class="evidence-thresholds" aria-label="Diagnostic thresholds">
         <div><dt>Commitment disadvantage</dt><dd>${args.minimumCommitmentDisadvantage.toFixed(2)}×</dd></div>
         <div><dt>Economic leverage</dt><dd>${args.minimumEconomicLeverage.toFixed(2)}×</dd></div>
+        <div><dt>Ejection share</dt><dd>${Math.round(args.minimumEjectionShare * 100)}%</dd></div>
         <div><dt>Non-destructive share</dt><dd>${Math.round(args.minimumNonDestructiveResolutionShare * 100)}%</dd></div>
         <div><dt>Route distance</dt><dd>${Math.round(args.minimumRouteDistanceAdded)}</dd></div>
         <div><dt>Delay</dt><dd>${Math.round(args.minimumDelaySeconds)} s</dd></div>

--- a/experiments/storybook/src/Foundations/Strategy/AsymmetricVictoryEvidence.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/AsymmetricVictoryEvidence.stories.ts
@@ -1,0 +1,352 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+  evaluateAsymmetricVictory,
+  type AsymmetricEncounterEvidence,
+  type AsymmetricVictoryThresholds
+} from "@defend/gameplay/asymmetricEncounterEvidence";
+import { createLabShell } from "../../labTheme";
+
+type EvidenceArgs = {
+  minimumCommitmentDisadvantage: number;
+  minimumEconomicLeverage: number;
+  minimumNonDestructiveResolutionShare: number;
+  minimumRouteDistanceAdded: number;
+  minimumDelaySeconds: number;
+  maximumBreachRate: number;
+};
+
+type EvidenceCase = {
+  id: string;
+  title: string;
+  premise: string;
+  evidence: AsymmetricEncounterEvidence;
+};
+
+const cases: EvidenceCase[] = [
+  {
+    id: "brute-force",
+    title: "Brute-force hold",
+    premise:
+      "The player survives, but does so by spending almost as much as the attacker and resolving the encounter mainly through direct destruction.",
+    evidence: {
+      playerSucceeded: true,
+      criticalAssetPreserved: true,
+      playerCommittedEnergy: 18000,
+      opponentCommittedEnergy: 27000,
+      playerOperatingCost: 0,
+      opponentOperatingCost: 1200,
+      playerRecoveredEnergy: 2500,
+      opponentRecoveredEnergy: 0,
+      playerInfrastructureLoss: 0,
+      opponentInfrastructureLoss: 0,
+      bodiesFaced: 3,
+      bodiesDestroyed: 3,
+      bodiesEjected: 0,
+      bodiesExpired: 0,
+      bodiesBreached: 0,
+      routeDistanceAdded: 4,
+      delaySeconds: 2
+    }
+  },
+  {
+    id: "barrier-delay",
+    title: "Cheap barrier, expensive failure",
+    premise:
+      "A low-cost barrier lengthens the route until finite-life decay and mothership operating pressure make a much larger commitment unprofitable.",
+    evidence: {
+      playerSucceeded: true,
+      criticalAssetPreserved: true,
+      playerCommittedEnergy: 3000,
+      opponentCommittedEnergy: 27000,
+      playerOperatingCost: 0,
+      opponentOperatingCost: 4200,
+      playerRecoveredEnergy: 3600,
+      opponentRecoveredEnergy: 0,
+      playerInfrastructureLoss: 0,
+      opponentInfrastructureLoss: 0,
+      bodiesFaced: 3,
+      bodiesDestroyed: 0,
+      bodiesEjected: 0,
+      bodiesExpired: 3,
+      bodiesBreached: 0,
+      routeDistanceAdded: 96,
+      delaySeconds: 19
+    }
+  },
+  {
+    id: "edge-ejection",
+    title: "Titan edge ejection",
+    premise:
+      "The defender cannot win a damage race against the heavy commitment, but one positional impulse converts the attacker's mass and trajectory into an ejection.",
+    evidence: {
+      playerSucceeded: true,
+      criticalAssetPreserved: true,
+      playerCommittedEnergy: 9000,
+      opponentCommittedEnergy: 30000,
+      playerOperatingCost: 0,
+      opponentOperatingCost: 1800,
+      playerRecoveredEnergy: 1200,
+      opponentRecoveredEnergy: 0,
+      playerInfrastructureLoss: 0,
+      opponentInfrastructureLoss: 0,
+      bodiesFaced: 2,
+      bodiesDestroyed: 0,
+      bodiesEjected: 1,
+      bodiesExpired: 1,
+      bodiesBreached: 0,
+      routeDistanceAdded: 18,
+      delaySeconds: 7
+    }
+  },
+  {
+    id: "pyrrhic-breach",
+    title: "Pyrrhic breach",
+    premise:
+      "A raider physically reaches the silo, but extraction is too small relative to commitment and operating cost to count as strategic success.",
+    evidence: {
+      playerSucceeded: false,
+      criticalAssetPreserved: true,
+      playerCommittedEnergy: 27000,
+      opponentCommittedEnergy: 18000,
+      playerOperatingCost: 5200,
+      opponentOperatingCost: 0,
+      playerRecoveredEnergy: 8000,
+      opponentRecoveredEnergy: 3200,
+      playerInfrastructureLoss: 0,
+      opponentInfrastructureLoss: 3000,
+      bodiesFaced: 1,
+      bodiesDestroyed: 0,
+      bodiesEjected: 0,
+      bodiesExpired: 0,
+      bodiesBreached: 1,
+      routeDistanceAdded: 0,
+      delaySeconds: 0
+    }
+  }
+];
+
+function thresholdsFromArgs(args: EvidenceArgs): AsymmetricVictoryThresholds {
+  return {
+    minimumCommitmentDisadvantage: args.minimumCommitmentDisadvantage,
+    minimumEconomicLeverage: args.minimumEconomicLeverage,
+    minimumNonDestructiveResolutionShare: args.minimumNonDestructiveResolutionShare,
+    minimumRouteDistanceAdded: args.minimumRouteDistanceAdded,
+    minimumDelaySeconds: args.minimumDelaySeconds,
+    maximumBreachRate: args.maximumBreachRate
+  };
+}
+
+function formatEnergy(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function formatRatio(value: number): string {
+  if (value >= 1000) return ">999×";
+  return `${value.toFixed(2)}×`;
+}
+
+function caseMarkup(testCase: EvidenceCase, thresholds: AsymmetricVictoryThresholds): string {
+  const result = evaluateAsymmetricVictory(testCase.evidence, thresholds);
+  const state = result.qualifies ? "asymmetric victory" : "ordinary / failed";
+  const axes = result.axes.length > 0 ? result.axes.join(" · ") : "none";
+
+  return `
+    <article
+      class="evidence-card evidence-card--${result.qualifies ? "qualified" : "ordinary"}"
+      data-case="${testCase.id}"
+      data-qualifies="${String(result.qualifies)}"
+    >
+      <header class="evidence-card__header">
+        <div>
+          <p class="evidence-card__state">${state}</p>
+          <h2>${testCase.title}</h2>
+        </div>
+        <strong class="evidence-card__ratio">${formatRatio(result.commitmentDisadvantage)}</strong>
+      </header>
+      <p class="evidence-card__premise">${testCase.premise}</p>
+      <dl class="evidence-card__metrics">
+        <div><dt>Commitment disadvantage</dt><dd>${formatRatio(result.commitmentDisadvantage)}</dd></div>
+        <div><dt>Economic leverage</dt><dd>${formatRatio(result.economicLeverage)}</dd></div>
+        <div><dt>Player net cost</dt><dd>${formatEnergy(result.playerNetCost)}</dd></div>
+        <div><dt>Opponent net cost</dt><dd>${formatEnergy(result.opponentNetCost)}</dd></div>
+        <div><dt>Non-destructive share</dt><dd>${Math.round(result.nonDestructiveResolutionShare * 100)}%</dd></div>
+        <div><dt>Breach rate</dt><dd>${Math.round(result.breachRate * 100)}%</dd></div>
+        <div><dt>Route distance added</dt><dd>${Math.round(testCase.evidence.routeDistanceAdded)}</dd></div>
+        <div><dt>Delay created</dt><dd>${testCase.evidence.delaySeconds.toFixed(1)} s</dd></div>
+      </dl>
+      <p class="evidence-card__axes"><span>Observed leverage</span>${axes}</p>
+    </article>
+  `;
+}
+
+const meta = {
+  title: "Foundations/Strategy/Asymmetric Victory Evidence",
+  tags: ["test", "visual"],
+  args: {
+    minimumCommitmentDisadvantage: 2,
+    minimumEconomicLeverage: 2,
+    minimumNonDestructiveResolutionShare: 0.5,
+    minimumRouteDistanceAdded: 40,
+    minimumDelaySeconds: 8,
+    maximumBreachRate: 0.25
+  },
+  argTypes: {
+    minimumCommitmentDisadvantage: {
+      control: { type: "range", min: 1, max: 6, step: 0.25 }
+    },
+    minimumEconomicLeverage: {
+      control: { type: "range", min: 1, max: 10, step: 0.25 }
+    },
+    minimumNonDestructiveResolutionShare: {
+      control: { type: "range", min: 0, max: 1, step: 0.05 }
+    },
+    minimumRouteDistanceAdded: {
+      control: { type: "range", min: 0, max: 160, step: 5 }
+    },
+    minimumDelaySeconds: {
+      control: { type: "range", min: 0, max: 30, step: 1 }
+    },
+    maximumBreachRate: {
+      control: { type: "range", min: 0, max: 1, step: 0.05 }
+    }
+  },
+  render: (args: EvidenceArgs) => {
+    const thresholds = thresholdsFromArgs(args);
+    const shell = createLabShell(
+      "Foundations / strategy",
+      "Asymmetric victory evidence",
+      "A diagnostic surface for comparing measured encounter outcomes. It identifies high-leverage wins without creating an underdog reward or predicting physics; live fixtures can later supply these measurements."
+    );
+
+    shell.frame.innerHTML = `
+      <style>
+        .evidence-thresholds {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+          gap: 1px;
+          margin-bottom: 18px;
+          background: rgba(215, 164, 108, 0.14);
+          border: 1px solid rgba(215, 164, 108, 0.14);
+        }
+        .evidence-thresholds > div {
+          padding: 12px 14px;
+          background: rgba(18, 4, 31, 0.92);
+        }
+        .evidence-thresholds dt,
+        .evidence-card__metrics dt,
+        .evidence-card__axes span {
+          color: rgba(244, 237, 247, 0.5);
+          font-size: 11px;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+        }
+        .evidence-thresholds dd {
+          margin: 3px 0 0;
+          color: #e4b980;
+          font-variant-numeric: tabular-nums;
+        }
+        .evidence-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+          gap: 14px;
+        }
+        .evidence-card {
+          border: 1px solid rgba(215, 164, 108, 0.16);
+          padding: 18px;
+          background: rgba(18, 4, 31, 0.86);
+        }
+        .evidence-card--qualified {
+          border-color: rgba(228, 185, 128, 0.55);
+          box-shadow: inset 3px 0 0 rgba(228, 185, 128, 0.72);
+        }
+        .evidence-card__header {
+          display: flex;
+          justify-content: space-between;
+          gap: 18px;
+          align-items: start;
+        }
+        .evidence-card h2 {
+          margin: 3px 0 0;
+          font-size: 18px;
+          font-weight: 560;
+        }
+        .evidence-card__state {
+          margin: 0;
+          color: #d7a46c;
+          font-size: 10px;
+          text-transform: uppercase;
+          letter-spacing: 0.12em;
+        }
+        .evidence-card__ratio {
+          color: #e4b980;
+          font-size: 20px;
+          font-variant-numeric: tabular-nums;
+        }
+        .evidence-card__premise {
+          min-height: 66px;
+          margin: 14px 0 16px;
+          color: rgba(244, 237, 247, 0.66);
+        }
+        .evidence-card__metrics {
+          display: grid;
+          grid-template-columns: 1fr auto;
+          gap: 7px 12px;
+          margin: 0;
+        }
+        .evidence-card__metrics > div {
+          display: contents;
+        }
+        .evidence-card__metrics dd {
+          margin: 0;
+          text-align: right;
+          font-variant-numeric: tabular-nums;
+        }
+        .evidence-card__axes {
+          display: grid;
+          gap: 4px;
+          margin: 16px 0 0;
+          padding-top: 12px;
+          border-top: 1px solid rgba(215, 164, 108, 0.14);
+          color: #e4b980;
+        }
+      </style>
+      <dl class="evidence-thresholds" aria-label="Diagnostic thresholds">
+        <div><dt>Commitment disadvantage</dt><dd>${args.minimumCommitmentDisadvantage.toFixed(2)}×</dd></div>
+        <div><dt>Economic leverage</dt><dd>${args.minimumEconomicLeverage.toFixed(2)}×</dd></div>
+        <div><dt>Non-destructive share</dt><dd>${Math.round(args.minimumNonDestructiveResolutionShare * 100)}%</dd></div>
+        <div><dt>Route distance</dt><dd>${Math.round(args.minimumRouteDistanceAdded)}</dd></div>
+        <div><dt>Delay</dt><dd>${Math.round(args.minimumDelaySeconds)} s</dd></div>
+        <div><dt>Maximum breach rate</dt><dd>${Math.round(args.maximumBreachRate * 100)}%</dd></div>
+      </dl>
+      <section class="evidence-grid" aria-label="Encounter evidence comparisons">
+        ${cases.map(testCase => caseMarkup(testCase, thresholds)).join("")}
+      </section>
+    `;
+
+    return shell.root;
+  }
+} satisfies Meta<EvidenceArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ComparativeEvidence: Story = {
+  play: async ({ canvasElement }) => {
+    const barrier = canvasElement.querySelector<HTMLElement>("[data-case='barrier-delay']");
+    const edge = canvasElement.querySelector<HTMLElement>("[data-case='edge-ejection']");
+    const bruteForce = canvasElement.querySelector<HTMLElement>("[data-case='brute-force']");
+    const pyrrhic = canvasElement.querySelector<HTMLElement>("[data-case='pyrrhic-breach']");
+
+    await expect(barrier).not.toBeNull();
+    await expect(edge).not.toBeNull();
+    await expect(bruteForce).not.toBeNull();
+    await expect(pyrrhic).not.toBeNull();
+    if (!barrier || !edge || !bruteForce || !pyrrhic) return;
+
+    await expect(barrier).toHaveAttribute("data-qualifies", "true");
+    await expect(edge).toHaveAttribute("data-qualifies", "true");
+    await expect(bruteForce).toHaveAttribute("data-qualifies", "false");
+    await expect(pyrrhic).toHaveAttribute("data-qualifies", "false");
+  }
+};

--- a/src/js/gameplay/asymmetricEncounterEvidence.ts
+++ b/src/js/gameplay/asymmetricEncounterEvidence.ts
@@ -28,6 +28,7 @@ interface AsymmetricEncounterEvidence {
 interface AsymmetricVictoryThresholds {
 	minimumCommitmentDisadvantage: number;
 	minimumEconomicLeverage: number;
+	minimumEjectionShare: number;
 	minimumNonDestructiveResolutionShare: number;
 	minimumRouteDistanceAdded: number;
 	minimumDelaySeconds: number;
@@ -42,6 +43,7 @@ interface AsymmetricVictoryEvaluation {
 	playerNetCost: number;
 	opponentNetCost: number;
 	economicLeverage: number;
+	ejectionShare: number;
 	nonDestructiveResolutionShare: number;
 	breachRate: number;
 	resolvedBodies: number;
@@ -80,6 +82,10 @@ function fraction(numerator: number, denominator: number): number {
 		return 0;
 	}
 	return Math.max(0, Math.min(1, nonnegative(numerator) / safeDenominator));
+}
+
+function boundedFractionThreshold(value: number): number {
+	return Math.max(0, Math.min(1, finiteScalar(value)));
 }
 
 function encounterGrossCost(
@@ -148,6 +154,7 @@ function evaluateAsymmetricVictory(
 			nonnegative(evidence.bodiesExpired) +
 			nonnegative(evidence.bodiesBreached)
 	);
+	const ejectionShare = fraction(evidence.bodiesEjected, resolvedBodies);
 	const nonDestructiveResolutionShare = fraction(
 		nonnegative(evidence.bodiesEjected) + nonnegative(evidence.bodiesExpired),
 		resolvedBodies
@@ -160,7 +167,7 @@ function evaluateAsymmetricVictory(
 	if (economicLeverage >= nonnegative(thresholds.minimumEconomicLeverage)) {
 		axes.push("economic");
 	}
-	if (nonnegative(evidence.bodiesEjected) > 0) {
+	if (ejectionShare >= boundedFractionThreshold(thresholds.minimumEjectionShare)) {
 		axes.push("displacement");
 	}
 	if (delaySeconds >= nonnegative(thresholds.minimumDelaySeconds)) {
@@ -169,7 +176,10 @@ function evaluateAsymmetricVictory(
 	if (routeDistanceAdded >= nonnegative(thresholds.minimumRouteDistanceAdded)) {
 		axes.push("geometric");
 	}
-	if (nonDestructiveResolutionShare >= nonnegative(thresholds.minimumNonDestructiveResolutionShare)) {
+	if (
+		nonDestructiveResolutionShare >=
+		boundedFractionThreshold(thresholds.minimumNonDestructiveResolutionShare)
+	) {
 		axes.push("attrition");
 	}
 
@@ -178,10 +188,7 @@ function evaluateAsymmetricVictory(
 		1,
 		nonnegative(thresholds.minimumCommitmentDisadvantage)
 	);
-	const breachThreshold = Math.max(
-		0,
-		Math.min(1, finiteScalar(thresholds.maximumBreachRate, 1))
-	);
+	const breachThreshold = boundedFractionThreshold(thresholds.maximumBreachRate);
 
 	return {
 		qualifies:
@@ -196,6 +203,7 @@ function evaluateAsymmetricVictory(
 		playerNetCost,
 		opponentNetCost,
 		economicLeverage,
+		ejectionShare,
 		nonDestructiveResolutionShare,
 		breachRate,
 		resolvedBodies,

--- a/src/js/gameplay/asymmetricEncounterEvidence.ts
+++ b/src/js/gameplay/asymmetricEncounterEvidence.ts
@@ -1,0 +1,214 @@
+type AsymmetricVictoryAxis =
+	| "economic"
+	| "displacement"
+	| "temporal"
+	| "geometric"
+	| "attrition";
+
+interface AsymmetricEncounterEvidence {
+	playerSucceeded: boolean;
+	criticalAssetPreserved: boolean;
+	playerCommittedEnergy: number;
+	opponentCommittedEnergy: number;
+	playerOperatingCost: number;
+	opponentOperatingCost: number;
+	playerRecoveredEnergy: number;
+	opponentRecoveredEnergy: number;
+	playerInfrastructureLoss: number;
+	opponentInfrastructureLoss: number;
+	bodiesFaced: number;
+	bodiesDestroyed: number;
+	bodiesEjected: number;
+	bodiesExpired: number;
+	bodiesBreached: number;
+	routeDistanceAdded: number;
+	delaySeconds: number;
+}
+
+interface AsymmetricVictoryThresholds {
+	minimumCommitmentDisadvantage: number;
+	minimumEconomicLeverage: number;
+	minimumNonDestructiveResolutionShare: number;
+	minimumRouteDistanceAdded: number;
+	minimumDelaySeconds: number;
+	maximumBreachRate: number;
+}
+
+interface AsymmetricVictoryEvaluation {
+	qualifies: boolean;
+	commitmentDisadvantage: number;
+	playerGrossCost: number;
+	opponentGrossCost: number;
+	playerNetCost: number;
+	opponentNetCost: number;
+	economicLeverage: number;
+	nonDestructiveResolutionShare: number;
+	breachRate: number;
+	resolvedBodies: number;
+	axes: AsymmetricVictoryAxis[];
+}
+
+const MAX_EVIDENCE_SCALAR = 1e100;
+const MIN_RATIO_DENOMINATOR = 1;
+
+function finiteScalar(value: number, fallback = 0): number {
+	if (value !== value) {
+		return fallback;
+	}
+	if (value > MAX_EVIDENCE_SCALAR) {
+		return MAX_EVIDENCE_SCALAR;
+	}
+	if (value < -MAX_EVIDENCE_SCALAR) {
+		return -MAX_EVIDENCE_SCALAR;
+	}
+	return value;
+}
+
+function nonnegative(value: number): number {
+	return Math.max(0, finiteScalar(value));
+}
+
+function boundedRatio(numerator: number, denominator: number): number {
+	const safeNumerator = nonnegative(numerator);
+	const safeDenominator = Math.max(MIN_RATIO_DENOMINATOR, nonnegative(denominator));
+	return Math.min(MAX_EVIDENCE_SCALAR, safeNumerator / safeDenominator);
+}
+
+function fraction(numerator: number, denominator: number): number {
+	const safeDenominator = nonnegative(denominator);
+	if (safeDenominator <= 0) {
+		return 0;
+	}
+	return Math.max(0, Math.min(1, nonnegative(numerator) / safeDenominator));
+}
+
+function encounterGrossCost(
+	committedEnergy: number,
+	operatingCost: number,
+	infrastructureLoss: number
+): number {
+	return (
+		nonnegative(committedEnergy) +
+		nonnegative(operatingCost) +
+		nonnegative(infrastructureLoss)
+	);
+}
+
+function encounterNetCost(
+	committedEnergy: number,
+	operatingCost: number,
+	infrastructureLoss: number,
+	recoveredEnergy: number
+): number {
+	return Math.max(
+		0,
+		encounterGrossCost(committedEnergy, operatingCost, infrastructureLoss) -
+			nonnegative(recoveredEnergy)
+	);
+}
+
+function evaluateAsymmetricVictory(
+	evidence: AsymmetricEncounterEvidence,
+	thresholds: AsymmetricVictoryThresholds
+): AsymmetricVictoryEvaluation {
+	const playerCommittedEnergy = nonnegative(evidence.playerCommittedEnergy);
+	const opponentCommittedEnergy = nonnegative(evidence.opponentCommittedEnergy);
+	const playerGrossCost = encounterGrossCost(
+		playerCommittedEnergy,
+		evidence.playerOperatingCost,
+		evidence.playerInfrastructureLoss
+	);
+	const opponentGrossCost = encounterGrossCost(
+		opponentCommittedEnergy,
+		evidence.opponentOperatingCost,
+		evidence.opponentInfrastructureLoss
+	);
+	const playerNetCost = encounterNetCost(
+		playerCommittedEnergy,
+		evidence.playerOperatingCost,
+		evidence.playerInfrastructureLoss,
+		evidence.playerRecoveredEnergy
+	);
+	const opponentNetCost = encounterNetCost(
+		opponentCommittedEnergy,
+		evidence.opponentOperatingCost,
+		evidence.opponentInfrastructureLoss,
+		evidence.opponentRecoveredEnergy
+	);
+	const commitmentDisadvantage = boundedRatio(
+		opponentCommittedEnergy,
+		playerCommittedEnergy
+	);
+	const economicLeverage = boundedRatio(opponentNetCost, playerGrossCost);
+	const bodiesFaced = nonnegative(evidence.bodiesFaced);
+	const resolvedBodies = Math.min(
+		bodiesFaced,
+		nonnegative(evidence.bodiesDestroyed) +
+			nonnegative(evidence.bodiesEjected) +
+			nonnegative(evidence.bodiesExpired) +
+			nonnegative(evidence.bodiesBreached)
+	);
+	const nonDestructiveResolutionShare = fraction(
+		nonnegative(evidence.bodiesEjected) + nonnegative(evidence.bodiesExpired),
+		resolvedBodies
+	);
+	const breachRate = fraction(evidence.bodiesBreached, bodiesFaced);
+	const routeDistanceAdded = nonnegative(evidence.routeDistanceAdded);
+	const delaySeconds = nonnegative(evidence.delaySeconds);
+
+	const axes: AsymmetricVictoryAxis[] = [];
+	if (economicLeverage >= nonnegative(thresholds.minimumEconomicLeverage)) {
+		axes.push("economic");
+	}
+	if (nonnegative(evidence.bodiesEjected) > 0) {
+		axes.push("displacement");
+	}
+	if (delaySeconds >= nonnegative(thresholds.minimumDelaySeconds)) {
+		axes.push("temporal");
+	}
+	if (routeDistanceAdded >= nonnegative(thresholds.minimumRouteDistanceAdded)) {
+		axes.push("geometric");
+	}
+	if (nonDestructiveResolutionShare >= nonnegative(thresholds.minimumNonDestructiveResolutionShare)) {
+		axes.push("attrition");
+	}
+
+	const hasLeverageSignal = axes.length > 0;
+	const commitmentThreshold = Math.max(
+		1,
+		nonnegative(thresholds.minimumCommitmentDisadvantage)
+	);
+	const breachThreshold = Math.max(
+		0,
+		Math.min(1, finiteScalar(thresholds.maximumBreachRate, 1))
+	);
+
+	return {
+		qualifies:
+			evidence.playerSucceeded === true &&
+			evidence.criticalAssetPreserved === true &&
+			commitmentDisadvantage >= commitmentThreshold &&
+			breachRate <= breachThreshold &&
+			hasLeverageSignal,
+		commitmentDisadvantage,
+		playerGrossCost,
+		opponentGrossCost,
+		playerNetCost,
+		opponentNetCost,
+		economicLeverage,
+		nonDestructiveResolutionShare,
+		breachRate,
+		resolvedBodies,
+		axes
+	};
+}
+
+export {
+	AsymmetricEncounterEvidence,
+	AsymmetricVictoryAxis,
+	AsymmetricVictoryEvaluation,
+	AsymmetricVictoryThresholds,
+	encounterGrossCost,
+	encounterNetCost,
+	evaluateAsymmetricVictory
+};


### PR DESCRIPTION
Refs #113, #72, #73, #79, #92

## Purpose

Turn #113's asymmetric-victory design principle into a small deterministic evidence layer without changing live gameplay, wave scheduling, physics, AI, balance, rewards, or the frozen #92 certification heads.

The diagnostic answers a narrow question after an encounter has produced measured outcomes: did the player succeed from a materially lower commitment by exploiting economic, displacement, temporal, geometric, or non-destructive attrition leverage?

It does **not** predict physics and must not become an arbitrary underdog reward.

## Pure contract

Adds `src/js/gameplay/asymmetricEncounterEvidence.ts`.

Inputs are observed/caller-supplied encounter evidence:

- player/opponent committed energy;
- operating cost;
- recovery/extraction represented as recovered energy;
- infrastructure loss;
- bodies faced/destroyed/ejected/expired/breached;
- route distance added;
- delay created;
- strategic success / critical-asset preservation.

Caller-owned thresholds define what qualifies as sufficiently asymmetric for experiments. No final balance constants are baked into production.

Outputs include:

- commitment disadvantage;
- gross and net costs for both sides;
- economic leverage;
- non-destructive resolution share;
- breach rate;
- observed leverage axes;
- diagnostic `qualifies` state.

Economic leverage intentionally compares opponent net loss with the player's **gross committed cost**, not player net cost after recovery. This avoids artificial infinite leverage when successful recovery drives player net cost to zero.

## Storybook fixture

Adds `Foundations/Strategy/Asymmetric Victory Evidence` with four deterministic comparisons:

1. brute-force hold — survives, but without enough commitment asymmetry/leverage to qualify;
2. cheap barrier / expensive failure — 3k intervention versus 27k attack, resolved through route extension, delay and expiry;
3. titan edge ejection — lower defensive commitment converts mass/trajectory into displacement;
4. Pyrrhic breach — physical silo contact but negative strategic/economic outcome, explicitly not treated as victory.

Controls expose all diagnostic thresholds. The play assertion verifies the two intended leverage cases qualify while brute force and the Pyrrhic breach do not.

The fixture creates no RAF, timer, Babylon scene, Worker, AudioContext or production mutation.

## Concurrency / scope

Created on an isolated branch. `master` advanced repeatedly while this was prepared; comparison still shows exactly two added files and no overlapping edits. Do not insert this branch into the frozen #95/#97/#105 certification heads.

## Validation required

Keep draft until a later post-freeze campaign records:

```sh
npm run lint
npm run build
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Also exercise threshold extremes and malformed numeric inputs, and confirm all diagnostic outputs remain finite/bounded.

After #72/#86 live physics fixtures exist, replace illustrative Storybook evidence with captured/measured encounter results while keeping this contract downstream of simulation authority.