### PR TITLE
experiment: treat raider launch energy as capital at risk

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/RaiderCapitalEconomy.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/RaiderCapitalEconomy.stories.ts
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	DEFAULT_RAIDER_CAPITAL_PROFILES,
+	estimateRaiderCapitalExpectedValue,
+	raiderCapitalExpectedValueIsPositive,
+	settleRaiderCapitalEconomy,
+	type RaiderCapitalMode,
+	type RaiderCapitalProfile
+} from "@defend/gameplay/raiderCapitalEconomy";
+import { createLabShell } from "../../labTheme";
+
+type CapitalEconomyArgs = {
+	expectedBreachProbability: number;
+	expectedBreachViability: number;
+	expectedFailureReturnViability: number;
+	realizedViability: number;
+	travelAndOperatingCost: number;
+	defenderCaptureFraction: number;
+};
+
+type TargetWitness = {
+	label: string;
+	reserve: number;
+};
+
+const TARGETS: TargetWitness[] = [
+	{ label: "Poor target", reserve: 5000 },
+	{ label: "Medium target", reserve: 15000 },
+	{ label: "Rich target", reserve: 30000 }
+];
+
+const MODES: RaiderCapitalMode[] = ["fully-sunk", "embodied-return"];
+
+function fixed(value: number, digits = 0): string {
+	if (value !== value || value === Infinity || value === -Infinity) return "0";
+	return value.toFixed(digits);
+}
+
+function signed(value: number): string {
+	return `${value >= 0 ? "+" : ""}${fixed(value, 0)}`;
+}
+
+function modeLabel(mode: RaiderCapitalMode): string {
+	return mode === "fully-sunk" ? "Fully sunk launch" : "Embodied capital return";
+}
+
+function estimateCell(
+	mode: RaiderCapitalMode,
+	profile: RaiderCapitalProfile,
+	target: TargetWitness,
+	args: CapitalEconomyArgs
+): string {
+	const estimate = estimateRaiderCapitalExpectedValue({
+		mode,
+		profile,
+		perceivedTargetEnergy: target.reserve,
+		expectedBreachProbability: args.expectedBreachProbability,
+		expectedArrivalViabilityOnBreach: args.expectedBreachViability,
+		expectedReturnViabilityOnFailure: args.expectedFailureReturnViability,
+		travelAndOperatingCost: args.travelAndOperatingCost
+	});
+	const positive = raiderCapitalExpectedValueIsPositive(estimate);
+	return `
+		<div class="capital-cell" data-mode="${mode}" data-target="${target.reserve}" data-tier="${profile.tier}" data-positive="${positive}">
+			<header><strong>R${profile.tier}</strong><span>${positive ? "positive EV" : "negative EV"}</span></header>
+			<div class="capital-net">${signed(estimate.expectedNetReturn)}</div>
+			<small>extract ${fixed(estimate.expectedExtractedEnergy)} · return ${fixed(estimate.expectedReturnedCapital)} · capital loss ${fixed(estimate.expectedCapitalLoss)}</small>
+		</div>
+	`;
+}
+
+function modePanel(mode: RaiderCapitalMode, args: CapitalEconomyArgs): string {
+	return `
+		<section class="lab__panel lab__panel--padded capital-mode">
+			<div class="capital-mode__heading">
+				<div><small>capital interpretation</small><h2>${modeLabel(mode)}</h2></div>
+				<p>${
+					mode === "fully-sunk"
+						? "Launch commitment is consumed immediately; surviving body state cannot return that commitment."
+						: "Launch commitment moves into the raider; surviving viability returns capital and damaged capital becomes capture/loss exposure."
+				}</p>
+			</div>
+			<div class="capital-targets">
+				${TARGETS.map(
+					target => `
+					<section class="capital-target">
+						<header><strong>${target.label}</strong><span>${fixed(target.reserve)} teal</span></header>
+						<div class="capital-tier-grid">${DEFAULT_RAIDER_CAPITAL_PROFILES.map(profile => estimateCell(mode, profile, target, args)).join("")}</div>
+					</section>`
+				).join("")}
+			</div>
+		</section>
+	`;
+}
+
+const meta = {
+	title: "Foundations/Strategy/Raider Capital Economy",
+	tags: ["test", "visual"],
+	args: {
+		expectedBreachProbability: 0.55,
+		expectedBreachViability: 0.55,
+		expectedFailureReturnViability: 0.3,
+		realizedViability: 0.55,
+		travelAndOperatingCost: 500,
+		defenderCaptureFraction: 0.72
+	},
+	argTypes: {
+		expectedBreachProbability: { control: { type: "range", min: 0.05, max: 1, step: 0.05 } },
+		expectedBreachViability: { control: { type: "range", min: 0.05, max: 1, step: 0.05 } },
+		expectedFailureReturnViability: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
+		realizedViability: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
+		travelAndOperatingCost: { control: { type: "range", min: 0, max: 3000, step: 100 } },
+		defenderCaptureFraction: { control: { type: "range", min: 0, max: 1, step: 0.05 } }
+	},
+	render: (args: CapitalEconomyArgs) => {
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Raider launch capital at risk",
+			"Compare fully sunk launch cost with a conservation-first hypothesis where launch energy remains embodied in the raider and returns only in proportion to physical survival. The witness is diagnostic, not production balance."
+		);
+		shell.frame.innerHTML = `
+			<style>
+				.capital-layout { display:grid; gap:14px; }
+				.capital-mode__heading { display:grid; grid-template-columns:minmax(180px,.7fr) minmax(240px,1.3fr); gap:20px; align-items:start; margin-bottom:14px; }
+				.capital-mode__heading small, .capital-cell small { color:rgba(244,237,247,.46); }
+				.capital-mode__heading h2 { margin:3px 0 0; font-size:15px; }
+				.capital-mode__heading p { margin:0; color:rgba(244,237,247,.58); font-size:11px; line-height:1.5; }
+				.capital-targets { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:10px; }
+				.capital-target { padding:10px; border:1px solid rgba(244,237,247,.08); }
+				.capital-target > header { display:flex; justify-content:space-between; gap:8px; margin-bottom:8px; font-size:11px; }
+				.capital-target > header span { opacity:.52; }
+				.capital-tier-grid { display:grid; gap:7px; }
+				.capital-cell { padding:9px; border:1px solid rgba(228,185,128,.16); background:rgba(10,3,17,.36); }
+				.capital-cell header { display:flex; justify-content:space-between; gap:8px; font-size:10px; }
+				.capital-cell[data-positive="true"] { border-style:solid; }
+				.capital-cell[data-positive="false"] { border-style:dashed; opacity:.68; }
+				.capital-net { margin:7px 0 4px; font-size:17px; font-variant-numeric:tabular-nums; }
+				.capital-cell small { display:block; font-size:9px; line-height:1.45; }
+				.capital-note { margin-top:12px; padding-top:10px; border-top:1px solid rgba(244,237,247,.08); font-size:10px; color:rgba(244,237,247,.5); }
+				@media (max-width:900px) { .capital-targets { grid-template-columns:1fr; } .capital-mode__heading { grid-template-columns:1fr; } }
+			</style>
+			<div class="capital-layout">${MODES.map(mode => modePanel(mode, args)).join("")}</div>
+			<div class="capital-note">Expected value includes target-bounded extraction, launch-capital loss/return and travel/operating drain. Defender capture is tested separately through the realized conserved settlement and never exceeds damaged embodied capital.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<CapitalEconomyArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CapitalAtRiskMatrix: Story = {
+	play: async ({ canvasElement, args }) => {
+		const cells = canvasElement.querySelectorAll<HTMLElement>("[data-mode][data-target][data-tier]");
+		await expect(cells.length).toBe(MODES.length * TARGETS.length * DEFAULT_RAIDER_CAPITAL_PROFILES.length);
+
+		const embodiedPoorR1 = canvasElement.querySelector<HTMLElement>(
+			'[data-mode="embodied-return"][data-target="5000"][data-tier="1"]'
+		);
+		const embodiedPoorR2 = canvasElement.querySelector<HTMLElement>(
+			'[data-mode="embodied-return"][data-target="5000"][data-tier="2"]'
+		);
+		const embodiedMediumR2 = canvasElement.querySelector<HTMLElement>(
+			'[data-mode="embodied-return"][data-target="15000"][data-tier="2"]'
+		);
+		const embodiedMediumR3 = canvasElement.querySelector<HTMLElement>(
+			'[data-mode="embodied-return"][data-target="15000"][data-tier="3"]'
+		);
+		const embodiedRichR3 = canvasElement.querySelector<HTMLElement>(
+			'[data-mode="embodied-return"][data-target="30000"][data-tier="3"]'
+		);
+		await expect(embodiedPoorR1?.dataset.positive).toBe("true");
+		await expect(embodiedPoorR2?.dataset.positive).toBe("false");
+		await expect(embodiedMediumR2?.dataset.positive).toBe("true");
+		await expect(embodiedMediumR3?.dataset.positive).toBe("false");
+		await expect(embodiedRichR3?.dataset.positive).toBe("true");
+
+		for (let modeIndex = 0; modeIndex < MODES.length; modeIndex += 1) {
+			for (let targetIndex = 0; targetIndex < TARGETS.length; targetIndex += 1) {
+				for (let tierIndex = 0; tierIndex < DEFAULT_RAIDER_CAPITAL_PROFILES.length; tierIndex += 1) {
+					const mode = MODES[modeIndex];
+					const target = TARGETS[targetIndex];
+					const profile = DEFAULT_RAIDER_CAPITAL_PROFILES[tierIndex];
+					const settlement = settleRaiderCapitalEconomy({
+						mode,
+						profile,
+						defenderReserve: target.reserve,
+						defenderCapacity: 30000,
+						breached: true,
+						remainingViability: args.realizedViability,
+						travelAndOperatingCost: args.travelAndOperatingCost,
+						defenderCaptureFraction: args.defenderCaptureFraction,
+						collateralDissipationRatio: 0
+					});
+					await expect(settlement.extractedEnergy).toBeLessThanOrEqual(target.reserve);
+					await expect(settlement.returnedCapital).toBeLessThanOrEqual(profile.committedEnergy);
+					await expect(settlement.capturedCapital).toBeLessThanOrEqual(settlement.capitalAtRiskLost);
+					await expect(Math.abs(settlement.conservationResidual)).toBeLessThan(0.000001);
+					if (mode === "fully-sunk") {
+						await expect(settlement.returnedCapital).toBe(0);
+						await expect(settlement.capturedCapital).toBe(0);
+					}
+				}
+			}
+		}
+	}
+};

--- a/experiments/storybook/src/Foundations/Strategy/RaiderCapitalEconomy.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/RaiderCapitalEconomy.stories.ts
@@ -32,6 +32,13 @@ const TARGETS: TargetWitness[] = [
 
 const MODES: RaiderCapitalMode[] = ["fully-sunk", "embodied-return"];
 
+const FIXED_WITNESS = {
+	expectedBreachProbability: 0.55,
+	expectedBreachViability: 0.55,
+	expectedFailureReturnViability: 0.3,
+	travelAndOperatingCost: 500
+};
+
 function fixed(value: number, digits = 0): string {
 	if (value !== value || value === Infinity || value === -Infinity) return "0";
 	return value.toFixed(digits);
@@ -94,6 +101,22 @@ function modePanel(mode: RaiderCapitalMode, args: CapitalEconomyArgs): string {
 	`;
 }
 
