### PR TITLE
Add deterministic defense interaction legibility contract

### DIFF
--- a/experiments/storybook/src/Foundations/Interaction/DefenseInteraction.stories.ts
+++ b/experiments/storybook/src/Foundations/Interaction/DefenseInteraction.stories.ts
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/html-vite";
 import { expect, userEvent } from "storybook/test";
 import {
   resolveDefenseInteraction,
+  type DefenseInteractionAction,
+  type DefenseInteractionRejection,
   type DefenseInteractionRequest,
   type DefenseInteractionResolution
 } from "@defend/gameplay/defenseInteraction";
@@ -12,6 +14,8 @@ type Scenario = {
   title: string;
   note: string;
   request: DefenseInteractionRequest;
+  expectedAction: DefenseInteractionAction;
+  expectedRejection: DefenseInteractionRejection;
 };
 
 const scenarios: Scenario[] = [
@@ -27,7 +31,41 @@ const scenarios: Scenario[] = [
       terrainValid: true,
       protectedTarget: false,
       occupied: false
-    }
+    },
+    expectedAction: "place",
+    expectedRejection: "none"
+  },
+  {
+    id: "place-invalid-terrain",
+    title: "Invalid terrain",
+    note: "A world target exists, but the surface is outside the buildable terrain contract.",
+    request: {
+      kind: "placement",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      terrainValid: false,
+      protectedTarget: false,
+      occupied: false
+    },
+    expectedAction: "none",
+    expectedRejection: "invalid-terrain"
+  },
+  {
+    id: "place-protected",
+    title: "Protected core",
+    note: "The target is buildable terrain but belongs to protected/core space.",
+    request: {
+      kind: "placement",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      terrainValid: true,
+      protectedTarget: true,
+      occupied: false
+    },
+    expectedAction: "none",
+    expectedRejection: "protected-target"
   },
   {
     id: "place-occupied",
@@ -41,21 +79,9 @@ const scenarios: Scenario[] = [
       terrainValid: true,
       protectedTarget: false,
       occupied: true
-    }
-  },
-  {
-    id: "place-protected",
-    title: "Protected core",
-    note: "The target exists but belongs to protected/core space.",
-    request: {
-      kind: "placement",
-      gestureOwner: "world",
-      targetAvailable: true,
-      affordable: true,
-      terrainValid: true,
-      protectedTarget: true,
-      occupied: false
-    }
+    },
+    expectedAction: "none",
+    expectedRejection: "occupied"
   },
   {
     id: "place-unaffordable",
@@ -69,7 +95,9 @@ const scenarios: Scenario[] = [
       terrainValid: true,
       protectedTarget: false,
       occupied: false
-    }
+    },
+    expectedAction: "none",
+    expectedRejection: "unaffordable"
   },
   {
     id: "camera-gesture",
@@ -83,7 +111,25 @@ const scenarios: Scenario[] = [
       terrainValid: true,
       protectedTarget: false,
       occupied: false
-    }
+    },
+    expectedAction: "none",
+    expectedRejection: "camera-gesture"
+  },
+  {
+    id: "stale-target",
+    title: "Stale target",
+    note: "The selected world object disappeared or became unavailable before commitment.",
+    request: {
+      kind: "tower",
+      gestureOwner: "world",
+      targetAvailable: false,
+      affordable: true,
+      currentTowerLevel: 2,
+      maxTowerLevel: 3,
+      maxTowerAction: "reject"
+    },
+    expectedAction: "none",
+    expectedRejection: "stale-target"
   },
   {
     id: "tower-upgrade",
@@ -97,7 +143,25 @@ const scenarios: Scenario[] = [
       currentTowerLevel: 1,
       maxTowerLevel: 3,
       maxTowerAction: "reject"
-    }
+    },
+    expectedAction: "upgrade",
+    expectedRejection: "none"
+  },
+  {
+    id: "tower-unaffordable",
+    title: "Upgrade lacks energy",
+    note: "A valid tower remains unchanged when the requested upgrade is unaffordable.",
+    request: {
+      kind: "tower",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: false,
+      currentTowerLevel: 2,
+      maxTowerLevel: 3,
+      maxTowerAction: "reject"
+    },
+    expectedAction: "none",
+    expectedRejection: "unaffordable"
   },
   {
     id: "tower-max",
@@ -111,12 +175,14 @@ const scenarios: Scenario[] = [
       currentTowerLevel: 3,
       maxTowerLevel: 3,
       maxTowerAction: "reject"
-    }
+    },
+    expectedAction: "none",
+    expectedRejection: "max-state"
   },
   {
     id: "tower-refresh",
     title: "Explicit refresh policy",
-    note: "If a future design intentionally refreshes a max-level tower, it must be represented as a distinct action.",
+    note: "If a future design intentionally refreshes a max-level tower, it is represented as a distinct action.",
     request: {
       kind: "tower",
       gestureOwner: "world",
@@ -125,7 +191,25 @@ const scenarios: Scenario[] = [
       currentTowerLevel: 3,
       maxTowerLevel: 3,
       maxTowerAction: "refresh"
-    }
+    },
+    expectedAction: "refresh",
+    expectedRejection: "none"
+  },
+  {
+    id: "tower-invalid-state",
+    title: "Invalid tower state",
+    note: "Malformed or stale semantic tower levels are rejected instead of being guessed from presentation data.",
+    request: {
+      kind: "tower",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      currentTowerLevel: 4,
+      maxTowerLevel: 3,
+      maxTowerAction: "reject"
+    },
+    expectedAction: "none",
+    expectedRejection: "invalid-tower-state"
   }
 ];
 
