### PR TITLE
experiment: make deterrence learn from attacker beliefs

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/RaidBelief.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/RaidBelief.stories.ts
@@ -38,12 +38,11 @@ function percent(value: number): string {
 
 function buildStages(args: RaidBeliefArgs): BeliefStage[] {
 	const calibration = DEFAULT_RAID_BELIEF_CALIBRATION;
-	const initial = createRaidBelief(DEFAULT_RAID_BELIEF_PRIOR, calibration);
-	let state = initial;
+	let state = createRaidBelief(DEFAULT_RAID_BELIEF_PRIOR, calibration);
 	const stages: BeliefStage[] = [
 		{
 			label: "Prior",
-			note: "Valuable target, optimistic but uncertain physical expectations.",
+			note: "One target-wide opportunity estimate plus one optimistic but uncertain approach context.",
 			state
 		}
 	];
@@ -57,7 +56,7 @@ function buildStages(args: RaidBeliefArgs): BeliefStage[] {
 	}
 	stages.push({
 		label: "Repeated failures",
-		note: "Direct evidence lowers breach/viability expectations and reduces uncertainty.",
+		note: "Direct evidence lowers this approach's breach/viability expectation without changing target-wide energy belief.",
 		state
 	});
 
@@ -68,27 +67,31 @@ function buildStages(args: RaidBeliefArgs): BeliefStage[] {
 	);
 	stages.push({
 		label: "One lucky success",
-		note: "Belief recovers partially; one result does not erase the accumulated history.",
+		note: "The contextual approach recovers partially; one result does not erase accumulated history.",
 		state
 	});
 
 	for (let index = 0; index < 4; index += 1) {
 		state = observeRaidOutcome(
 			state,
-			{ breached: true, remainingViability: Math.min(1, args.successViability + 0.08), reliability: 1 },
+			{
+				breached: true,
+				remainingViability: Math.min(1, args.successViability + 0.08),
+				reliability: 1
+			},
 			calibration
 		);
 	}
 	stages.push({
 		label: "Repeated success",
-		note: "Accumulated contrary evidence can restore broader confidence.",
+		note: "Accumulated contrary evidence can genuinely restore this approach's expectations.",
 		state
 	});
 
 	state = ageRaidBelief(state, args.quietSeconds, calibration);
 	stages.push({
 		label: "Deterrent quiet",
-		note: "Physical means remain unchanged, but old information becomes stale and uncertainty rises.",
+		note: "Approach means stay fixed, but old route/tier information becomes stale and uncertain.",
 		state
 	});
 
@@ -100,7 +103,7 @@ function buildStages(args: RaidBeliefArgs): BeliefStage[] {
 	);
 	stages.push({
 		label: "Target brightens",
-		note: "Passive teal evidence raises perceived opportunity without revealing hidden defense quality.",
+		note: "The shared target opportunity rises; the approach-specific breach estimate does not magically improve.",
 		state
 	});
 
@@ -111,26 +114,41 @@ function buildStages(args: RaidBeliefArgs): BeliefStage[] {
 	);
 	stages.push({
 		label: "Fresh probe",
-		note: "A new direct observation reduces uncertainty and updates the physical estimate again.",
+		note: "Fresh direct evidence reduces uncertainty for this approach context only.",
 		state
 	});
 
 	return stages;
 }
 
-function stageCard(stage: BeliefStage, calibration: RaidBeliefCalibration, index: number): string {
+function stageCard(
+	stage: BeliefStage,
+	calibration: RaidBeliefCalibration,
+	index: number
+): string {
 	const informationNeed = raidBeliefInformationNeed(stage.state, calibration);
+	const opportunity = stage.state.opportunity;
+	const approach = stage.state.approach;
 	return `
-		<article class="belief-card" data-stage="${index}" data-breach="${stage.state.expectedBreachProbability}" data-viability="${stage.state.expectedArrivalViability}" data-uncertainty="${stage.state.uncertainty}" data-energy="${stage.state.perceivedTargetEnergy}" data-information-need="${informationNeed}">
+		<article class="belief-card" data-stage="${index}" data-breach="${approach.expectedBreachProbability}" data-viability="${approach.expectedArrivalViability}" data-uncertainty="${approach.uncertainty}" data-energy="${opportunity.perceivedTargetEnergy}" data-information-need="${informationNeed}">
 			<header><small>${String(index + 1).padStart(2, "0")}</small><strong>${stage.label}</strong></header>
 			<p>${stage.note}</p>
-			<div class="belief-metrics">
-				<div><small>perceived energy</small><strong>${fixed(stage.state.perceivedTargetEnergy, 0)}</strong></div>
-				<div><small>breach expectation</small><strong>${percent(stage.state.expectedBreachProbability)}</strong></div>
-				<div><small>arrival viability</small><strong>${percent(stage.state.expectedArrivalViability)}</strong></div>
-				<div><small>uncertainty</small><strong>${percent(stage.state.uncertainty)}</strong></div>
-				<div><small>information need</small><strong>${percent(informationNeed)}</strong></div>
-				<div><small>direct observations</small><strong>${stage.state.directObservations}</strong></div>
+			<div class="belief-sections">
+				<div class="belief-section">
+					<small>target-wide opportunity</small>
+					<strong>${fixed(opportunity.perceivedTargetEnergy, 0)} teal</strong>
+				</div>
+				<div class="belief-section">
+					<small>this approach context</small>
+					<div class="belief-metrics">
+						<div><small>breach expectation</small><strong>${percent(approach.expectedBreachProbability)}</strong></div>
+						<div><small>arrival viability</small><strong>${percent(approach.expectedArrivalViability)}</strong></div>
+						<div><small>uncertainty</small><strong>${percent(approach.uncertainty)}</strong></div>
+						<div><small>information need</small><strong>${percent(informationNeed)}</strong></div>
+						<div><small>direct observations</small><strong>${approach.directObservations}</strong></div>
+						<div><small>stale for</small><strong>${fixed(approach.secondsSinceDirectObservation, 0)} s</strong></div>
+					</div>
+				</div>
 			</div>
 		</article>
 	`;
@@ -188,23 +206,27 @@ const meta = {
 		const shell = createLabShell(
 			"Foundations / strategy",
 			"Attacker beliefs and stale information",
-			"Deterrence should emerge because attackers learn from outcomes, not because they read authoritative fortress state. Direct raids update physical expectations; passive teal signatures update opportunity; quiet makes old information uncertain enough to justify later re-probing."
+			"Target richness is global; breach and viability evidence are contextual. A failed R1 route should not teach the attacker that every R3 insertion is equally bad. Direct outcomes update one approach belief, while passive teal signatures update shared opportunity."
 		);
 		shell.frame.innerHTML = `
 			<style>
-				.belief-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:10px; }
+				.belief-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(235px,1fr)); gap:10px; }
 				.belief-card { padding:12px; border:1px solid rgba(228,185,128,.18); background:rgba(10,3,17,.4); }
 				.belief-card header { display:flex; gap:8px; align-items:baseline; }
 				.belief-card header small { opacity:.38; }
-				.belief-card p { min-height:48px; font-size:10px; line-height:1.5; color:rgba(244,237,247,.5); }
+				.belief-card p { min-height:54px; font-size:10px; line-height:1.5; color:rgba(244,237,247,.5); }
+				.belief-sections { display:grid; gap:9px; }
+				.belief-section { border-top:1px solid rgba(244,237,247,.08); padding-top:7px; }
+				.belief-section > small { display:block; margin-bottom:4px; font-size:8px; text-transform:uppercase; letter-spacing:.06em; color:rgba(244,237,247,.38); }
+				.belief-section > strong { font-size:12px; }
 				.belief-metrics { display:grid; grid-template-columns:1fr 1fr; gap:7px; }
-				.belief-metrics > div { border-top:1px solid rgba(244,237,247,.08); padding-top:6px; }
-				.belief-metrics small { display:block; font-size:8px; text-transform:uppercase; letter-spacing:.06em; color:rgba(244,237,247,.38); }
-				.belief-metrics strong { display:block; margin-top:2px; font-size:12px; font-variant-numeric:tabular-nums; }
+				.belief-metrics > div { padding-top:4px; }
+				.belief-metrics small { display:block; font-size:8px; color:rgba(244,237,247,.38); }
+				.belief-metrics strong { display:block; margin-top:2px; font-size:11px; font-variant-numeric:tabular-nums; }
 				.belief-note { margin-top:12px; font-size:10px; line-height:1.5; color:rgba(244,237,247,.48); }
 			</style>
 			<div class="belief-grid">${stages.map((stage, index) => stageCard(stage, calibration, index)).join("")}</div>
-			<div class="belief-note">`information need` is a bounded diagnostic derived from uncertainty × perceived target richness. It does not choose a raid or award hidden ROI; a later planner may use it to compare the value of a cheap probe with ordinary economic return.</div>
+			<div class="belief-note">A caller should share the opportunity belief across the target, but keep separate approach beliefs for materially different sector/tier/insertion contexts. `information need` remains a bounded diagnostic, not a raid authorization or hidden ROI bonus.</div>
 		`;
 		return shell.root;
 	}
@@ -224,7 +246,9 @@ export const LearningAndStaleness: Story = {
 			brightSignatureEnergy: 29000
 		};
 		const stages = buildStages(fixedArgs);
-		await expect(canvasElement.querySelectorAll("[data-stage]").length).toBe(stages.length);
+		await expect(canvasElement.querySelectorAll("[data-stage]").length).toBe(
+			stages.length
+		);
 
 		const prior = stages[0].state;
 		const failures = stages[1].state;
@@ -234,31 +258,90 @@ export const LearningAndStaleness: Story = {
 		const bright = stages[5].state;
 		const probe = stages[6].state;
 
-		await expect(failures.expectedBreachProbability).toBeLessThan(prior.expectedBreachProbability);
-		await expect(failures.expectedArrivalViability).toBeLessThan(prior.expectedArrivalViability);
-		await expect(failures.uncertainty).toBeLessThan(prior.uncertainty);
-		await expect(lucky.expectedBreachProbability).toBeGreaterThan(failures.expectedBreachProbability);
-		await expect(lucky.expectedBreachProbability).toBeLessThan(prior.expectedBreachProbability);
-		await expect(repeatedSuccess.expectedBreachProbability).toBeGreaterThan(lucky.expectedBreachProbability);
-		await expect(quiet.expectedBreachProbability).toBe(repeatedSuccess.expectedBreachProbability);
-		await expect(quiet.expectedArrivalViability).toBe(repeatedSuccess.expectedArrivalViability);
-		await expect(quiet.uncertainty).toBeGreaterThan(repeatedSuccess.uncertainty);
-		await expect(bright.perceivedTargetEnergy).toBeGreaterThan(quiet.perceivedTargetEnergy);
-		await expect(bright.expectedBreachProbability).toBe(quiet.expectedBreachProbability);
-		await expect(probe.uncertainty).toBeLessThan(bright.uncertainty);
+		await expect(failures.approach.expectedBreachProbability).toBeLessThan(
+			prior.approach.expectedBreachProbability
+		);
+		await expect(failures.approach.expectedArrivalViability).toBeLessThan(
+			prior.approach.expectedArrivalViability
+		);
+		await expect(failures.approach.uncertainty).toBeLessThan(
+			prior.approach.uncertainty
+		);
+		await expect(failures.opportunity.perceivedTargetEnergy).toBe(
+			prior.opportunity.perceivedTargetEnergy
+		);
+		await expect(lucky.approach.expectedBreachProbability).toBeGreaterThan(
+			failures.approach.expectedBreachProbability
+		);
+		await expect(lucky.approach.expectedBreachProbability).toBeLessThan(
+			prior.approach.expectedBreachProbability
+		);
+		await expect(
+			repeatedSuccess.approach.expectedBreachProbability
+		).toBeGreaterThan(lucky.approach.expectedBreachProbability);
+		await expect(quiet.approach.expectedBreachProbability).toBe(
+			repeatedSuccess.approach.expectedBreachProbability
+		);
+		await expect(quiet.approach.expectedArrivalViability).toBe(
+			repeatedSuccess.approach.expectedArrivalViability
+		);
+		await expect(quiet.approach.uncertainty).toBeGreaterThan(
+			repeatedSuccess.approach.uncertainty
+		);
+		await expect(bright.opportunity.perceivedTargetEnergy).toBeGreaterThan(
+			quiet.opportunity.perceivedTargetEnergy
+		);
+		await expect(bright.approach.expectedBreachProbability).toBe(
+			quiet.approach.expectedBreachProbability
+		);
+		await expect(probe.approach.uncertainty).toBeLessThan(
+			bright.approach.uncertainty
+		);
 
 		const initial = createRaidBelief(DEFAULT_RAID_BELIEF_PRIOR, calibration);
 		const age30 = repeatAge(initial, 120, 30 * 120, calibration);
 		const age60 = repeatAge(initial, 120, 60 * 120, calibration);
 		const age120 = repeatAge(initial, 120, 120 * 120, calibration);
-		await expect(Math.abs(age30.uncertainty - age60.uncertainty)).toBeLessThan(0.000001);
-		await expect(Math.abs(age60.uncertainty - age120.uncertainty)).toBeLessThan(0.000001);
+		await expect(
+			Math.abs(age30.approach.uncertainty - age60.approach.uncertainty)
+		).toBeLessThan(0.000001);
+		await expect(
+			Math.abs(age60.approach.uncertainty - age120.approach.uncertainty)
+		).toBeLessThan(0.000001);
 
-		const signature30 = repeatSignature(initial, 29000, 16, 30 * 16, calibration);
-		const signature60 = repeatSignature(initial, 29000, 16, 60 * 16, calibration);
-		const signature120 = repeatSignature(initial, 29000, 16, 120 * 16, calibration);
-		await expect(Math.abs(signature30.perceivedTargetEnergy - signature60.perceivedTargetEnergy)).toBeLessThan(0.01);
-		await expect(Math.abs(signature60.perceivedTargetEnergy - signature120.perceivedTargetEnergy)).toBeLessThan(0.01);
+		const signature30 = repeatSignature(
+			initial,
+			29000,
+			16,
+			30 * 16,
+			calibration
+		);
+		const signature60 = repeatSignature(
+			initial,
+			29000,
+			16,
+			60 * 16,
+			calibration
+		);
+		const signature120 = repeatSignature(
+			initial,
+			29000,
+			16,
+			120 * 16,
+			calibration
+		);
+		await expect(
+			Math.abs(
+				signature30.opportunity.perceivedTargetEnergy -
+					signature60.opportunity.perceivedTargetEnergy
+			)
+		).toBeLessThan(0.01);
+		await expect(
+			Math.abs(
+				signature60.opportunity.perceivedTargetEnergy -
+					signature120.opportunity.perceivedTargetEnergy
+			)
+		).toBeLessThan(0.01);
 
 		const malformed = createRaidBelief(
 			{
@@ -269,9 +352,15 @@ export const LearningAndStaleness: Story = {
 			},
 			calibration
 		);
-		await expect(Number.isFinite(malformed.perceivedTargetEnergy)).toBe(true);
-		await expect(Number.isFinite(malformed.expectedBreachProbability)).toBe(true);
-		await expect(Number.isFinite(malformed.expectedArrivalViability)).toBe(true);
-		await expect(Number.isFinite(malformed.uncertainty)).toBe(true);
+		await expect(
+			Number.isFinite(malformed.opportunity.perceivedTargetEnergy)
+		).toBe(true);
+		await expect(
+			Number.isFinite(malformed.approach.expectedBreachProbability)
+		).toBe(true);
+		await expect(
+			Number.isFinite(malformed.approach.expectedArrivalViability)
+		).toBe(true);
+		await expect(Number.isFinite(malformed.approach.uncertainty)).toBe(true);
 	}
 };

--- a/experiments/storybook/src/Foundations/Strategy/RaidBelief.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/RaidBelief.stories.ts
@@ -1,0 +1,277 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	ageRaidBelief,
+	createRaidBelief,
+	DEFAULT_RAID_BELIEF_CALIBRATION,
+	DEFAULT_RAID_BELIEF_PRIOR,
+	observeRaidOutcome,
+	observeRaidSignature,
+	raidBeliefInformationNeed,
+	type RaidBeliefCalibration,
+	type RaidBeliefState
+} from "@defend/gameplay/raidBelief";
+import { createLabShell } from "../../labTheme";
+
+type RaidBeliefArgs = {
+	failureCount: number;
+	failedViability: number;
+	successViability: number;
+	quietSeconds: number;
+	brightSignatureEnergy: number;
+};
+
+type BeliefStage = {
+	label: string;
+	note: string;
+	state: RaidBeliefState;
+};
+
+function fixed(value: number, digits = 2): string {
+	if (value !== value || value === Infinity || value === -Infinity) return "0";
+	return value.toFixed(digits);
+}
+
+function percent(value: number): string {
+	return `${fixed(value * 100, 0)}%`;
+}
+
+function buildStages(args: RaidBeliefArgs): BeliefStage[] {
+	const calibration = DEFAULT_RAID_BELIEF_CALIBRATION;
+	const initial = createRaidBelief(DEFAULT_RAID_BELIEF_PRIOR, calibration);
+	let state = initial;
+	const stages: BeliefStage[] = [
+		{
+			label: "Prior",
+			note: "Valuable target, optimistic but uncertain physical expectations.",
+			state
+		}
+	];
+
+	for (let index = 0; index < Math.max(1, Math.floor(args.failureCount)); index += 1) {
+		state = observeRaidOutcome(
+			state,
+			{ breached: false, remainingViability: args.failedViability, reliability: 1 },
+			calibration
+		);
+	}
+	stages.push({
+		label: "Repeated failures",
+		note: "Direct evidence lowers breach/viability expectations and reduces uncertainty.",
+		state
+	});
+
+	state = observeRaidOutcome(
+		state,
+		{ breached: true, remainingViability: args.successViability, reliability: 1 },
+		calibration
+	);
+	stages.push({
+		label: "One lucky success",
+		note: "Belief recovers partially; one result does not erase the accumulated history.",
+		state
+	});
+
+	for (let index = 0; index < 4; index += 1) {
+		state = observeRaidOutcome(
+			state,
+			{ breached: true, remainingViability: Math.min(1, args.successViability + 0.08), reliability: 1 },
+			calibration
+		);
+	}
+	stages.push({
+		label: "Repeated success",
+		note: "Accumulated contrary evidence can restore broader confidence.",
+		state
+	});
+
+	state = ageRaidBelief(state, args.quietSeconds, calibration);
+	stages.push({
+		label: "Deterrent quiet",
+		note: "Physical means remain unchanged, but old information becomes stale and uncertainty rises.",
+		state
+	});
+
+	state = observeRaidSignature(
+		state,
+		args.brightSignatureEnergy,
+		16,
+		calibration
+	);
+	stages.push({
+		label: "Target brightens",
+		note: "Passive teal evidence raises perceived opportunity without revealing hidden defense quality.",
+		state
+	});
+
+	state = observeRaidOutcome(
+		state,
+		{ breached: false, remainingViability: args.failedViability, reliability: 1 },
+		calibration
+	);
+	stages.push({
+		label: "Fresh probe",
+		note: "A new direct observation reduces uncertainty and updates the physical estimate again.",
+		state
+	});
+
+	return stages;
+}
+
+function stageCard(stage: BeliefStage, calibration: RaidBeliefCalibration, index: number): string {
+	const informationNeed = raidBeliefInformationNeed(stage.state, calibration);
+	return `
+		<article class="belief-card" data-stage="${index}" data-breach="${stage.state.expectedBreachProbability}" data-viability="${stage.state.expectedArrivalViability}" data-uncertainty="${stage.state.uncertainty}" data-energy="${stage.state.perceivedTargetEnergy}" data-information-need="${informationNeed}">
+			<header><small>${String(index + 1).padStart(2, "0")}</small><strong>${stage.label}</strong></header>
+			<p>${stage.note}</p>
+			<div class="belief-metrics">
+				<div><small>perceived energy</small><strong>${fixed(stage.state.perceivedTargetEnergy, 0)}</strong></div>
+				<div><small>breach expectation</small><strong>${percent(stage.state.expectedBreachProbability)}</strong></div>
+				<div><small>arrival viability</small><strong>${percent(stage.state.expectedArrivalViability)}</strong></div>
+				<div><small>uncertainty</small><strong>${percent(stage.state.uncertainty)}</strong></div>
+				<div><small>information need</small><strong>${percent(informationNeed)}</strong></div>
+				<div><small>direct observations</small><strong>${stage.state.directObservations}</strong></div>
+			</div>
+		</article>
+	`;
+}
+
+function repeatAge(
+	initial: RaidBeliefState,
+	totalSeconds: number,
+	steps: number,
+	calibration: RaidBeliefCalibration
+): RaidBeliefState {
+	let state = initial;
+	const delta = totalSeconds / Math.max(1, steps);
+	for (let index = 0; index < steps; index += 1) {
+		state = ageRaidBelief(state, delta, calibration);
+	}
+	return state;
+}
+
+function repeatSignature(
+	initial: RaidBeliefState,
+	targetEnergy: number,
+	totalSeconds: number,
+	steps: number,
+	calibration: RaidBeliefCalibration
+): RaidBeliefState {
+	let state = initial;
+	const delta = totalSeconds / Math.max(1, steps);
+	for (let index = 0; index < steps; index += 1) {
+		state = observeRaidSignature(state, targetEnergy, delta, calibration);
+	}
+	return state;
+}
+
+const meta = {
+	title: "Foundations/Strategy/Raid Belief",
+	tags: ["test", "visual"],
+	args: {
+		failureCount: 5,
+		failedViability: 0.12,
+		successViability: 0.65,
+		quietSeconds: 180,
+		brightSignatureEnergy: 29000
+	},
+	argTypes: {
+		failureCount: { control: { type: "range", min: 1, max: 12, step: 1 } },
+		failedViability: { control: { type: "range", min: 0, max: 0.5, step: 0.02 } },
+		successViability: { control: { type: "range", min: 0.3, max: 1, step: 0.02 } },
+		quietSeconds: { control: { type: "range", min: 0, max: 600, step: 15 } },
+		brightSignatureEnergy: { control: { type: "range", min: 1000, max: 30000, step: 1000 } }
+	},
+	render: (args: RaidBeliefArgs) => {
+		const calibration = DEFAULT_RAID_BELIEF_CALIBRATION;
+		const stages = buildStages(args);
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Attacker beliefs and stale information",
+			"Deterrence should emerge because attackers learn from outcomes, not because they read authoritative fortress state. Direct raids update physical expectations; passive teal signatures update opportunity; quiet makes old information uncertain enough to justify later re-probing."
+		);
+		shell.frame.innerHTML = `
+			<style>
+				.belief-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:10px; }
+				.belief-card { padding:12px; border:1px solid rgba(228,185,128,.18); background:rgba(10,3,17,.4); }
+				.belief-card header { display:flex; gap:8px; align-items:baseline; }
+				.belief-card header small { opacity:.38; }
+				.belief-card p { min-height:48px; font-size:10px; line-height:1.5; color:rgba(244,237,247,.5); }
+				.belief-metrics { display:grid; grid-template-columns:1fr 1fr; gap:7px; }
+				.belief-metrics > div { border-top:1px solid rgba(244,237,247,.08); padding-top:6px; }
+				.belief-metrics small { display:block; font-size:8px; text-transform:uppercase; letter-spacing:.06em; color:rgba(244,237,247,.38); }
+				.belief-metrics strong { display:block; margin-top:2px; font-size:12px; font-variant-numeric:tabular-nums; }
+				.belief-note { margin-top:12px; font-size:10px; line-height:1.5; color:rgba(244,237,247,.48); }
+			</style>
+			<div class="belief-grid">${stages.map((stage, index) => stageCard(stage, calibration, index)).join("")}</div>
+			<div class="belief-note">`information need` is a bounded diagnostic derived from uncertainty × perceived target richness. It does not choose a raid or award hidden ROI; a later planner may use it to compare the value of a cheap probe with ordinary economic return.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<RaidBeliefArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LearningAndStaleness: Story = {
+	play: async ({ canvasElement }) => {
+		const calibration = DEFAULT_RAID_BELIEF_CALIBRATION;
+		const fixedArgs: RaidBeliefArgs = {
+			failureCount: 5,
+			failedViability: 0.12,
+			successViability: 0.65,
+			quietSeconds: 180,
+			brightSignatureEnergy: 29000
+		};
+		const stages = buildStages(fixedArgs);
+		await expect(canvasElement.querySelectorAll("[data-stage]").length).toBe(stages.length);
+
+		const prior = stages[0].state;
+		const failures = stages[1].state;
+		const lucky = stages[2].state;
+		const repeatedSuccess = stages[3].state;
+		const quiet = stages[4].state;
+		const bright = stages[5].state;
+		const probe = stages[6].state;
+
+		await expect(failures.expectedBreachProbability).toBeLessThan(prior.expectedBreachProbability);
+		await expect(failures.expectedArrivalViability).toBeLessThan(prior.expectedArrivalViability);
+		await expect(failures.uncertainty).toBeLessThan(prior.uncertainty);
+		await expect(lucky.expectedBreachProbability).toBeGreaterThan(failures.expectedBreachProbability);
+		await expect(lucky.expectedBreachProbability).toBeLessThan(prior.expectedBreachProbability);
+		await expect(repeatedSuccess.expectedBreachProbability).toBeGreaterThan(lucky.expectedBreachProbability);
+		await expect(quiet.expectedBreachProbability).toBe(repeatedSuccess.expectedBreachProbability);
+		await expect(quiet.expectedArrivalViability).toBe(repeatedSuccess.expectedArrivalViability);
+		await expect(quiet.uncertainty).toBeGreaterThan(repeatedSuccess.uncertainty);
+		await expect(bright.perceivedTargetEnergy).toBeGreaterThan(quiet.perceivedTargetEnergy);
+		await expect(bright.expectedBreachProbability).toBe(quiet.expectedBreachProbability);
+		await expect(probe.uncertainty).toBeLessThan(bright.uncertainty);
+
+		const initial = createRaidBelief(DEFAULT_RAID_BELIEF_PRIOR, calibration);
+		const age30 = repeatAge(initial, 120, 30 * 120, calibration);
+		const age60 = repeatAge(initial, 120, 60 * 120, calibration);
+		const age120 = repeatAge(initial, 120, 120 * 120, calibration);
+		await expect(Math.abs(age30.uncertainty - age60.uncertainty)).toBeLessThan(0.000001);
+		await expect(Math.abs(age60.uncertainty - age120.uncertainty)).toBeLessThan(0.000001);
+
+		const signature30 = repeatSignature(initial, 29000, 16, 30 * 16, calibration);
+		const signature60 = repeatSignature(initial, 29000, 16, 60 * 16, calibration);
+		const signature120 = repeatSignature(initial, 29000, 16, 120 * 16, calibration);
+		await expect(Math.abs(signature30.perceivedTargetEnergy - signature60.perceivedTargetEnergy)).toBeLessThan(0.01);
+		await expect(Math.abs(signature60.perceivedTargetEnergy - signature120.perceivedTargetEnergy)).toBeLessThan(0.01);
+
+		const malformed = createRaidBelief(
+			{
+				perceivedTargetEnergy: Number.POSITIVE_INFINITY,
+				expectedBreachProbability: Number.NaN,
+				expectedArrivalViability: Number.NEGATIVE_INFINITY,
+				uncertainty: Number.POSITIVE_INFINITY
+			},
+			calibration
+		);
+		await expect(Number.isFinite(malformed.perceivedTargetEnergy)).toBe(true);
+		await expect(Number.isFinite(malformed.expectedBreachProbability)).toBe(true);
+		await expect(Number.isFinite(malformed.expectedArrivalViability)).toBe(true);
+		await expect(Number.isFinite(malformed.uncertainty)).toBe(true);
+	}
+};

--- a/src/js/gameplay/raidBelief.ts
+++ b/src/js/gameplay/raidBelief.ts
@@ -1,0 +1,255 @@
+export interface RaidBeliefState {
+	perceivedTargetEnergy: number;
+	expectedBreachProbability: number;
+	expectedArrivalViability: number;
+	uncertainty: number;
+	directObservations: number;
+	secondsSinceDirectObservation: number;
+}
+
+export interface RaidBeliefCalibration {
+	targetEnergyCapacity: number;
+	signatureHalfLifeSeconds: number;
+	uncertaintyStaleHalfLifeSeconds: number;
+	breachObservationWeight: number;
+	viabilityObservationWeight: number;
+	directUncertaintyReduction: number;
+}
+
+export interface RaidBeliefPrior {
+	perceivedTargetEnergy: number;
+	expectedBreachProbability: number;
+	expectedArrivalViability: number;
+	uncertainty: number;
+}
+
+export interface RaidOutcomeObservation {
+	breached: boolean;
+	remainingViability: number;
+	reliability: number;
+}
+
+export interface RaidBeliefExpectedValueInputs {
+	perceivedTargetEnergy: number;
+	expectedBreachProbability: number;
+	expectedArrivalViability: number;
+}
+
+function finite(value: number, fallback = 0): number {
+	if (value !== value || value === Infinity || value === -Infinity) return fallback;
+	return value;
+}
+
+function positive(value: number): number {
+	return Math.max(0, finite(value));
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
+}
+
+function clamp01(value: number): number {
+	return clamp(value, 0, 1);
+}
+
+function normalizeCalibration(
+	input: RaidBeliefCalibration
+): RaidBeliefCalibration {
+	return {
+		targetEnergyCapacity: Math.max(1, positive(input.targetEnergyCapacity)),
+		signatureHalfLifeSeconds: positive(input.signatureHalfLifeSeconds),
+		uncertaintyStaleHalfLifeSeconds: positive(
+			input.uncertaintyStaleHalfLifeSeconds
+		),
+		breachObservationWeight: clamp01(input.breachObservationWeight),
+		viabilityObservationWeight: clamp01(input.viabilityObservationWeight),
+		directUncertaintyReduction: clamp01(input.directUncertaintyReduction)
+	};
+}
+
+function timeAlpha(deltaSeconds: number, halfLifeSeconds: number): number {
+	const delta = positive(deltaSeconds);
+	if (delta <= 0) return 0;
+	if (halfLifeSeconds <= 0) return 1;
+	return 1 - Math.pow(0.5, delta / halfLifeSeconds);
+}
+
+export function createRaidBelief(
+	prior: RaidBeliefPrior,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefState {
+	const calibration = normalizeCalibration(calibrationInput);
+	return {
+		perceivedTargetEnergy: clamp(
+			prior.perceivedTargetEnergy,
+			0,
+			calibration.targetEnergyCapacity
+		),
+		expectedBreachProbability: clamp01(prior.expectedBreachProbability),
+		expectedArrivalViability: clamp01(prior.expectedArrivalViability),
+		uncertainty: clamp01(prior.uncertainty),
+		directObservations: 0,
+		secondsSinceDirectObservation: 0
+	};
+}
+
+/**
+ * Age information without changing the mean physical belief. A quiet target may
+ * have changed because towers degrade, geometry changes and reserves move, so
+ * certainty erodes even though the attacker has not received evidence that the
+ * target became easier or harder.
+ */
+export function ageRaidBelief(
+	state: RaidBeliefState,
+	deltaSeconds: number,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefState {
+	const calibration = normalizeCalibration(calibrationInput);
+	const delta = positive(deltaSeconds);
+	const staleAlpha = timeAlpha(
+		delta,
+		calibration.uncertaintyStaleHalfLifeSeconds
+	);
+	return {
+		perceivedTargetEnergy: clamp(
+			state.perceivedTargetEnergy,
+			0,
+			calibration.targetEnergyCapacity
+		),
+		expectedBreachProbability: clamp01(state.expectedBreachProbability),
+		expectedArrivalViability: clamp01(state.expectedArrivalViability),
+		uncertainty: clamp01(
+			state.uncertainty + (1 - state.uncertainty) * staleAlpha
+		),
+		directObservations: Math.max(
+			0,
+			Math.floor(positive(state.directObservations))
+		),
+		secondsSinceDirectObservation:
+			positive(state.secondsSinceDirectObservation) + delta
+	};
+}
+
+/**
+ * A passive teal signature updates perceived opportunity but not hidden defense
+ * quality. The time-domain half-life keeps a constant observation equivalent
+ * across different sampling cadences.
+ */
+export function observeRaidSignature(
+	stateInput: RaidBeliefState,
+	observedTargetEnergy: number,
+	deltaSeconds: number,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefState {
+	const calibration = normalizeCalibration(calibrationInput);
+	const state = ageRaidBelief(stateInput, deltaSeconds, calibration);
+	const target = clamp(
+		observedTargetEnergy,
+		0,
+		calibration.targetEnergyCapacity
+	);
+	const alpha = timeAlpha(deltaSeconds, calibration.signatureHalfLifeSeconds);
+	return {
+		perceivedTargetEnergy:
+			state.perceivedTargetEnergy +
+			(target - state.perceivedTargetEnergy) * alpha,
+		expectedBreachProbability: state.expectedBreachProbability,
+		expectedArrivalViability: state.expectedArrivalViability,
+		uncertainty: state.uncertainty,
+		directObservations: state.directObservations,
+		secondsSinceDirectObservation: state.secondsSinceDirectObservation
+	};
+}
+
+/**
+ * Direct raid evidence updates breach and viability expectations gradually. A
+ * single success after repeated failure cannot reset the model to perfect
+ * optimism; repeated evidence is required. Direct evidence also makes current
+ * information less uncertain and resets its staleness clock.
+ */
+export function observeRaidOutcome(
+	stateInput: RaidBeliefState,
+	observation: RaidOutcomeObservation,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefState {
+	const calibration = normalizeCalibration(calibrationInput);
+	const reliability = clamp01(observation.reliability);
+	const breachAlpha = calibration.breachObservationWeight * reliability;
+	const viabilityAlpha = calibration.viabilityObservationWeight * reliability;
+	const breachEvidence = observation.breached ? 1 : 0;
+	const viabilityEvidence = clamp01(observation.remainingViability);
+	const breach = clamp01(
+		stateInput.expectedBreachProbability +
+			(breachEvidence - stateInput.expectedBreachProbability) * breachAlpha
+	);
+	const viability = clamp01(
+		stateInput.expectedArrivalViability +
+			(viabilityEvidence - stateInput.expectedArrivalViability) * viabilityAlpha
+	);
+	const uncertaintyRetention =
+		1 - calibration.directUncertaintyReduction * reliability;
+
+	return {
+		perceivedTargetEnergy: clamp(
+			stateInput.perceivedTargetEnergy,
+			0,
+			calibration.targetEnergyCapacity
+		),
+		expectedBreachProbability: breach,
+		expectedArrivalViability: viability,
+		uncertainty: clamp01(stateInput.uncertainty * uncertaintyRetention),
+		directObservations:
+			Math.max(0, Math.floor(positive(stateInput.directObservations))) + 1,
+		secondsSinceDirectObservation: 0
+	};
+}
+
+/**
+ * Bounded information-need signal for downstream probe experiments. It does not
+ * choose a raid or grant an economic bonus. A stale belief matters more when the
+ * target still appears valuable; a dim target has little reason to re-check.
+ */
+export function raidBeliefInformationNeed(
+	state: RaidBeliefState,
+	calibrationInput: RaidBeliefCalibration
+): number {
+	const calibration = normalizeCalibration(calibrationInput);
+	const richness = clamp(
+		positive(state.perceivedTargetEnergy) / calibration.targetEnergyCapacity,
+		0,
+		1
+	);
+	return clamp01(clamp01(state.uncertainty) * Math.sqrt(richness));
+}
+
+export function raidBeliefExpectedValueInputs(
+	state: RaidBeliefState,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefExpectedValueInputs {
+	const calibration = normalizeCalibration(calibrationInput);
+	return {
+		perceivedTargetEnergy: clamp(
+			state.perceivedTargetEnergy,
+			0,
+			calibration.targetEnergyCapacity
+		),
+		expectedBreachProbability: clamp01(state.expectedBreachProbability),
+		expectedArrivalViability: clamp01(state.expectedArrivalViability)
+	};
+}
+
+export const DEFAULT_RAID_BELIEF_CALIBRATION: RaidBeliefCalibration = {
+	targetEnergyCapacity: 30000,
+	signatureHalfLifeSeconds: 8,
+	uncertaintyStaleHalfLifeSeconds: 90,
+	breachObservationWeight: 0.18,
+	viabilityObservationWeight: 0.22,
+	directUncertaintyReduction: 0.45
+};
+
+export const DEFAULT_RAID_BELIEF_PRIOR: RaidBeliefPrior = {
+	perceivedTargetEnergy: 24000,
+	expectedBreachProbability: 0.74,
+	expectedArrivalViability: 0.68,
+	uncertainty: 0.58
+};

--- a/src/js/gameplay/raidBelief.ts
+++ b/src/js/gameplay/raidBelief.ts
@@ -1,10 +1,23 @@
-export interface RaidBeliefState {
+export interface RaidOpportunityBelief {
 	perceivedTargetEnergy: number;
+}
+
+export interface RaidApproachBelief {
 	expectedBreachProbability: number;
 	expectedArrivalViability: number;
 	uncertainty: number;
 	directObservations: number;
 	secondsSinceDirectObservation: number;
+}
+
+/**
+ * Convenience composite for one target + one approach context. Callers should
+ * share `opportunity` across a target while keeping separate `approach` beliefs
+ * for materially different sector/tier/insertion contexts.
+ */
+export interface RaidBeliefState {
+	opportunity: RaidOpportunityBelief;
+	approach: RaidApproachBelief;
 }
 
 export interface RaidBeliefCalibration {
@@ -74,17 +87,24 @@ function timeAlpha(deltaSeconds: number, halfLifeSeconds: number): number {
 	return 1 - Math.pow(0.5, delta / halfLifeSeconds);
 }
 
-export function createRaidBelief(
-	prior: RaidBeliefPrior,
+export function createRaidOpportunityBelief(
+	perceivedTargetEnergy: number,
 	calibrationInput: RaidBeliefCalibration
-): RaidBeliefState {
+): RaidOpportunityBelief {
 	const calibration = normalizeCalibration(calibrationInput);
 	return {
 		perceivedTargetEnergy: clamp(
-			prior.perceivedTargetEnergy,
+			perceivedTargetEnergy,
 			0,
 			calibration.targetEnergyCapacity
-		),
+		)
+	};
+}
+
+export function createRaidApproachBelief(
+	prior: RaidBeliefPrior
+): RaidApproachBelief {
+	return {
 		expectedBreachProbability: clamp01(prior.expectedBreachProbability),
 		expectedArrivalViability: clamp01(prior.expectedArrivalViability),
 		uncertainty: clamp01(prior.uncertainty),
@@ -93,56 +113,85 @@ export function createRaidBelief(
 	};
 }
 
-/**
- * Age information without changing the mean physical belief. A quiet target may
- * have changed because towers degrade, geometry changes and reserves move, so
- * certainty erodes even though the attacker has not received evidence that the
- * target became easier or harder.
- */
-export function ageRaidBelief(
-	state: RaidBeliefState,
-	deltaSeconds: number,
+export function createRaidBelief(
+	prior: RaidBeliefPrior,
 	calibrationInput: RaidBeliefCalibration
 ): RaidBeliefState {
+	return {
+		opportunity: createRaidOpportunityBelief(
+			prior.perceivedTargetEnergy,
+			calibrationInput
+		),
+		approach: createRaidApproachBelief(prior)
+	};
+}
+
+/**
+ * Age one approach context without changing its mean physical belief. Callers
+ * may age many approach beliefs independently while sharing one target-level
+ * opportunity belief.
+ */
+export function ageRaidApproachBelief(
+	approach: RaidApproachBelief,
+	deltaSeconds: number,
+	calibrationInput: RaidBeliefCalibration
+): RaidApproachBelief {
 	const calibration = normalizeCalibration(calibrationInput);
 	const delta = positive(deltaSeconds);
 	const staleAlpha = timeAlpha(
 		delta,
 		calibration.uncertaintyStaleHalfLifeSeconds
 	);
+	const uncertainty = clamp01(approach.uncertainty);
 	return {
-		perceivedTargetEnergy: clamp(
-			state.perceivedTargetEnergy,
-			0,
-			calibration.targetEnergyCapacity
-		),
-		expectedBreachProbability: clamp01(state.expectedBreachProbability),
-		expectedArrivalViability: clamp01(state.expectedArrivalViability),
+		expectedBreachProbability: clamp01(approach.expectedBreachProbability),
+		expectedArrivalViability: clamp01(approach.expectedArrivalViability),
 		uncertainty: clamp01(
-			state.uncertainty + (1 - state.uncertainty) * staleAlpha
+			uncertainty + (1 - uncertainty) * staleAlpha
 		),
 		directObservations: Math.max(
 			0,
-			Math.floor(positive(state.directObservations))
+			Math.floor(positive(approach.directObservations))
 		),
 		secondsSinceDirectObservation:
-			positive(state.secondsSinceDirectObservation) + delta
+			positive(approach.secondsSinceDirectObservation) + delta
+	};
+}
+
+export function ageRaidBelief(
+	state: RaidBeliefState,
+	deltaSeconds: number,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefState {
+	return {
+		opportunity: createRaidOpportunityBelief(
+			state.opportunity.perceivedTargetEnergy,
+			calibrationInput
+		),
+		approach: ageRaidApproachBelief(
+			state.approach,
+			deltaSeconds,
+			calibrationInput
+		)
 	};
 }
 
 /**
- * A passive teal signature updates perceived opportunity but not hidden defense
- * quality. The time-domain half-life keeps a constant observation equivalent
- * across different sampling cadences.
+ * Update target-global opportunity from a lossy teal signature. This function
+ * knows nothing about a route, raider tier or defense quality.
  */
-export function observeRaidSignature(
-	stateInput: RaidBeliefState,
+export function observeRaidOpportunitySignature(
+	opportunity: RaidOpportunityBelief,
 	observedTargetEnergy: number,
 	deltaSeconds: number,
 	calibrationInput: RaidBeliefCalibration
-): RaidBeliefState {
+): RaidOpportunityBelief {
 	const calibration = normalizeCalibration(calibrationInput);
-	const state = ageRaidBelief(stateInput, deltaSeconds, calibration);
+	const current = clamp(
+		opportunity.perceivedTargetEnergy,
+		0,
+		calibration.targetEnergyCapacity
+	);
 	const target = clamp(
 		observedTargetEnergy,
 		0,
@@ -150,64 +199,92 @@ export function observeRaidSignature(
 	);
 	const alpha = timeAlpha(deltaSeconds, calibration.signatureHalfLifeSeconds);
 	return {
-		perceivedTargetEnergy:
-			state.perceivedTargetEnergy +
-			(target - state.perceivedTargetEnergy) * alpha,
-		expectedBreachProbability: state.expectedBreachProbability,
-		expectedArrivalViability: state.expectedArrivalViability,
-		uncertainty: state.uncertainty,
-		directObservations: state.directObservations,
-		secondsSinceDirectObservation: state.secondsSinceDirectObservation
+		perceivedTargetEnergy: current + (target - current) * alpha
+	};
+}
+
+/** Convenience composite: time passes for this approach while the target-wide
+ * passive signature updates opportunity only. */
+export function observeRaidSignature(
+	state: RaidBeliefState,
+	observedTargetEnergy: number,
+	deltaSeconds: number,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefState {
+	return {
+		opportunity: observeRaidOpportunitySignature(
+			state.opportunity,
+			observedTargetEnergy,
+			deltaSeconds,
+			calibrationInput
+		),
+		approach: ageRaidApproachBelief(
+			state.approach,
+			deltaSeconds,
+			calibrationInput
+		)
 	};
 }
 
 /**
- * Direct raid evidence updates breach and viability expectations gradually. A
- * single success after repeated failure cannot reset the model to perfect
- * optimism; repeated evidence is required. Direct evidence also makes current
- * information less uncertain and resets its staleness clock.
+ * Direct raid evidence updates one contextual approach belief only. A failed R1
+ * path therefore need not change the belief for a different R3 insertion unless
+ * the caller intentionally shares that context.
  */
-export function observeRaidOutcome(
-	stateInput: RaidBeliefState,
+export function observeRaidApproachOutcome(
+	approach: RaidApproachBelief,
 	observation: RaidOutcomeObservation,
 	calibrationInput: RaidBeliefCalibration
-): RaidBeliefState {
+): RaidApproachBelief {
 	const calibration = normalizeCalibration(calibrationInput);
 	const reliability = clamp01(observation.reliability);
 	const breachAlpha = calibration.breachObservationWeight * reliability;
 	const viabilityAlpha = calibration.viabilityObservationWeight * reliability;
 	const breachEvidence = observation.breached ? 1 : 0;
 	const viabilityEvidence = clamp01(observation.remainingViability);
-	const breach = clamp01(
-		stateInput.expectedBreachProbability +
-			(breachEvidence - stateInput.expectedBreachProbability) * breachAlpha
-	);
-	const viability = clamp01(
-		stateInput.expectedArrivalViability +
-			(viabilityEvidence - stateInput.expectedArrivalViability) * viabilityAlpha
-	);
+	const currentBreach = clamp01(approach.expectedBreachProbability);
+	const currentViability = clamp01(approach.expectedArrivalViability);
+	const uncertainty = clamp01(approach.uncertainty);
 	const uncertaintyRetention =
 		1 - calibration.directUncertaintyReduction * reliability;
 
 	return {
-		perceivedTargetEnergy: clamp(
-			stateInput.perceivedTargetEnergy,
-			0,
-			calibration.targetEnergyCapacity
+		expectedBreachProbability: clamp01(
+			currentBreach + (breachEvidence - currentBreach) * breachAlpha
 		),
-		expectedBreachProbability: breach,
-		expectedArrivalViability: viability,
-		uncertainty: clamp01(stateInput.uncertainty * uncertaintyRetention),
+		expectedArrivalViability: clamp01(
+			currentViability +
+				(viabilityEvidence - currentViability) * viabilityAlpha
+		),
+		uncertainty: clamp01(uncertainty * uncertaintyRetention),
 		directObservations:
-			Math.max(0, Math.floor(positive(stateInput.directObservations))) + 1,
+			Math.max(0, Math.floor(positive(approach.directObservations))) + 1,
 		secondsSinceDirectObservation: 0
 	};
 }
 
+export function observeRaidOutcome(
+	state: RaidBeliefState,
+	observation: RaidOutcomeObservation,
+	calibrationInput: RaidBeliefCalibration
+): RaidBeliefState {
+	return {
+		opportunity: createRaidOpportunityBelief(
+			state.opportunity.perceivedTargetEnergy,
+			calibrationInput
+		),
+		approach: observeRaidApproachOutcome(
+			state.approach,
+			observation,
+			calibrationInput
+		)
+	};
+}
+
 /**
- * Bounded information-need signal for downstream probe experiments. It does not
- * choose a raid or grant an economic bonus. A stale belief matters more when the
- * target still appears valuable; a dim target has little reason to re-check.
+ * Bounded information-need signal for one approach context. It does not choose
+ * a raid or grant economic return. A stale route belief matters more when the
+ * shared target still appears valuable.
  */
 export function raidBeliefInformationNeed(
 	state: RaidBeliefState,
@@ -215,11 +292,14 @@ export function raidBeliefInformationNeed(
 ): number {
 	const calibration = normalizeCalibration(calibrationInput);
 	const richness = clamp(
-		positive(state.perceivedTargetEnergy) / calibration.targetEnergyCapacity,
+		positive(state.opportunity.perceivedTargetEnergy) /
+			calibration.targetEnergyCapacity,
 		0,
 		1
 	);
-	return clamp01(clamp01(state.uncertainty) * Math.sqrt(richness));
+	return clamp01(
+		clamp01(state.approach.uncertainty) * Math.sqrt(richness)
+	);
 }
 
 export function raidBeliefExpectedValueInputs(
@@ -229,12 +309,16 @@ export function raidBeliefExpectedValueInputs(
 	const calibration = normalizeCalibration(calibrationInput);
 	return {
 		perceivedTargetEnergy: clamp(
-			state.perceivedTargetEnergy,
+			state.opportunity.perceivedTargetEnergy,
 			0,
 			calibration.targetEnergyCapacity
 		),
-		expectedBreachProbability: clamp01(state.expectedBreachProbability),
-		expectedArrivalViability: clamp01(state.expectedArrivalViability)
+		expectedBreachProbability: clamp01(
+			state.approach.expectedBreachProbability
+		),
+		expectedArrivalViability: clamp01(
+			state.approach.expectedArrivalViability
+		)
 	};
 }
 


### PR DESCRIPTION
Refs #126, #107, #103
Related: #73, #76, #119, #124, #125

## Purpose

Make deterrence compatible with rational but non-omniscient attackers by introducing a small history-updated belief state that can feed later expected-value planners.

The campaign should not jump from strong defense directly to silence because AI reads authoritative fortress strength. Attackers should learn through outcomes, reduce commitment, probe while information remains uncertain, go quiet when failure becomes well established, and eventually re-check a world whose old information has become stale.

## Scope

Base: `master` `e9852845601606db97fc7a2931b69fd7d1af6d23`.

Exactly two added files:

- `src/js/gameplay/raidBelief.ts`;
- `experiments/storybook/src/Foundations/Strategy/RaidBelief.stories.ts`.

No production AI/wave call sites, package/dependency metadata, economy constants, rendering, Babylon/Cannon objects, timers, Workers, or frozen #92 certification heads are changed.

## Belief boundary

The pure model owns estimates only:

- perceived target energy;
- expected breach probability;
- expected arrival viability;
- uncertainty/staleness;
- direct observation count;
- time since direct observation.

It does not choose a raider tier, calculate final ROI, mutate authoritative reserve, or inspect hidden defense state.

Downstream experiments can feed these estimates into #119's target-bounded expected value or #125's embodied-capital expected value.

## Passive signature observation

`observeRaidSignature()` moves perceived target energy toward a lossy observed teal-energy signal with a time-domain half-life.

It deliberately does **not** reveal breach probability or defense quality. A brightening target can become more interesting without magically becoming easier.

The smoothing is time-based so a constant signal is equivalent at different observation cadences.

## Direct raid evidence

`observeRaidOutcome()` gradually updates:

- breach expectation toward observed breach/failure;
- arrival viability toward observed survivor viability;
- uncertainty downward because direct evidence is fresh.

The update is bounded and caller-calibrated. One lucky result cannot reset a history of failures; repeated contrary evidence is required.

## Staleness

`ageRaidBelief()` leaves mean breach/viability beliefs unchanged but increases uncertainty toward 1 with a time-domain half-life.

This represents a quiet world's capacity to change through tower degradation, topology changes and reserve movement without granting the attacker free information about the direction of that change.

## Information-need diagnostic

`raidBeliefInformationNeed()` returns a bounded diagnostic:

`uncertainty × sqrt(perceived target richness)`

It does not authorize a raid or add hidden economic return. A later planner may compare this information need with the bounded cost of an R1 probe.

The intended consequence is:

- dim + uncertain target: little reason to inspect;
- valuable + well-known bad target: little immediate reason to inspect;
- valuable + stale target: meaningful reason for a cheap probe.

## Storybook witness

Adds `Foundations/Strategy/Raid Belief` showing:

1. optimistic prior;
2. repeated failed raids;
3. one lucky success;
4. repeated success;
5. deterrent quiet;
6. target signature brightening;
7. fresh probe.

The fixture demonstrates:

- repeated failures gradually lower breach and viability expectations;
- one success only partially reverses the history;
- repeated success can genuinely restore expectations;
- quiet increases uncertainty without changing physical means;
- passive brightness raises perceived opportunity without changing defense estimates;
- a fresh direct probe reduces uncertainty again.

## Deterministic invariants

The Storybook `play` test verifies the learning/staleness relationships above and additionally compares equivalent 30/60/120 Hz aging and passive-signature sequences. Time-domain updates converge to the same state within tight tolerance.

Malformed/non-finite prior inputs are also required to normalize to finite bounded state.

## Design consequence

This creates an explicit separation between:

- **world truth** — authoritative simulation;
- **observable evidence** — signatures and raid outcomes;
- **attacker belief** — imperfect estimates;
- **planner economics** — #119/#125;
- **behavior** — later commitment/probe policy.

That separation is important for fairness and legibility: an attacker should adapt because of evidence the player can plausibly understand, not because an invisible director knows the correct answer.

## Validation / follow-up

Keep draft until a later post-freeze campaign can run root compatibility plus Storybook typecheck/build/test.

Then:

- sweep update rates and staleness half-life;
- test noisy/partial-reliability observations;
- connect belief outputs to #119/#125 in a headless planner experiment;
- assign explicit bounded information value to probes rather than a tier-specific bonus;
- prove one lucky probe cannot restore heavy commitment immediately;
- test long-horizon `adapt → probe → quiet → stale → re-probe` behavior in #107;
- calibrate observation evidence from measured #72/#86 outcomes.

No permanent player-facing `confidence` meter should be inferred from this diagnostic model.