+function fixedWitnessPositive(tierIndex: number, targetEnergy: number): boolean {
+	const profile = DEFAULT_RAIDER_CAPITAL_PROFILES[tierIndex];
+	return raiderCapitalExpectedValueIsPositive(
+		estimateRaiderCapitalExpectedValue({
+			mode: "embodied-return",
+			profile,
+			perceivedTargetEnergy: targetEnergy,
+			expectedBreachProbability: FIXED_WITNESS.expectedBreachProbability,
+			expectedArrivalViabilityOnBreach: FIXED_WITNESS.expectedBreachViability,
+			expectedReturnViabilityOnFailure:
+				FIXED_WITNESS.expectedFailureReturnViability,
+			travelAndOperatingCost: FIXED_WITNESS.travelAndOperatingCost
+		})
+	);
+}
+
 const meta = {
 	title: "Foundations/Strategy/Raider Capital Economy",
 	tags: ["test", "visual"],
@@ -117,7 +140,7 @@ const meta = {
 		const shell = createLabShell(
 			"Foundations / strategy",
 			"Raider launch capital at risk",
-			"Compare fully sunk launch cost with a conservation-first hypothesis where launch energy remains embodied in the raider and returns only in proportion to physical survival. The witness is diagnostic, not production balance."
+			"Compare fully sunk launch cost with a conservation-first hypothesis where launch energy remains embodied in the raider and returns only in proportion to physical survival. Controls are exploratory; the automated witness stays fixed."
 		);
 		shell.frame.innerHTML = `
 			<style>
@@ -141,7 +164,7 @@ const meta = {
 				@media (max-width:900px) { .capital-targets { grid-template-columns:1fr; } .capital-mode__heading { grid-template-columns:1fr; } }
 			</style>
 			<div class="capital-layout">${MODES.map(mode => modePanel(mode, args)).join("")}</div>
-			<div class="capital-note">Expected value includes target-bounded extraction, launch-capital loss/return and travel/operating drain. Defender capture is tested separately through the realized conserved settlement and never exceeds damaged embodied capital.</div>
+			<div class="capital-note">Expected value includes target-bounded extraction, launch-capital loss/return and travel/operating drain. Changing controls is meant to reveal regimes where the default contextual role pattern fails; those exploratory states do not invalidate the fixed automated witness.</div>
 		`;
 		return shell.root;
 	}
@@ -153,32 +176,23 @@ type Story = StoryObj<typeof meta>;
 export const CapitalAtRiskMatrix: Story = {
 	play: async ({ canvasElement, args }) => {
 		const cells = canvasElement.querySelectorAll<HTMLElement>("[data-mode][data-target][data-tier]");
-		await expect(cells.length).toBe(MODES.length * TARGETS.length * DEFAULT_RAIDER_CAPITAL_PROFILES.length);
+		await expect(cells.length).toBe(
+			MODES.length * TARGETS.length * DEFAULT_RAIDER_CAPITAL_PROFILES.length
+		);
 
-		const embodiedPoorR1 = canvasElement.querySelector<HTMLElement>(
-			'[data-mode="embodied-return"][data-target="5000"][data-tier="1"]'
-		);
-		const embodiedPoorR2 = canvasElement.querySelector<HTMLElement>(
-			'[data-mode="embodied-return"][data-target="5000"][data-tier="2"]'
-		);
-		const embodiedMediumR2 = canvasElement.querySelector<HTMLElement>(
-			'[data-mode="embodied-return"][data-target="15000"][data-tier="2"]'
-		);
-		const embodiedMediumR3 = canvasElement.querySelector<HTMLElement>(
-			'[data-mode="embodied-return"][data-target="15000"][data-tier="3"]'
-		);
-		const embodiedRichR3 = canvasElement.querySelector<HTMLElement>(
-			'[data-mode="embodied-return"][data-target="30000"][data-tier="3"]'
-		);
-		await expect(embodiedPoorR1?.dataset.positive).toBe("true");
-		await expect(embodiedPoorR2?.dataset.positive).toBe("false");
-		await expect(embodiedMediumR2?.dataset.positive).toBe("true");
-		await expect(embodiedMediumR3?.dataset.positive).toBe("false");
-		await expect(embodiedRichR3?.dataset.positive).toBe("true");
+		await expect(fixedWitnessPositive(0, 5000)).toBe(true);
+		await expect(fixedWitnessPositive(1, 5000)).toBe(false);
+		await expect(fixedWitnessPositive(1, 15000)).toBe(true);
+		await expect(fixedWitnessPositive(2, 15000)).toBe(false);
+		await expect(fixedWitnessPositive(2, 30000)).toBe(true);
 
 		for (let modeIndex = 0; modeIndex < MODES.length; modeIndex += 1) {
 			for (let targetIndex = 0; targetIndex < TARGETS.length; targetIndex += 1) {
-				for (let tierIndex = 0; tierIndex < DEFAULT_RAIDER_CAPITAL_PROFILES.length; tierIndex += 1) {
+				for (
+					let tierIndex = 0;
+					tierIndex < DEFAULT_RAIDER_CAPITAL_PROFILES.length;
+					tierIndex += 1
+				) {
 					const mode = MODES[modeIndex];
 					const target = TARGETS[targetIndex];
 					const profile = DEFAULT_RAIDER_CAPITAL_PROFILES[tierIndex];
@@ -193,10 +207,18 @@ export const CapitalAtRiskMatrix: Story = {
 						defenderCaptureFraction: args.defenderCaptureFraction,
 						collateralDissipationRatio: 0
 					});
-					await expect(settlement.extractedEnergy).toBeLessThanOrEqual(target.reserve);
-					await expect(settlement.returnedCapital).toBeLessThanOrEqual(profile.committedEnergy);
-					await expect(settlement.capturedCapital).toBeLessThanOrEqual(settlement.capitalAtRiskLost);
-					await expect(Math.abs(settlement.conservationResidual)).toBeLessThan(0.000001);
+					await expect(settlement.extractedEnergy).toBeLessThanOrEqual(
+						target.reserve
+					);
+					await expect(settlement.returnedCapital).toBeLessThanOrEqual(
+						profile.committedEnergy
+					);
+					await expect(settlement.capturedCapital).toBeLessThanOrEqual(
+						settlement.capitalAtRiskLost
+					);
+					await expect(Math.abs(settlement.conservationResidual)).toBeLessThan(
+						0.000001
+					);
 					if (mode === "fully-sunk") {
 						await expect(settlement.returnedCapital).toBe(0);
 						await expect(settlement.capturedCapital).toBe(0);

--- a/src/js/gameplay/raiderCapitalEconomy.ts
+++ b/src/js/gameplay/raiderCapitalEconomy.ts
@@ -1,0 +1,235 @@
+import {
+	settleConservedRaidExchange,
+	type ConservedRaidExchangeResult
+} from "./conservedRaidExchange";
+
+export type RaiderCapitalTier = 1 | 2 | 3;
+export type RaiderCapitalMode = "fully-sunk" | "embodied-return";
+
+export interface RaiderCapitalProfile {
+	tier: RaiderCapitalTier;
+	committedEnergy: number;
+	extractionPotential: number;
+}
+
+export interface RaiderCapitalSettlementInput {
+	mode: RaiderCapitalMode;
+	profile: RaiderCapitalProfile;
+	defenderReserve: number;
+	defenderCapacity: number;
+	breached: boolean;
+	remainingViability: number;
+	travelAndOperatingCost: number;
+	defenderCaptureFraction: number;
+	collateralDissipationRatio: number;
+}
+
+export interface RaiderCapitalSettlement {
+	mode: RaiderCapitalMode;
+	tier: RaiderCapitalTier;
+	committedEnergy: number;
+	remainingViability: number;
+	requestedExtractionEnergy: number;
+	extractedEnergy: number;
+	returnedCapital: number;
+	capitalAtRiskLost: number;
+	capturedCapital: number;
+	looseOrDissipatedCapital: number;
+	sunkAtLaunch: number;
+	attackerNetReturn: number;
+	trackedEnergyBefore: number;
+	trackedEnergyAfter: number;
+	conservationResidual: number;
+	exchange: ConservedRaidExchangeResult;
+}
+
+export interface RaiderCapitalExpectedValueInput {
+	mode: RaiderCapitalMode;
+	profile: RaiderCapitalProfile;
+	perceivedTargetEnergy: number;
+	expectedBreachProbability: number;
+	expectedArrivalViabilityOnBreach: number;
+	expectedReturnViabilityOnFailure: number;
+	travelAndOperatingCost: number;
+}
+
+export interface RaiderCapitalExpectedValue {
+	mode: RaiderCapitalMode;
+	tier: RaiderCapitalTier;
+	committedEnergy: number;
+	perceivedTargetEnergy: number;
+	expectedExtractedEnergy: number;
+	expectedReturnedCapital: number;
+	expectedCapitalLoss: number;
+	expectedNetReturn: number;
+	expectedReturnOnCommitment: number;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) return fallback;
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function clamp01(value: number): number {
+	return Math.max(0, Math.min(1, finite(value)));
+}
+
+function normalizedProfile(profile: RaiderCapitalProfile): RaiderCapitalProfile {
+	return {
+		tier: profile.tier,
+		committedEnergy: positive(profile.committedEnergy),
+		extractionPotential: positive(profile.extractionPotential)
+	};
+}
+
+/**
+ * Compare two interpretations of launch commitment while keeping the target
+ * exchange conserved through #114's settlement contract.
+ *
+ * `fully-sunk` deliberately treats launch commitment as an explicit sink. It
+ * therefore cannot also be a defender-recovery source without introducing an
+ * additional embodied-energy source.
+ *
+ * `embodied-return` moves launch commitment into the raider. Surviving capital
+ * returns in proportion to final viability; capital that does not return is
+ * the only launch capital available for defender capture or dissipation.
+ */
+export function settleRaiderCapitalEconomy(
+	input: RaiderCapitalSettlementInput
+): RaiderCapitalSettlement {
+	const profile = normalizedProfile(input.profile);
+	const viability = clamp01(input.remainingViability);
+	const captureFraction = clamp01(input.defenderCaptureFraction);
+	const requestedExtractionEnergy = input.breached
+		? profile.extractionPotential * viability
+		: 0;
+
+	const returnedCapital =
+		input.mode === "embodied-return"
+			? profile.committedEnergy * viability
+			: 0;
+	const capitalAtRiskLost =
+		input.mode === "embodied-return"
+			? profile.committedEnergy - returnedCapital
+			: 0;
+	const requestedRecoveryEnergy = capitalAtRiskLost * captureFraction;
+	const sunkAtLaunch =
+		input.mode === "fully-sunk" ? profile.committedEnergy : 0;
+
+	const exchange = settleConservedRaidExchange({
+		defenderReserve: positive(input.defenderReserve),
+		defenderCapacity: positive(input.defenderCapacity),
+		requestedExtractionEnergy,
+		attackerEmbodiedEnergy: capitalAtRiskLost,
+		requestedRecoveryEnergy,
+		collateralDissipationRatio: positive(input.collateralDissipationRatio)
+	});
+
+	const capturedCapital = exchange.recoveredEnergy;
+	const looseOrDissipatedCapital = Math.max(
+		0,
+		capitalAtRiskLost - capturedCapital
+	);
+	const travelAndOperatingCost = positive(input.travelAndOperatingCost);
+	const attackerNetReturn =
+		exchange.extractedEnergy +
+		returnedCapital -
+		profile.committedEnergy -
+		travelAndOperatingCost;
+
+	const trackedEnergyBefore =
+		exchange.reserveBefore + profile.committedEnergy;
+	const trackedEnergyAfter =
+		exchange.reserveAfter +
+		exchange.extractedEnergy +
+		exchange.collateralDissipation +
+		returnedCapital +
+		capturedCapital +
+		looseOrDissipatedCapital +
+		sunkAtLaunch -
+		capturedCapital;
+
+	return {
+		mode: input.mode,
+		tier: profile.tier,
+		committedEnergy: profile.committedEnergy,
+		remainingViability: viability,
+		requestedExtractionEnergy,
+		extractedEnergy: exchange.extractedEnergy,
+		returnedCapital,
+		capitalAtRiskLost,
+		capturedCapital,
+		looseOrDissipatedCapital,
+		sunkAtLaunch,
+		attackerNetReturn,
+		trackedEnergyBefore,
+		trackedEnergyAfter,
+		conservationResidual: trackedEnergyAfter - trackedEnergyBefore,
+		exchange
+	};
+}
+
+/**
+ * Pre-commit expected value with the same target-richness cap used by #119,
+ * extended to account for capital that can physically return from a surviving
+ * raider. Failure viability represents a retreat/failed-breach survival
+ * hypothesis and remains caller-owned.
+ */
+export function estimateRaiderCapitalExpectedValue(
+	input: RaiderCapitalExpectedValueInput
+): RaiderCapitalExpectedValue {
+	const profile = normalizedProfile(input.profile);
+	const perceivedTargetEnergy = positive(input.perceivedTargetEnergy);
+	const breachProbability = clamp01(input.expectedBreachProbability);
+	const breachViability = clamp01(input.expectedArrivalViabilityOnBreach);
+	const failureViability = clamp01(input.expectedReturnViabilityOnFailure);
+	const travelAndOperatingCost = positive(input.travelAndOperatingCost);
+	const extractionOnBreach = Math.min(
+		perceivedTargetEnergy,
+		profile.extractionPotential * breachViability
+	);
+	const expectedExtractedEnergy = extractionOnBreach * breachProbability;
+
+	const expectedReturnedCapital =
+		input.mode === "embodied-return"
+			? profile.committedEnergy *
+				(breachProbability * breachViability +
+					(1 - breachProbability) * failureViability)
+			: 0;
+	const expectedCapitalLoss =
+		profile.committedEnergy - expectedReturnedCapital;
+	const expectedNetReturn =
+		expectedExtractedEnergy - expectedCapitalLoss - travelAndOperatingCost;
+	const expectedReturnOnCommitment =
+		profile.committedEnergy <= 0
+			? 0
+			: expectedNetReturn / profile.committedEnergy;
+
+	return {
+		mode: input.mode,
+		tier: profile.tier,
+		committedEnergy: profile.committedEnergy,
+		perceivedTargetEnergy,
+		expectedExtractedEnergy,
+		expectedReturnedCapital,
+		expectedCapitalLoss,
+		expectedNetReturn,
+		expectedReturnOnCommitment
+	};
+}
+
+export function raiderCapitalExpectedValueIsPositive(
+	estimate: RaiderCapitalExpectedValue
+): boolean {
+	return estimate.expectedNetReturn > 0;
+}
+
+export const DEFAULT_RAIDER_CAPITAL_PROFILES: RaiderCapitalProfile[] = [
+	{ tier: 1, committedEnergy: 3000, extractionPotential: 7720 },
+	{ tier: 2, committedEnergy: 12000, extractionPotential: 30440 },
+	{ tier: 3, committedEnergy: 27000, extractionPotential: 68160 }
+];

--- a/src/js/gameplay/raiderCapitalEconomy.ts
+++ b/src/js/gameplay/raiderCapitalEconomy.ts
@@ -1,6 +1,6 @@
 import {
 	settleConservedRaidExchange,
-	type ConservedRaidExchangeResult
+	ConservedRaidExchangeResult
 } from "./conservedRaidExchange";
 
 export type RaiderCapitalTier = 1 | 2 | 3;
@@ -148,10 +148,8 @@ export function settleRaiderCapitalEconomy(
 		exchange.extractedEnergy +
 		exchange.collateralDissipation +
 		returnedCapital +
-		capturedCapital +
 		looseOrDissipatedCapital +
-		sunkAtLaunch -
-		capturedCapital;
+		sunkAtLaunch;
 
 	return {
 		mode: input.mode,


### PR DESCRIPTION
Refs #124, #107, #103
Parent: #119
Related: #114, #74, #76

## Purpose

Compare the current fully-sunk launch-cost interpretation with a conservation-first hypothesis where launch energy moves into the raider as embodied capital and returns only in proportion to physical survival.

This addresses the structural problem documented in #124: once target extraction is correctly capped by the canonical 30,000 silo reserve, a fully sunk 27,000 R3 commitment has positive expected value only under near-certain rich-target extraction. The earlier tier-symmetric ~40% break-even argument therefore does not survive conserved target supply.

## Scope

Relative to #119 exact head `720b3fa880a8d7fd388f33baa6b2e52497f6487f`:

- 3 commits ahead / 0 behind;
- exactly 2 added files;
- `src/js/gameplay/raiderCapitalEconomy.ts`;
- `experiments/storybook/src/Foundations/Strategy/RaiderCapitalEconomy.stories.ts`;
- no production call-site changes;
- no package/dependency changes;
- no final launch-cost, return-efficiency or balance promotion;
- no changes to the frozen #92 certification heads.

The branch inherits #114 conserved target settlement and #119 perceived-target expected-value work.

## Capital interpretations

### Fully sunk baseline

Launch commitment is an explicit energy sink at deployment. It cannot simultaneously be defender-capturable embodied energy without introducing another source.

### Embodied return hypothesis

`mothership reserve -> raider embodied capital -> surviving return OR damage/capture/loss`

For the first experiment:

`returnedCapital = commitment × remainingViability`

`capitalLoss = commitment - returnedCapital`

`attackerNet = actualTargetBoundedExtraction - capitalLoss - travel/operatingCost`

This is a hypothesis, not production semantics.

## Conserved realized settlement

`settleRaiderCapitalEconomy()` composes #114's `settleConservedRaidExchange()`.

For embodied capital:

- extraction is capped by actual defender reserve;
- surviving capital returns according to physical viability;
- only non-returning capital is exposed to defender capture;
- defender capture is bounded by that damaged/lost capital and storage headroom;
- uncaptured non-returning capital remains explicitly loose/dissipative for later physical interpretation;
- collateral loss remains dissipative rather than attacker income;
- an explicit conservation residual verifies the tracked target + launch-capital exchange reconciles.

For the sunk baseline, commitment is tracked as an explicit launch sink and cannot also produce defender recovery.

Travel/operating drain is reported in attacker net but intentionally outside the per-contact tracked-energy identity because it is a separate mothership/system sink.

## Expected-value comparison

`estimateRaiderCapitalExpectedValue()` extends the #119 target-richness idea with expected returned capital.

Inputs remain explicit and injectable:

- perceived target energy;
- breach probability;
- arrival viability on breach;
- return viability after a failed breach/retreat;
- travel/operating cost.

Expected extraction remains target-bounded.

## Storybook witness

Adds `Foundations/Strategy/Raider Capital Economy`.

The default moderate-risk witness uses:

- breach probability 0.55;
- successful arrival/return viability 0.55;
- failed-breach return viability 0.30;
- travel/operating cost 500;
- target reserves 5k / 15k / 30k.

Under the **embodied-capital** hypothesis, the fixed witness intentionally demonstrates contextual economic viability rather than universal tier efficiency:

- 5k poor target: R1 positive, R2/R3 negative;
- 15k medium target: R2 positive, R3 negative;
- 30k rich target: R3 becomes positive.

The exact values are not balance targets. The point is that target richness, physical survival and concentrated capital risk can produce tier differentiation without a hidden tier-specific ROI bonus.

Controls expose probability, success/failure viability, realized viability, operating cost and defender capture fraction.

## Automated invariants

The Storybook fixture verifies across both capital modes, three target reserves and all three tiers:

- actual extraction never exceeds target reserve;
- returned capital never exceeds committed energy;
- defender-captured capital never exceeds non-returning embodied capital;
- the tracked target + launch-capital exchange has near-zero conservation residual;
- fully sunk launch cost returns no launch capital and yields no capture from that sunk source;
- the default embodied witness has the intended poor→medium→rich tier-viability progression.

## Design interpretation

This model strengthens the existing `physics <-> economy` pillar:

- a surviving raider preserves capital;
- damage destroys/exposes capital;
- defender recovery becomes captured opposing investment;
- ejection or failed evacuation can become real capital loss;
- R3 is risky because a large amount of capital is physically concentrated in one body, not because the game silently deletes a large tier tax.

It also makes intentional under-defense less attractive in a physically grounded way: weak defense lets raiders retain more of their own capital, gives the defender less capture, and allows more extraction.

## Validation / decision gate

Keep draft. Before choosing a capital model:

- run Storybook typecheck/build/test in a post-freeze campaign;
- sweep breach probability, target richness and success/failure viability;
- compare R1/R2/R3 contextual usefulness;
- add ejection/off-map and evacuation-return variants;
- feed measured viability distributions from #72/#86 rather than inventing permanent tier bonuses;
- compare long-horizon anti-farming behavior in #107;
- decide whether viability should map 1:1 to economic capital or through a separate bounded integrity curve.

Do not complete/promote the deterrence economy around fully sunk tier costs until this comparison is resolved.