@@ -141,6 +225,7 @@ function describeResolution(resolution: DefenseInteractionResolution): string {
 function scenarioMarkup(scenario: Scenario): string {
   const resolution = resolveDefenseInteraction(scenario.request);
   const outcomeClass = resolution.accepted ? "interaction-card--accepted" : "interaction-card--rejected";
+  const outcomeWord = resolution.accepted ? "Accepted" : "Rejected";
   return `
     <button
       class="interaction-card ${outcomeClass}"
@@ -149,6 +234,7 @@ function scenarioMarkup(scenario: Scenario): string {
       data-action="${resolution.action}"
       data-rejection="${resolution.rejection}"
     >
+      <span class="interaction-card__outcome">${outcomeWord}</span>
       <span class="interaction-card__title">${scenario.title}</span>
       <span class="interaction-card__note">${scenario.note}</span>
       <span class="interaction-card__result">${describeResolution(resolution)}</span>
@@ -170,12 +256,13 @@ const meta = {
       <style>
         .interaction-layout { display:grid; grid-template-columns:minmax(0,1.35fr) minmax(260px,.65fr); gap:16px; }
         .interaction-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:10px; }
-        .interaction-card { text-align:left; border:1px solid rgba(228,185,128,.26); background:rgba(17,13,20,.8); color:inherit; border-radius:10px; padding:14px; cursor:pointer; min-height:132px; }
+        .interaction-card { text-align:left; border:1px solid rgba(228,185,128,.26); background:rgba(17,13,20,.8); color:inherit; border-radius:10px; padding:14px; cursor:pointer; min-height:148px; }
         .interaction-card:hover,.interaction-card:focus-visible { border-color:rgba(244,237,247,.85); outline:none; }
         .interaction-card--accepted { box-shadow:inset 3px 0 0 rgba(133,220,194,.7); }
         .interaction-card--rejected { box-shadow:inset 3px 0 0 rgba(228,185,128,.62); }
         .interaction-card--selected { border-color:#f4edf7; background:rgba(228,185,128,.1); }
-        .interaction-card__title,.interaction-card__note,.interaction-card__result { display:block; }
+        .interaction-card__outcome,.interaction-card__title,.interaction-card__note,.interaction-card__result { display:block; }
+        .interaction-card__outcome { text-transform:uppercase; letter-spacing:.12em; font-size:.68rem; opacity:.62; margin-bottom:5px; }
         .interaction-card__title { font-weight:700; margin-bottom:7px; }
         .interaction-card__note { opacity:.72; font-size:.88rem; line-height:1.35; }
         .interaction-card__result { margin-top:12px; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.8rem; }
@@ -228,34 +315,19 @@ type Story = StoryObj<typeof meta>;
 export const RejectionAndActionMatrix: Story = {
   play: async ({ canvasElement }) => {
     const reason = canvasElement.querySelector<HTMLElement>("[data-selected-reason]");
-    const occupied = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='place-occupied']");
-    const unaffordable = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='place-unaffordable']");
-    const camera = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='camera-gesture']");
-    const maxTower = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='tower-max']");
-    const refresh = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='tower-refresh']");
-
     await expect(reason).not.toBeNull();
-    await expect(occupied).not.toBeNull();
-    await expect(unaffordable).not.toBeNull();
-    await expect(camera).not.toBeNull();
-    await expect(maxTower).not.toBeNull();
-    await expect(refresh).not.toBeNull();
-    if (!reason || !occupied || !unaffordable || !camera || !maxTower || !refresh) return;
+    if (!reason) return;
 
-    await userEvent.click(occupied);
-    await expect(reason).toHaveTextContent("rejection=occupied");
+    for (const scenario of scenarios) {
+      const card = canvasElement.querySelector<HTMLButtonElement>(`[data-scenario='${scenario.id}']`);
+      await expect(card).not.toBeNull();
+      if (!card) return;
 
-    await userEvent.click(unaffordable);
-    await expect(reason).toHaveTextContent("rejection=unaffordable");
-
-    await userEvent.click(camera);
-    await expect(reason).toHaveTextContent("rejection=camera-gesture");
-
-    await userEvent.click(maxTower);
-    await expect(reason).toHaveTextContent("rejection=max-state");
-
-    await userEvent.click(refresh);
-    await expect(reason).toHaveTextContent("action=refresh");
-    await expect(reason).toHaveTextContent("rejection=none");
+      await expect(card).toHaveAttribute("data-action", scenario.expectedAction);
+      await expect(card).toHaveAttribute("data-rejection", scenario.expectedRejection);
+      await userEvent.click(card);
+      await expect(reason).toHaveTextContent(`action=${scenario.expectedAction}`);
+      await expect(reason).toHaveTextContent(`rejection=${scenario.expectedRejection}`);
+    }
   }
 };

--- a/experiments/storybook/src/Foundations/Interaction/DefenseInteraction.stories.ts
+++ b/experiments/storybook/src/Foundations/Interaction/DefenseInteraction.stories.ts
@@ -1,0 +1,261 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect, userEvent } from "storybook/test";
+import {
+  resolveDefenseInteraction,
+  type DefenseInteractionRequest,
+  type DefenseInteractionResolution
+} from "@defend/gameplay/defenseInteraction";
+import { createLabShell } from "../../labTheme";
+
+type Scenario = {
+  id: string;
+  title: string;
+  note: string;
+  request: DefenseInteractionRequest;
+};
+
+const scenarios: Scenario[] = [
+  {
+    id: "place-valid",
+    title: "Valid placement",
+    note: "World-owned gesture, valid terrain, empty cell, sufficient energy.",
+    request: {
+      kind: "placement",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      terrainValid: true,
+      protectedTarget: false,
+      occupied: false
+    }
+  },
+  {
+    id: "place-occupied",
+    title: "Occupied cell",
+    note: "Placement resolves to an occupied location and must explain the rejection.",
+    request: {
+      kind: "placement",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      terrainValid: true,
+      protectedTarget: false,
+      occupied: true
+    }
+  },
+  {
+    id: "place-protected",
+    title: "Protected core",
+    note: "The target exists but belongs to protected/core space.",
+    request: {
+      kind: "placement",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      terrainValid: true,
+      protectedTarget: true,
+      occupied: false
+    }
+  },
+  {
+    id: "place-unaffordable",
+    title: "Insufficient energy",
+    note: "Affordability is supplied by the caller so #109 can change its boundary independently.",
+    request: {
+      kind: "placement",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: false,
+      terrainValid: true,
+      protectedTarget: false,
+      occupied: false
+    }
+  },
+  {
+    id: "camera-gesture",
+    title: "Camera owns gesture",
+    note: "Orbit/zoom won arbitration; placement must not look like a mysterious ignored tap.",
+    request: {
+      kind: "placement",
+      gestureOwner: "camera",
+      targetAvailable: true,
+      affordable: true,
+      terrainValid: true,
+      protectedTarget: false,
+      occupied: false
+    }
+  },
+  {
+    id: "tower-upgrade",
+    title: "Tower upgrade",
+    note: "A valid tower interaction advances one semantic level.",
+    request: {
+      kind: "tower",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      currentTowerLevel: 1,
+      maxTowerLevel: 3,
+      maxTowerAction: "reject"
+    }
+  },
+  {
+    id: "tower-max",
+    title: "Tower at max state",
+    note: "Max-level behavior is explicit rather than silently rebuilding the same state.",
+    request: {
+      kind: "tower",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      currentTowerLevel: 3,
+      maxTowerLevel: 3,
+      maxTowerAction: "reject"
+    }
+  },
+  {
+    id: "tower-refresh",
+    title: "Explicit refresh policy",
+    note: "If a future design intentionally refreshes a max-level tower, it must be represented as a distinct action.",
+    request: {
+      kind: "tower",
+      gestureOwner: "world",
+      targetAvailable: true,
+      affordable: true,
+      currentTowerLevel: 3,
+      maxTowerLevel: 3,
+      maxTowerAction: "refresh"
+    }
+  }
+];
+
+function describeResolution(resolution: DefenseInteractionResolution): string {
+  if (resolution.accepted) {
+    if (resolution.action === "place") return "Placement accepted";
+    if (resolution.action === "upgrade") return `Upgrade ${resolution.fromLevel} → ${resolution.toLevel}`;
+    if (resolution.action === "refresh") return `Refresh level ${resolution.fromLevel}`;
+  }
+  return `Rejected: ${resolution.rejection}`;
+}
+
+function scenarioMarkup(scenario: Scenario): string {
+  const resolution = resolveDefenseInteraction(scenario.request);
+  const outcomeClass = resolution.accepted ? "interaction-card--accepted" : "interaction-card--rejected";
+  return `
+    <button
+      class="interaction-card ${outcomeClass}"
+      type="button"
+      data-scenario="${scenario.id}"
+      data-action="${resolution.action}"
+      data-rejection="${resolution.rejection}"
+    >
+      <span class="interaction-card__title">${scenario.title}</span>
+      <span class="interaction-card__note">${scenario.note}</span>
+      <span class="interaction-card__result">${describeResolution(resolution)}</span>
+    </button>
+  `;
+}
+
+const meta = {
+  title: "Foundations/Interaction/Defense Interaction Legibility",
+  tags: ["test", "visual"],
+  render: () => {
+    const shell = createLabShell(
+      "Foundations / interaction",
+      "Defense interaction legibility",
+      "A deterministic feedforward/rejection matrix for direct-world placement and tower interaction. It classifies intent without Babylon, DOM ownership, or affordability arithmetic."
+    );
+
+    shell.frame.innerHTML = `
+      <style>
+        .interaction-layout { display:grid; grid-template-columns:minmax(0,1.35fr) minmax(260px,.65fr); gap:16px; }
+        .interaction-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:10px; }
+        .interaction-card { text-align:left; border:1px solid rgba(228,185,128,.26); background:rgba(17,13,20,.8); color:inherit; border-radius:10px; padding:14px; cursor:pointer; min-height:132px; }
+        .interaction-card:hover,.interaction-card:focus-visible { border-color:rgba(244,237,247,.85); outline:none; }
+        .interaction-card--accepted { box-shadow:inset 3px 0 0 rgba(133,220,194,.7); }
+        .interaction-card--rejected { box-shadow:inset 3px 0 0 rgba(228,185,128,.62); }
+        .interaction-card--selected { border-color:#f4edf7; background:rgba(228,185,128,.1); }
+        .interaction-card__title,.interaction-card__note,.interaction-card__result { display:block; }
+        .interaction-card__title { font-weight:700; margin-bottom:7px; }
+        .interaction-card__note { opacity:.72; font-size:.88rem; line-height:1.35; }
+        .interaction-card__result { margin-top:12px; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.8rem; }
+        .interaction-stage { min-height:300px; display:grid; place-items:center; position:relative; overflow:hidden; }
+        .interaction-cell { width:154px; height:112px; border:1px solid rgba(228,185,128,.55); transform:skewY(-8deg); display:grid; place-items:center; background:rgba(228,185,128,.05); }
+        .interaction-cell__content { transform:skewY(8deg); text-align:center; max-width:120px; }
+        .interaction-state { font-weight:700; margin-bottom:8px; }
+        .interaction-reason { opacity:.72; font-size:.86rem; word-break:break-word; }
+        @media (max-width:820px) { .interaction-layout { grid-template-columns:1fr; } }
+      </style>
+      <div class="interaction-layout">
+        <section class="interaction-grid" aria-label="Interaction scenarios">
+          ${scenarios.map(scenarioMarkup).join("")}
+        </section>
+        <aside class="lab__panel interaction-stage" aria-live="polite">
+          <div class="interaction-cell">
+            <div class="interaction-cell__content">
+              <div class="interaction-state" data-selected-state>Placement accepted</div>
+              <div class="interaction-reason" data-selected-reason>action=place · rejection=none</div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    `;
+
+    const cards = Array.from(shell.root.querySelectorAll<HTMLButtonElement>("[data-scenario]"));
+    const selectedState = shell.root.querySelector<HTMLElement>("[data-selected-state]");
+    const selectedReason = shell.root.querySelector<HTMLElement>("[data-selected-reason]");
+
+    const selectCard = (card: HTMLButtonElement): void => {
+      cards.forEach(candidate => candidate.classList.remove("interaction-card--selected"));
+      card.classList.add("interaction-card--selected");
+      const scenario = scenarios.find(candidate => candidate.id === card.dataset.scenario);
+      if (!scenario) return;
+      const resolution = resolveDefenseInteraction(scenario.request);
+      if (selectedState) selectedState.textContent = describeResolution(resolution);
+      if (selectedReason) selectedReason.textContent = `action=${resolution.action} · rejection=${resolution.rejection}`;
+    };
+
+    cards.forEach(card => card.addEventListener("click", () => selectCard(card)));
+    if (cards[0]) selectCard(cards[0]);
+
+    return shell.root;
+  }
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RejectionAndActionMatrix: Story = {
+  play: async ({ canvasElement }) => {
+    const reason = canvasElement.querySelector<HTMLElement>("[data-selected-reason]");
+    const occupied = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='place-occupied']");
+    const unaffordable = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='place-unaffordable']");
+    const camera = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='camera-gesture']");
+    const maxTower = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='tower-max']");
+    const refresh = canvasElement.querySelector<HTMLButtonElement>("[data-scenario='tower-refresh']");
+
+    await expect(reason).not.toBeNull();
+    await expect(occupied).not.toBeNull();
+    await expect(unaffordable).not.toBeNull();
+    await expect(camera).not.toBeNull();
+    await expect(maxTower).not.toBeNull();
+    await expect(refresh).not.toBeNull();
+    if (!reason || !occupied || !unaffordable || !camera || !maxTower || !refresh) return;
+
+    await userEvent.click(occupied);
+    await expect(reason).toHaveTextContent("rejection=occupied");
+
+    await userEvent.click(unaffordable);
+    await expect(reason).toHaveTextContent("rejection=unaffordable");
+
+    await userEvent.click(camera);
+    await expect(reason).toHaveTextContent("rejection=camera-gesture");
+
+    await userEvent.click(maxTower);
+    await expect(reason).toHaveTextContent("rejection=max-state");
+
+    await userEvent.click(refresh);
+    await expect(reason).toHaveTextContent("action=refresh");
+    await expect(reason).toHaveTextContent("rejection=none");
+  }
+};

--- a/src/js/gameplay/defenseInteraction.ts
+++ b/src/js/gameplay/defenseInteraction.ts
@@ -1,0 +1,147 @@
+type DefenseInteractionKind = "placement" | "tower";
+type DefenseGestureOwner = "world" | "camera";
+type DefenseMaxTowerAction = "reject" | "refresh";
+type DefenseInteractionAction = "none" | "place" | "upgrade" | "refresh";
+type DefenseInteractionRejection =
+	| "none"
+	| "camera-gesture"
+	| "stale-target"
+	| "invalid-terrain"
+	| "protected-target"
+	| "occupied"
+	| "unaffordable"
+	| "invalid-tower-state"
+	| "max-state";
+
+interface DefenseInteractionRequest {
+	kind: DefenseInteractionKind;
+	gestureOwner: DefenseGestureOwner;
+	targetAvailable: boolean;
+	affordable: boolean;
+	terrainValid?: boolean;
+	protectedTarget?: boolean;
+	occupied?: boolean;
+	currentTowerLevel?: number;
+	maxTowerLevel?: number;
+	maxTowerAction?: DefenseMaxTowerAction;
+}
+
+interface DefenseInteractionResolution {
+	accepted: boolean;
+	action: DefenseInteractionAction;
+	rejection: DefenseInteractionRejection;
+	fromLevel: number | null;
+	toLevel: number | null;
+}
+
+function rejected(
+	rejection: DefenseInteractionRejection,
+	fromLevel: number | null = null
+): DefenseInteractionResolution {
+	return {
+		accepted: false,
+		action: "none",
+		rejection,
+		fromLevel,
+		toLevel: fromLevel
+	};
+}
+
+function accepted(
+	action: DefenseInteractionAction,
+	fromLevel: number | null,
+	toLevel: number | null
+): DefenseInteractionResolution {
+	return {
+		accepted: true,
+		action,
+		rejection: "none",
+		fromLevel,
+		toLevel
+	};
+}
+
+function resolvePlacementInteraction(
+	request: DefenseInteractionRequest
+): DefenseInteractionResolution {
+	if (request.terrainValid !== true) {
+		return rejected("invalid-terrain");
+	}
+	if (request.protectedTarget === true) {
+		return rejected("protected-target");
+	}
+	if (request.occupied === true) {
+		return rejected("occupied");
+	}
+	if (!request.affordable) {
+		return rejected("unaffordable");
+	}
+	return accepted("place", null, 1);
+}
+
+function resolveTowerInteraction(
+	request: DefenseInteractionRequest
+): DefenseInteractionResolution {
+	const currentLevel = request.currentTowerLevel;
+	const maxLevel = request.maxTowerLevel;
+
+	if (
+		typeof currentLevel !== "number" ||
+		typeof maxLevel !== "number" ||
+		currentLevel < 1 ||
+		maxLevel < 1 ||
+		currentLevel > maxLevel
+	) {
+		return rejected("invalid-tower-state");
+	}
+
+	if (currentLevel === maxLevel) {
+		if (request.maxTowerAction !== "refresh") {
+			return rejected("max-state", currentLevel);
+		}
+		if (!request.affordable) {
+			return rejected("unaffordable", currentLevel);
+		}
+		return accepted("refresh", currentLevel, currentLevel);
+	}
+
+	if (!request.affordable) {
+		return rejected("unaffordable", currentLevel);
+	}
+
+	return accepted("upgrade", currentLevel, currentLevel + 1);
+}
+
+/**
+ * Classify a direct-world defensive interaction without depending on Babylon,
+ * DOM state, balance arithmetic, or presentation effects.
+ *
+ * The caller resolves affordability separately. This keeps the interaction
+ * contract neutral while the legacy strict-greater-than affordability behavior
+ * is characterized and later corrected independently.
+ */
+function resolveDefenseInteraction(
+	request: DefenseInteractionRequest
+): DefenseInteractionResolution {
+	if (request.gestureOwner === "camera") {
+		return rejected("camera-gesture");
+	}
+	if (!request.targetAvailable) {
+		return rejected("stale-target");
+	}
+	if (request.kind === "placement") {
+		return resolvePlacementInteraction(request);
+	}
+	return resolveTowerInteraction(request);
+}
+
+export {
+	DefenseInteractionKind,
+	DefenseGestureOwner,
+	DefenseMaxTowerAction,
+	DefenseInteractionAction,
+	DefenseInteractionRejection,
+	DefenseInteractionRequest,
+	DefenseInteractionResolution,
+	resolveDefenseInteraction
+};


### PR DESCRIPTION
Refs #108
Related: #33, #56, #92, #109

## Purpose

Create the first implementation seam for the ludic/intuitiveness work without changing live placement, upgrade, balance, camera, or Babylon behavior.

The core problem from #108 is that direct-world interaction is mechanically simple but rejected/ambiguous actions are not represented by an explicit semantic contract. This PR makes those outcomes classifiable before presentation adapters are added.

## Pure interaction contract

Adds `src/js/gameplay/defenseInteraction.ts`.

The Babylon/DOM-independent resolver distinguishes:

- accepted placement;
- accepted tower upgrade;
- explicit max-level refresh when a caller intentionally selects that policy;
- camera-owned gesture;
- stale/missing target;
- invalid terrain;
- protected/core target;
- occupied target;
- unaffordable action;
- invalid tower state;
- max semantic tower state.

It returns an explicit action (`place`, `upgrade`, `refresh`, `none`), rejection reason, and tower before/after levels where relevant.

### Important affordability boundary

This module deliberately receives `affordable: boolean` from the caller. It does **not** encode the current legacy `balance > cost` rule or #109's intended `balance >= cost` correction.

That keeps #109 independently fixable after the baseline is characterized and prevents this PR from contaminating #95/#97 certification semantics.

## Storybook playground

Adds `Foundations/Interaction/Defense Interaction Legibility`.

The deterministic matrix now covers every outcome in the resolver contract:

- valid placement;
- invalid terrain;
- protected core;
- occupied cell;
- insufficient energy;
- camera gesture ownership;
- stale target;
- normal tower upgrade;
- unaffordable tower upgrade;
- max-state rejection;
- explicit max-state refresh policy;
- invalid tower semantic state.

Accepted/rejected state is conveyed by text as well as presentation styling, so the fixture does not depend on color alone. The `play` assertion iterates the complete matrix, verifies each semantic action/rejection pair, clicks each scenario, and checks the live result announcement.

The story creates no Babylon scene, RAF loop, Worker, AudioContext, timer, or production event listener.

## Scope

Current head: `13e0b5ee7f5135f2411b202d19bd1791699b3119`.

Relative to current `master`:

- 3 commits ahead / 0 behind;
- exactly 2 added files;
- no live production call-site changes;
- no balance/cost change;
- no pointer/camera behavior change;
- no dependency/package change;
- no #56 hex-topology ownership;
- no #95/#97/#105 modification.

## Certification

Keep draft until a later local certification campaign can run:

```sh
npm run lint
npm run build
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Then exercise the story with keyboard/pointer input and confirm all rejected cases expose a distinct reason without relying only on color.

The root gate should specifically confirm the helper remains compatible with the historical TypeScript target.

## Follow-up after certification

1. adapt current pointer/touch targeting to produce this semantic request/result without changing behavior first;
2. use the result to drive world-grounded feedforward and rejection feedback;
3. implement #109's affordability boundary as a separate narrow change;
4. build the deterministic first-contact comprehension fixture from #108.

This PR is intentionally a semantic/testing foundation, not the final presentation implementation.