### PR TITLE
Experiment with world-grounded tower interaction feedback grammar

### DIFF
--- a/experiments/storybook/src/Arena/Interaction/TowerFeedbackGrammar.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/TowerFeedbackGrammar.stories.ts
@@ -1,0 +1,301 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	classifyTowerInteraction,
+	type TowerInteractionRequest
+} from "@defend/gameplay/towerInteraction";
+import {
+	towerInteractionFeedback,
+	type TowerInteractionFeedbackDescriptor
+} from "@defend/presentation/towerInteractionFeedback";
+import { createLabShell } from "../../labTheme";
+
+type FeedbackArgs = {
+	reducedMotion: boolean;
+	audioEnabled: boolean;
+	grayscale: boolean;
+};
+
+interface Scenario {
+	id: string;
+	label: string;
+	description: string;
+	request: TowerInteractionRequest;
+}
+
+const BASE_COST = 3000;
+
+function request(
+	overrides: Partial<TowerInteractionRequest> = {}
+): TowerInteractionRequest {
+	return {
+		inputOwner: "world",
+		targetKind: "ground",
+		occupied: false,
+		balance: 15000,
+		requestedCost: BASE_COST,
+		currentLevel: 0,
+		maximumLevel: 3,
+		affordabilityRule: "legacy-strict",
+		maxLevelBehavior: "no-op",
+		...overrides
+	};
+}
+
+const SCENARIOS: Scenario[] = [
+	{
+		id: "place-ready",
+		label: "Placement ready",
+		description: "Stable ground anchor and visible reserve relationship.",
+		request: request()
+	},
+	{
+		id: "occupied",
+		label: "Occupied",
+		description: "Same candidate location remains visible, but overlap is a spatial conflict.",
+		request: request({ occupied: true })
+	},
+	{
+		id: "protected",
+		label: "Protected core",
+		description: "The protected region owns the response rather than implying a missed tap.",
+		request: request({ targetKind: "protected-core" })
+	},
+	{
+		id: "invalid-terrain",
+		label: "Invalid terrain",
+		description: "Broken contact language indicates surface incompatibility.",
+		request: request({ targetKind: "invalid-terrain" })
+	},
+	{
+		id: "outside-arena",
+		label: "Outside arena",
+		description: "Clipped boundary language distinguishes arena limits from terrain failure.",
+		request: request({ targetKind: "outside-arena" })
+	},
+	{
+		id: "unaffordable",
+		label: "Insufficient energy",
+		description: "Spatial validity remains readable; failure occurs at the resource relationship.",
+		request: request({ balance: BASE_COST - 1 })
+	},
+	{
+		id: "camera",
+		label: "Camera gesture",
+		description: "Orbit/zoom ownership suppresses false world-error feedback.",
+		request: request({ inputOwner: "camera" })
+	},
+	{
+		id: "stale",
+		label: "Stale target",
+		description: "Old target ownership tears down cleanly without charge or spatial error language.",
+		request: request({ targetKind: "stale-target" })
+	},
+	{
+		id: "upgrade",
+		label: "Upgrade ready",
+		description: "Existing tower remains the anchor and projected change reads as an upgrade.",
+		request: request({
+			targetKind: "tower",
+			currentLevel: 1,
+			requestedCost: BASE_COST * 2
+		})
+	},
+	{
+		id: "max-level",
+		label: "Healthy maximum",
+		description: "No-op max policy is explicit and cannot masquerade as a paid upgrade.",
+		request: request({
+			targetKind: "tower",
+			currentLevel: 3,
+			requestedCost: BASE_COST * 4,
+			maxLevelBehavior: "no-op"
+		})
+	},
+	{
+		id: "maintenance",
+		label: "Maintenance ready",
+		description: "Service is represented as maintenance rather than an invented fourth upgrade tier.",
+		request: request({
+			targetKind: "tower",
+			currentLevel: 3,
+			requestedCost: BASE_COST * 2,
+			maxLevelBehavior: "maintenance"
+		})
+	},
+	{
+		id: "invalid-cost",
+		label: "Diagnostic fallback",
+		description: "Malformed authority fails closed without inventing a misleading economy explanation.",
+		request: request({ requestedCost: NaN })
+	}
+];
+
+function patternMarkup(descriptor: TowerInteractionFeedbackDescriptor): string {
+	if (descriptor.suppressed) {
+		return '<div class="feedback-stage__suppressed">camera owns gesture</div>';
+	}
+	return `
+		<div
+			class="feedback-shape feedback-shape--${descriptor.pattern} feedback-shape--motion-${descriptor.motion}"
+			data-pattern="${descriptor.pattern}"
+			data-motion="${descriptor.motion}"
+		>
+			<span>${descriptor.anchor}</span>
+		</div>
+	`;
+}
+
+function scenarioCard(scenario: Scenario, args: FeedbackArgs): string {
+	const preview = classifyTowerInteraction(scenario.request);
+	const descriptor = towerInteractionFeedback(preview, {
+		reducedMotion: args.reducedMotion,
+		audioEnabled: args.audioEnabled
+	});
+	return `
+		<article
+			class="feedback-card"
+			data-scenario="${scenario.id}"
+			data-disposition="${preview.disposition}"
+			data-reason="${preview.reason}"
+			data-meaning="${descriptor.meaning}"
+			data-anchor="${descriptor.anchor}"
+			data-pattern="${descriptor.pattern}"
+			data-motion="${descriptor.motion}"
+			data-audio="${descriptor.audioCue}"
+			data-suppressed="${descriptor.suppressed}"
+		>
+			<header>
+				<small>${preview.disposition} · ${preview.reason}</small>
+				<strong>${scenario.label}</strong>
+			</header>
+			<p>${scenario.description}</p>
+			<div class="feedback-stage">${patternMarkup(descriptor)}</div>
+			<dl>
+				<div><dt>meaning</dt><dd>${descriptor.meaning}</dd></div>
+				<div><dt>pattern</dt><dd>${descriptor.pattern}</dd></div>
+				<div><dt>motion</dt><dd>${descriptor.motion}</dd></div>
+				<div><dt>audio cue</dt><dd>${descriptor.audioCue}</dd></div>
+				<div><dt>preview</dt><dd>${descriptor.showPreview ? "shown" : "hidden"}</dd></div>
+				<div><dt>cost relation</dt><dd>${descriptor.showCostRelationship ? "shown" : "hidden"}</dd></div>
+			</dl>
+			<div class="feedback-announcement">${descriptor.announcement || "No world announcement"}</div>
+		</article>
+	`;
+}
+
+const meta = {
+	title: "Arena/Interaction/Tower Feedback Grammar",
+	tags: ["test", "visual"],
+	args: {
+		reducedMotion: false,
+		audioEnabled: true,
+		grayscale: false
+	},
+	argTypes: {
+		reducedMotion: { control: "boolean" },
+		audioEnabled: { control: "boolean" },
+		grayscale: { control: "boolean" }
+	},
+	render: (args: FeedbackArgs) => {
+		const shell = createLabShell(
+			"Arena / interaction",
+			"World-grounded interaction feedback grammar",
+			"Authoritative #117 interaction previews are mapped downstream into distinct geometry, pattern, motion, audio-cue and announcement semantics. Color is only reinforcement; camera-owned gestures deliberately produce no world-error feedback."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.feedback-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:12px; ${args.grayscale ? "filter:grayscale(1);" : ""} }
+				.feedback-card { padding:13px; border:1px solid rgba(244,237,247,.13); background:rgba(8,10,18,.48); }
+				.feedback-card header { display:grid; gap:3px; }
+				.feedback-card header small { opacity:.48; text-transform:uppercase; letter-spacing:.07em; font-size:9px; }
+				.feedback-card p { min-height:50px; font-size:10px; line-height:1.45; opacity:.58; }
+				.feedback-stage { min-height:112px; display:grid; place-items:center; margin:10px 0; border:1px solid rgba(244,237,247,.06); background:radial-gradient(circle,rgba(228,185,128,.045),transparent 62%); }
+				.feedback-stage__suppressed { font-size:10px; letter-spacing:.06em; text-transform:uppercase; opacity:.42; }
+				.feedback-shape { width:105px; height:72px; display:grid; place-items:center; border:2px solid rgba(228,185,128,.82); font-size:9px; text-transform:uppercase; letter-spacing:.06em; }
+				.feedback-shape--solid { border-style:solid; }
+				.feedback-shape--double { border-style:double; border-width:4px; }
+				.feedback-shape--dashed { border-style:dashed; }
+				.feedback-shape--hatch { background:repeating-linear-gradient(135deg,transparent 0 7px,rgba(244,237,247,.13) 7px 9px); }
+				.feedback-shape--broken { border-style:dashed; transform:skew(-7deg); }
+				.feedback-shape--clipped { clip-path:polygon(0 0,75% 0,100% 35%,75% 100%,0 100%); border-style:dashed; }
+				.feedback-shape--service { border-style:double; border-radius:14px; background:repeating-linear-gradient(90deg,transparent 0 14px,rgba(244,237,247,.08) 14px 16px); }
+				.feedback-shape--motion-compress { transform:scaleX(.88); }
+				.feedback-shape--motion-repel { outline:1px solid rgba(244,237,247,.35); outline-offset:10px; }
+				.feedback-shape--motion-pulse { box-shadow:0 0 0 7px rgba(228,185,128,.08); }
+				.feedback-shape--motion-break { transform:skew(-7deg); }
+				.feedback-shape--motion-fade { opacity:.48; }
+				.feedback-shape--motion-service { outline:1px dashed rgba(244,237,247,.35); outline-offset:6px; }
+				.feedback-card dl { display:grid; gap:3px; margin:0; font-size:9px; }
+				.feedback-card dl div { display:grid; grid-template-columns:1fr auto; gap:8px; }
+				.feedback-card dt { opacity:.46; }
+				.feedback-card dd { margin:0; opacity:.78; }
+				.feedback-announcement { margin-top:10px; min-height:28px; padding-top:8px; border-top:1px solid rgba(244,237,247,.08); font-size:10px; opacity:.72; }
+			</style>
+			<div class="feedback-grid">
+				${SCENARIOS.map(scenario => scenarioCard(scenario, args)).join("")}
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta<FeedbackArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SemanticMatrix: Story = {
+	play: async ({ canvasElement }) => {
+		const occupied = canvasElement.querySelector<HTMLElement>('[data-scenario="occupied"]');
+		const protectedCore = canvasElement.querySelector<HTMLElement>('[data-scenario="protected"]');
+		const terrain = canvasElement.querySelector<HTMLElement>('[data-scenario="invalid-terrain"]');
+		const boundary = canvasElement.querySelector<HTMLElement>('[data-scenario="outside-arena"]');
+		const unaffordable = canvasElement.querySelector<HTMLElement>('[data-scenario="unaffordable"]');
+		const camera = canvasElement.querySelector<HTMLElement>('[data-scenario="camera"]');
+		const upgrade = canvasElement.querySelector<HTMLElement>('[data-scenario="upgrade"]');
+		const maintenance = canvasElement.querySelector<HTMLElement>('[data-scenario="maintenance"]');
+		const invalidCost = canvasElement.querySelector<HTMLElement>('[data-scenario="invalid-cost"]');
+
+		await expect(occupied).not.toBeNull();
+		await expect(protectedCore).not.toBeNull();
+		await expect(terrain).not.toBeNull();
+		await expect(boundary).not.toBeNull();
+		await expect(unaffordable).not.toBeNull();
+		await expect(camera).not.toBeNull();
+		await expect(upgrade).not.toBeNull();
+		await expect(maintenance).not.toBeNull();
+		await expect(invalidCost).not.toBeNull();
+		if (!occupied || !protectedCore || !terrain || !boundary || !unaffordable || !camera || !upgrade || !maintenance || !invalidCost) return;
+
+		await expect(occupied.dataset.pattern).toBe("hatch");
+		await expect(protectedCore.dataset.anchor).toBe("core");
+		await expect(terrain.dataset.pattern).toBe("broken");
+		await expect(boundary.dataset.pattern).toBe("clipped");
+		await expect(unaffordable.dataset.meaning).toBe("resource-conflict");
+		await expect(unaffordable.dataset.pattern).toBe("solid");
+		await expect(camera.dataset.suppressed).toBe("true");
+		await expect(camera.dataset.audio).toBe("none");
+		await expect(upgrade.dataset.pattern).toBe("double");
+		await expect(maintenance.dataset.pattern).toBe("service");
+		await expect(invalidCost.dataset.meaning).toBe("diagnostic");
+	}
+};
+
+export const ReducedMotion: Story = {
+	args: {
+		reducedMotion: true,
+		audioEnabled: true,
+		grayscale: true
+	},
+	play: async ({ canvasElement }) => {
+		const cards = Array.from(canvasElement.querySelectorAll<HTMLElement>("[data-scenario]"));
+		await expect(cards.length).toBe(SCENARIOS.length);
+		for (let index = 0; index < cards.length; index += 1) {
+			await expect(cards[index].dataset.motion).toBe("none");
+		}
+		const occupied = canvasElement.querySelector<HTMLElement>('[data-scenario="occupied"]');
+		const terrain = canvasElement.querySelector<HTMLElement>('[data-scenario="invalid-terrain"]');
+		await expect(occupied?.dataset.pattern).toBe("hatch");
+		await expect(terrain?.dataset.pattern).toBe("broken");
+	}
+};

--- a/src/js/presentation/towerInteractionFeedback.ts
+++ b/src/js/presentation/towerInteractionFeedback.ts
@@ -1,4 +1,4 @@
-import type {
+import {
 	TowerInteractionIntent,
 	TowerInteractionPreview,
 	TowerInteractionReason

--- a/src/js/presentation/towerInteractionFeedback.ts
+++ b/src/js/presentation/towerInteractionFeedback.ts
@@ -1,0 +1,314 @@
+import type {
+	TowerInteractionIntent,
+	TowerInteractionPreview,
+	TowerInteractionReason
+} from "../gameplay/towerInteraction";
+
+export type TowerFeedbackAnchor =
+	| "ground"
+	| "tower"
+	| "core"
+	| "arena-boundary"
+	| "none";
+
+export type TowerFeedbackPattern =
+	| "solid"
+	| "double"
+	| "hatch"
+	| "dashed"
+	| "clipped"
+	| "broken"
+	| "service"
+	| "none";
+
+export type TowerFeedbackMotion =
+	| "steady"
+	| "compress"
+	| "repel"
+	| "pulse"
+	| "break"
+	| "fade"
+	| "service"
+	| "none";
+
+export type TowerFeedbackAudioCue =
+	| "placement-ready"
+	| "upgrade-ready"
+	| "rebuild-ready"
+	| "maintenance-ready"
+	| "occupied"
+	| "unaffordable"
+	| "protected-core"
+	| "invalid-terrain"
+	| "outside-arena"
+	| "stale-target"
+	| "max-level"
+	| "invalid-state"
+	| "none";
+
+export type TowerFeedbackMeaning =
+	| "ready"
+	| "spatial-conflict"
+	| "protected-space"
+	| "terrain-conflict"
+	| "boundary-conflict"
+	| "resource-conflict"
+	| "stale"
+	| "max-state"
+	| "diagnostic"
+	| "suppressed";
+
+export interface TowerInteractionFeedbackPreferences {
+	reducedMotion: boolean;
+	audioEnabled: boolean;
+}
+
+export interface TowerInteractionFeedbackDescriptor {
+	meaning: TowerFeedbackMeaning;
+	anchor: TowerFeedbackAnchor;
+	pattern: TowerFeedbackPattern;
+	motion: TowerFeedbackMotion;
+	audioCue: TowerFeedbackAudioCue;
+	announcement: string;
+	showPreview: boolean;
+	showCostRelationship: boolean;
+	suppressed: boolean;
+}
+
+const DEFAULT_PREFERENCES: TowerInteractionFeedbackPreferences = {
+	reducedMotion: false,
+	audioEnabled: true
+};
+
+function withPreferences(
+	descriptor: TowerInteractionFeedbackDescriptor,
+	preferences: TowerInteractionFeedbackPreferences
+): TowerInteractionFeedbackDescriptor {
+	return {
+		...descriptor,
+		motion: preferences.reducedMotion ? "none" : descriptor.motion,
+		audioCue: preferences.audioEnabled ? descriptor.audioCue : "none"
+	};
+}
+
+function readyDescriptor(
+	intent: TowerInteractionIntent
+): TowerInteractionFeedbackDescriptor {
+	if (intent === "place") {
+		return {
+			meaning: "ready",
+			anchor: "ground",
+			pattern: "solid",
+			motion: "steady",
+			audioCue: "placement-ready",
+			announcement: "Placement available",
+			showPreview: true,
+			showCostRelationship: true,
+			suppressed: false
+		};
+	}
+	if (intent === "upgrade") {
+		return {
+			meaning: "ready",
+			anchor: "tower",
+			pattern: "double",
+			motion: "pulse",
+			audioCue: "upgrade-ready",
+			announcement: "Tower upgrade available",
+			showPreview: true,
+			showCostRelationship: true,
+			suppressed: false
+		};
+	}
+	if (intent === "rebuild") {
+		return {
+			meaning: "ready",
+			anchor: "tower",
+			pattern: "double",
+			motion: "pulse",
+			audioCue: "rebuild-ready",
+			announcement: "Legacy tower reconstruction available",
+			showPreview: true,
+			showCostRelationship: true,
+			suppressed: false
+		};
+	}
+	if (intent === "maintain") {
+		return {
+			meaning: "ready",
+			anchor: "tower",
+			pattern: "service",
+			motion: "service",
+			audioCue: "maintenance-ready",
+			announcement: "Tower maintenance available",
+			showPreview: true,
+			showCostRelationship: true,
+			suppressed: false
+		};
+	}
+	return {
+		meaning: "diagnostic",
+		anchor: "none",
+		pattern: "broken",
+		motion: "none",
+		audioCue: "invalid-state",
+		announcement: "Interaction state unavailable",
+		showPreview: false,
+		showCostRelationship: false,
+		suppressed: false
+	};
+}
+
+function rejectionDescriptor(
+	reason: TowerInteractionReason,
+	preview: TowerInteractionPreview
+): TowerInteractionFeedbackDescriptor {
+	if (reason === "occupied") {
+		return {
+			meaning: "spatial-conflict",
+			anchor: "ground",
+			pattern: "hatch",
+			motion: "compress",
+			audioCue: "occupied",
+			announcement: "Placement blocked by occupied space",
+			showPreview: true,
+			showCostRelationship: false,
+			suppressed: false
+		};
+	}
+	if (reason === "protected-core") {
+		return {
+			meaning: "protected-space",
+			anchor: "core",
+			pattern: "double",
+			motion: "repel",
+			audioCue: "protected-core",
+			announcement: "This core space is protected",
+			showPreview: true,
+			showCostRelationship: false,
+			suppressed: false
+		};
+	}
+	if (reason === "invalid-terrain") {
+		return {
+			meaning: "terrain-conflict",
+			anchor: "ground",
+			pattern: "broken",
+			motion: "break",
+			audioCue: "invalid-terrain",
+			announcement: "This surface cannot support the action",
+			showPreview: true,
+			showCostRelationship: false,
+			suppressed: false
+		};
+	}
+	if (reason === "outside-arena") {
+		return {
+			meaning: "boundary-conflict",
+			anchor: "arena-boundary",
+			pattern: "clipped",
+			motion: "fade",
+			audioCue: "outside-arena",
+			announcement: "Target is outside the playable arena",
+			showPreview: true,
+			showCostRelationship: false,
+			suppressed: false
+		};
+	}
+	if (reason === "unaffordable") {
+		return {
+			meaning: "resource-conflict",
+			anchor: preview.intent === "place" ? "ground" : "tower",
+			pattern: "solid",
+			motion: "pulse",
+			audioCue: "unaffordable",
+			announcement: "Insufficient energy for this action",
+			showPreview: true,
+			showCostRelationship: true,
+			suppressed: false
+		};
+	}
+	if (reason === "stale-target") {
+		return {
+			meaning: "stale",
+			anchor: "none",
+			pattern: "dashed",
+			motion: "fade",
+			audioCue: "stale-target",
+			announcement: "Target is no longer available",
+			showPreview: false,
+			showCostRelationship: false,
+			suppressed: false
+		};
+	}
+	if (reason === "max-level") {
+		return {
+			meaning: "max-state",
+			anchor: "tower",
+			pattern: "double",
+			motion: "steady",
+			audioCue: "max-level",
+			announcement: "Tower is already at its maximum state",
+			showPreview: true,
+			showCostRelationship: false,
+			suppressed: false
+		};
+	}
+	if (reason === "invalid-cost" || reason === "invalid-tower-level") {
+		return {
+			meaning: "diagnostic",
+			anchor: preview.intent === "place" ? "ground" : "tower",
+			pattern: "broken",
+			motion: "none",
+			audioCue: "invalid-state",
+			announcement: "Interaction is unavailable",
+			showPreview: false,
+			showCostRelationship: false,
+			suppressed: false
+		};
+	}
+	return {
+		meaning: "diagnostic",
+		anchor: "none",
+		pattern: "broken",
+		motion: "none",
+		audioCue: "invalid-state",
+		announcement: "Interaction is unavailable",
+		showPreview: false,
+		showCostRelationship: false,
+		suppressed: false
+	};
+}
+
+/**
+ * Map an authoritative tower-interaction preview into presentation semantics.
+ *
+ * This is strictly downstream of gameplay classification. It cannot make a
+ * rejected interaction legal, alter cost/balance, choose max-tier policy, or
+ * mutate the scene. Presentation adapters may render these descriptors with
+ * Babylon/DOM/Web Audio later.
+ */
+export function towerInteractionFeedback(
+	preview: TowerInteractionPreview,
+	preferences: TowerInteractionFeedbackPreferences = DEFAULT_PREFERENCES
+): TowerInteractionFeedbackDescriptor {
+	if (preview.disposition === "ignored" && preview.reason === "camera-gesture") {
+		return {
+			meaning: "suppressed",
+			anchor: "none",
+			pattern: "none",
+			motion: "none",
+			audioCue: "none",
+			announcement: "",
+			showPreview: false,
+			showCostRelationship: false,
+			suppressed: true
+		};
+	}
+
+	const descriptor =
+		preview.disposition === "allowed"
+			? readyDescriptor(preview.intent)
+			: rejectionDescriptor(preview.reason, preview);
+	return withPreferences(descriptor, preferences);
+}


### PR DESCRIPTION
Refs #131, #108, #103
Parent chain: #112 → #117
Related: #33, #56, #109, #130

## Purpose

Provide a production-neutral presentation experiment for the explicit tower interaction states established by #112/#117.

This PR does **not** decide whether an action is legal. It consumes the authoritative `TowerInteractionPreview` downstream and maps it into a world-readable feedback vocabulary that can later be rendered by Babylon/Web Audio/accessibility adapters.

The design goal is to let the player distinguish **where**, **what**, **whether**, and **why** without a conventional build menu or generic red/green rejection flash.

## `src/js/presentation/towerInteractionFeedback.ts`

Adds a pure presentation descriptor with independent dimensions:

- semantic meaning;
- world anchor (`ground`, `tower`, `core`, `arena-boundary`, `none`);
- non-color line/pattern language;
- optional motion cue;
- semantic audio-cue identity;
- semantic announcement text;
- whether the spatial preview remains visible;
- whether the reserve/cost relationship should remain visible;
- explicit suppression state.

It maps the #117 states as follows:

- allowed placement → stable ground/solid preview;
- occupied → hatched spatial-conflict preview;
- protected core → core-anchored repelling/double-boundary language;
- invalid terrain → broken surface-contact language;
- outside arena → clipped arena-boundary language;
- unaffordable → preserve the valid spatial preview but expose the resource relationship;
- stale target → tear down/fade old ownership;
- upgrade → tower-anchored double/progression language;
- max-state no-op → explicit maximum-state feedback;
- maintenance → distinct service pattern, not an invented fourth upgrade tier;
- malformed cost/level → diagnostic fallback rather than a misleading player economy explanation;
- camera-owned gesture → **fully suppressed world error feedback**.

### Accessibility/preferences

`reducedMotion` removes motion while preserving pattern/anchor/announcement semantics.

`audioEnabled=false` removes audio-cue identity without altering visual or semantic information.

Audio cues and announcements are semantic identities for **state transitions**; adapters must not retrigger them on every hover/pointer-move recomputation.

Color is not part of the authority contract and is only reinforcement in the Storybook presentation.

## Storybook playground

Adds `Arena/Interaction/Tower Feedback Grammar`.

The matrix renders authoritative classifier outputs for:

- ready placement;
- occupied;
- protected core;
- invalid terrain;
- outside arena;
- insufficient energy;
- camera-owned gesture;
- stale target;
- upgrade;
- healthy max-level/no-op;
- maintenance;
- malformed-cost fallback.

Controls expose reduced-motion, audio-enabled and grayscale modes.

Automated assertions verify semantically important distinctions without relying on color:

- occupied = hatch;
- protected = core anchor;
- terrain = broken contact;
- boundary = clipped pattern;
- unaffordable remains a resource conflict with stable spatial pattern;
- camera gesture is suppressed and has no audio cue;
- upgrade and maintenance use distinct patterns;
- malformed cost is diagnostic;
- reduced-motion removes motion while preserving pattern distinctions.

The fixture creates no Babylon scene, RAF loop, timer, Worker, AudioContext, global listener or production mutation.

## Scope

Base: #117 exact head `0de9606e2bbdf1e917a28bca3a1e0487520cece0`.

Current branch contains exactly two added files relative to #117:

- `src/js/presentation/towerInteractionFeedback.ts`;
- `experiments/storybook/src/Arena/Interaction/TowerFeedbackGrammar.stories.ts`.

No live pointer/tower/economy/camera behavior changes. No package/dependency changes. No frozen #95/#97/#105 changes.

The root module intentionally avoids `import type` so it remains syntactically compatible with the historical TypeScript 3.2 toolchain pending local verification.

## Validation

Keep draft until a later post-freeze campaign can run:

```sh
npm run lint
npm run build
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Then inspect the matrix in normal color, grayscale and reduced-motion modes at representative desktop/touch viewport sizes.

Specifically verify that camera navigation never emits a false world failure cue and that unaffordable remains visually spatially valid rather than collapsing into the same grammar as occupied/invalid terrain.

## Follow-up

After this grammar and #112/#117 are certified, a narrow Babylon adapter can render the descriptors on real picked cells/towers. Presentation state must remain downstream of the authoritative classifier. #130 still owns the canonical max-level maintenance/no-op decision; this experiment merely shows both semantic languages.