### PR TITLE
Harden tower-interaction observation evidence integrity

### DIFF
--- a/experiments/storybook/src/Arena/Interaction/TowerObservationIntegrity.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/TowerObservationIntegrity.stories.ts
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	classifyTowerInteraction,
+	type TowerInteractionRequest
+} from "@defend/gameplay/towerInteraction";
+import {
+	createTowerInteractionObservationState,
+	recordTowerInteractionObservation,
+	summarizeTowerInteractionObservations,
+	type TowerInteractionObservation,
+	type TowerInteractionObservationState
+} from "@defend/gameplay/towerInteractionObservation";
+import { createLabShell } from "../../labTheme";
+
+function request(): TowerInteractionRequest {
+	return {
+		inputOwner: "world",
+		targetKind: "ground",
+		occupied: false,
+		balance: 10000,
+		requestedCost: 3000,
+		currentLevel: 0,
+		maximumLevel: 3,
+		affordabilityRule: "legacy-strict",
+		maxLevelBehavior: "no-op"
+	};
+}
+
+function observation(atSeconds: number): TowerInteractionObservation {
+	return {
+		atSeconds,
+		cellKey: "cell-a",
+		roleKey: "barrier",
+		tacticalContextKey: "opening",
+		interventionKind: "new-build",
+		preview: classifyTowerInteraction(request())
+	};
+}
+
+const meta = {
+	title: "Arena/Interaction/Tower Observation Integrity",
+	tags: ["test", "visual"],
+	render: () => {
+		let state = createTowerInteractionObservationState(0);
+		state = recordTowerInteractionObservation(state, observation(4));
+		state = recordTowerInteractionObservation(state, observation(2));
+		state = recordTowerInteractionObservation(state, observation(NaN));
+		const summary = summarizeTowerInteractionObservations(state);
+		const shell = createLabShell(
+			"Arena / interaction",
+			"Observation evidence integrity",
+			"Malformed or non-monotonic timestamps fail closed instead of being silently moved forward into first-build or maintenance evidence. Persisted/corrupt counters are sanitized before rates are calculated."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.integrity-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:10px; }
+				.integrity-card { padding:13px; border:1px solid rgba(244,237,247,.12); background:rgba(8,10,18,.48); }
+				.integrity-card span { display:block; font-size:9px; opacity:.48; text-transform:uppercase; }
+				.integrity-card strong { display:block; margin-top:4px; font-size:16px; }
+			</style>
+			<div class="integrity-grid">
+				<div class="integrity-card" data-attempts="${summary.attempts}"><span>valid attempts</span><strong>${summary.attempts}</strong></div>
+				<div class="integrity-card" data-invalid="${summary.invalidObservations}"><span>invalid observations</span><strong>${summary.invalidObservations}</strong></div>
+				<div class="integrity-card" data-nonmonotonic="${summary.nonMonotonicObservations}"><span>non-monotonic</span><strong>${summary.nonMonotonicObservations}</strong></div>
+				<div class="integrity-card" data-first-build="${summary.timeToFirstBuildSeconds ?? -1}"><span>first build</span><strong>${summary.timeToFirstBuildSeconds ?? "—"} s</strong></div>
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InvalidEvidenceFailsClosed: Story = {
+	play: async ({ canvasElement }) => {
+		const attempts = canvasElement.querySelector<HTMLElement>("[data-attempts]");
+		const invalid = canvasElement.querySelector<HTMLElement>("[data-invalid]");
+		const nonmonotonic = canvasElement.querySelector<HTMLElement>("[data-nonmonotonic]");
+		const firstBuild = canvasElement.querySelector<HTMLElement>("[data-first-build]");
+		await expect(attempts?.dataset.attempts).toBe("1");
+		await expect(invalid?.dataset.invalid).toBe("2");
+		await expect(nonmonotonic?.dataset.nonmonotonic).toBe("1");
+		await expect(firstBuild?.dataset.firstBuild).toBe("4");
+
+		const malformed = {
+			startedAtSeconds: 0,
+			lastObservedAtSeconds: 20,
+			attempts: 2,
+			allowedActions: Infinity,
+			rejectedActions: NaN,
+			ignoredActions: 99,
+			invalidObservations: NaN,
+			nonMonotonicObservations: Infinity,
+			cameraConflicts: 99,
+			rejectedBeforeFirstBuild: Infinity,
+			ignoredBeforeFirstBuild: 99,
+			firstAllowedAtSeconds: Infinity,
+			firstBuildAtSeconds: -5,
+			acceptedReplacements: 99,
+			repeatedSameContextReplacements: 99,
+			reasonCounts: undefined,
+			lastAcceptedContexts: undefined
+		} as unknown as TowerInteractionObservationState;
+		const sanitized = summarizeTowerInteractionObservations(malformed);
+		await expect(Number.isFinite(sanitized.allowanceRate)).toBe(true);
+		await expect(sanitized.allowanceRate).toBeGreaterThanOrEqual(0);
+		await expect(sanitized.allowanceRate).toBeLessThanOrEqual(1);
+		await expect(sanitized.repetitionRate).toBeGreaterThanOrEqual(0);
+		await expect(sanitized.repetitionRate).toBeLessThanOrEqual(1);
+		await expect(sanitized.timeToFirstAllowedSeconds).toBeNull();
+		await expect(sanitized.timeToFirstBuildSeconds).toBeNull();
+		await expect(sanitized.reasonCounts.occupied).toBe(0);
+	}
+};

--- a/src/js/gameplay/towerInteractionObservation.ts
+++ b/src/js/gameplay/towerInteractionObservation.ts
@@ -79,7 +79,12 @@ export interface TowerInteractionObservationSummary {
 }
 
 function isFiniteNumber(value: number): boolean {
-	return value === value && value !== Infinity && value !== -Infinity;
+	return (
+		typeof value === "number" &&
+		value === value &&
+		value !== Infinity &&
+		value !== -Infinity
+	);
 }
 
 function finite(value: number, fallback = 0): number {

--- a/src/js/gameplay/towerInteractionObservation.ts
+++ b/src/js/gameplay/towerInteractionObservation.ts
@@ -1,4 +1,4 @@
-import type {
+import {
 	TowerInteractionPreview,
 	TowerInteractionReason
 } from "./towerInteraction";
@@ -46,6 +46,8 @@ export interface TowerInteractionObservationState {
 	allowedActions: number;
 	rejectedActions: number;
 	ignoredActions: number;
+	invalidObservations: number;
+	nonMonotonicObservations: number;
 	cameraConflicts: number;
 	rejectedBeforeFirstBuild: number;
 	ignoredBeforeFirstBuild: number;
@@ -62,6 +64,8 @@ export interface TowerInteractionObservationSummary {
 	allowedActions: number;
 	rejectedActions: number;
 	ignoredActions: number;
+	invalidObservations: number;
+	nonMonotonicObservations: number;
 	allowanceRate: number;
 	cameraConflicts: number;
 	rejectedBeforeFirstBuild: number;
@@ -74,15 +78,30 @@ export interface TowerInteractionObservationSummary {
 	reasonCounts: TowerInteractionReasonCounts;
 }
 
+function isFiniteNumber(value: number): boolean {
+	return value === value && value !== Infinity && value !== -Infinity;
+}
+
 function finite(value: number, fallback = 0): number {
-	if (value !== value || value === Infinity || value === -Infinity) {
-		return fallback;
-	}
-	return value;
+	return isFiniteNumber(value) ? value : fallback;
 }
 
 function nonNegative(value: number): number {
 	return Math.max(0, finite(value));
+}
+
+function count(value: number): number {
+	return Math.floor(nonNegative(value));
+}
+
+function validHistoricalTime(
+	value: number | null,
+	start: number,
+	last: number
+): number | null {
+	if (value === null || !isFiniteNumber(value)) return null;
+	if (value < start || value > last) return null;
+	return value;
 }
 
 function emptyReasonCounts(): TowerInteractionReasonCounts {
@@ -101,30 +120,45 @@ function emptyReasonCounts(): TowerInteractionReasonCounts {
 }
 
 function copyReasonCounts(
-	counts: TowerInteractionReasonCounts
+	counts: TowerInteractionReasonCounts | null | undefined
 ): TowerInteractionReasonCounts {
+	if (!counts) return emptyReasonCounts();
 	return {
-		occupied: counts.occupied,
-		unaffordable: counts.unaffordable,
-		invalidCost: counts.invalidCost,
-		protectedCore: counts.protectedCore,
-		invalidTerrain: counts.invalidTerrain,
-		outsideArena: counts.outsideArena,
-		staleTarget: counts.staleTarget,
-		maxLevel: counts.maxLevel,
-		invalidTowerLevel: counts.invalidTowerLevel,
-		cameraGesture: counts.cameraGesture
+		occupied: count(counts.occupied),
+		unaffordable: count(counts.unaffordable),
+		invalidCost: count(counts.invalidCost),
+		protectedCore: count(counts.protectedCore),
+		invalidTerrain: count(counts.invalidTerrain),
+		outsideArena: count(counts.outsideArena),
+		staleTarget: count(counts.staleTarget),
+		maxLevel: count(counts.maxLevel),
+		invalidTowerLevel: count(counts.invalidTowerLevel),
+		cameraGesture: count(counts.cameraGesture)
 	};
 }
 
 function copyContexts(
-	contexts: TowerInteractionAcceptedContext[]
+	contexts: TowerInteractionAcceptedContext[] | null | undefined
 ): TowerInteractionAcceptedContext[] {
-	return contexts.map(context => ({
-		cellKey: context.cellKey,
-		roleKey: context.roleKey,
-		tacticalContextKey: context.tacticalContextKey
-	}));
+	if (!Array.isArray(contexts)) return [];
+	const copied: TowerInteractionAcceptedContext[] = [];
+	for (let index = 0; index < contexts.length; index += 1) {
+		const context = contexts[index];
+		if (
+			!context ||
+			typeof context.cellKey !== "string" ||
+			typeof context.roleKey !== "string" ||
+			typeof context.tacticalContextKey !== "string"
+		) {
+			continue;
+		}
+		copied.push({
+			cellKey: context.cellKey,
+			roleKey: context.roleKey,
+			tacticalContextKey: context.tacticalContextKey
+		});
+	}
+	return copied;
 }
 
 function incrementReason(
@@ -159,6 +193,54 @@ function contextIndex(
 	return -1;
 }
 
+function normalizeState(
+	state: TowerInteractionObservationState
+): TowerInteractionObservationState {
+	const start = nonNegative(state.startedAtSeconds);
+	const last = Math.max(start, nonNegative(state.lastObservedAtSeconds));
+	const attempts = count(state.attempts);
+	const acceptedReplacements = Math.min(
+		attempts,
+		count(state.acceptedReplacements)
+	);
+	return {
+		startedAtSeconds: start,
+		lastObservedAtSeconds: last,
+		attempts,
+		allowedActions: Math.min(attempts, count(state.allowedActions)),
+		rejectedActions: Math.min(attempts, count(state.rejectedActions)),
+		ignoredActions: Math.min(attempts, count(state.ignoredActions)),
+		invalidObservations: count(state.invalidObservations),
+		nonMonotonicObservations: count(state.nonMonotonicObservations),
+		cameraConflicts: Math.min(attempts, count(state.cameraConflicts)),
+		rejectedBeforeFirstBuild: Math.min(
+			attempts,
+			count(state.rejectedBeforeFirstBuild)
+		),
+		ignoredBeforeFirstBuild: Math.min(
+			attempts,
+			count(state.ignoredBeforeFirstBuild)
+		),
+		firstAllowedAtSeconds: validHistoricalTime(
+			state.firstAllowedAtSeconds,
+			start,
+			last
+		),
+		firstBuildAtSeconds: validHistoricalTime(
+			state.firstBuildAtSeconds,
+			start,
+			last
+		),
+		acceptedReplacements,
+		repeatedSameContextReplacements: Math.min(
+			acceptedReplacements,
+			count(state.repeatedSameContextReplacements)
+		),
+		reasonCounts: copyReasonCounts(state.reasonCounts),
+		lastAcceptedContexts: copyContexts(state.lastAcceptedContexts)
+	};
+}
+
 export function createTowerInteractionObservationState(
 	startedAtSeconds = 0
 ): TowerInteractionObservationState {
@@ -170,6 +252,8 @@ export function createTowerInteractionObservationState(
 		allowedActions: 0,
 		rejectedActions: 0,
 		ignoredActions: 0,
+		invalidObservations: 0,
+		nonMonotonicObservations: 0,
 		cameraConflicts: 0,
 		rejectedBeforeFirstBuild: 0,
 		ignoredBeforeFirstBuild: 0,
@@ -185,34 +269,31 @@ export function createTowerInteractionObservationState(
 /**
  * Append one passive observation downstream of #117's authoritative preview.
  * This function never changes whether an action is allowed or how much it costs.
+ *
+ * Invalid/non-monotonic timestamps fail closed. They are counted diagnostically
+ * but do not become attempts and cannot change first-build/repetition timing.
  */
 export function recordTowerInteractionObservation(
 	state: TowerInteractionObservationState,
 	observation: TowerInteractionObservation
 ): TowerInteractionObservationState {
-	const next: TowerInteractionObservationState = {
-		startedAtSeconds: nonNegative(state.startedAtSeconds),
-		lastObservedAtSeconds: Math.max(
-			nonNegative(state.lastObservedAtSeconds),
-			nonNegative(observation.atSeconds)
-		),
-		attempts: nonNegative(state.attempts) + 1,
-		allowedActions: nonNegative(state.allowedActions),
-		rejectedActions: nonNegative(state.rejectedActions),
-		ignoredActions: nonNegative(state.ignoredActions),
-		cameraConflicts: nonNegative(state.cameraConflicts),
-		rejectedBeforeFirstBuild: nonNegative(state.rejectedBeforeFirstBuild),
-		ignoredBeforeFirstBuild: nonNegative(state.ignoredBeforeFirstBuild),
-		firstAllowedAtSeconds: state.firstAllowedAtSeconds,
-		firstBuildAtSeconds: state.firstBuildAtSeconds,
-		acceptedReplacements: nonNegative(state.acceptedReplacements),
-		repeatedSameContextReplacements: nonNegative(
-			state.repeatedSameContextReplacements
-		),
-		reasonCounts: copyReasonCounts(state.reasonCounts),
-		lastAcceptedContexts: copyContexts(state.lastAcceptedContexts)
-	};
-	const atSeconds = next.lastObservedAtSeconds;
+	const next = normalizeState(state);
+	if (!isFiniteNumber(observation.atSeconds)) {
+		next.invalidObservations += 1;
+		return next;
+	}
+	if (
+		observation.atSeconds < next.startedAtSeconds ||
+		observation.atSeconds < next.lastObservedAtSeconds
+	) {
+		next.invalidObservations += 1;
+		next.nonMonotonicObservations += 1;
+		return next;
+	}
+
+	const atSeconds = observation.atSeconds;
+	next.lastObservedAtSeconds = atSeconds;
+	next.attempts += 1;
 	incrementReason(next.reasonCounts, observation.preview.reason);
 
 	if (observation.preview.disposition === "ignored") {
@@ -246,7 +327,13 @@ export function recordTowerInteractionObservation(
 		next.firstBuildAtSeconds = atSeconds;
 	}
 
-	if (observation.cellKey !== null && observation.roleKey !== null) {
+	if (
+		observation.cellKey !== null &&
+		observation.roleKey !== null &&
+		typeof observation.cellKey === "string" &&
+		typeof observation.roleKey === "string" &&
+		typeof observation.tacticalContextKey === "string"
+	) {
 		const index = contextIndex(
 			next.lastAcceptedContexts,
 			observation.cellKey,
@@ -278,43 +365,40 @@ export function recordTowerInteractionObservation(
 export function summarizeTowerInteractionObservations(
 	state: TowerInteractionObservationState
 ): TowerInteractionObservationSummary {
-	const attempts = nonNegative(state.attempts);
-	const allowedActions = nonNegative(state.allowedActions);
-	const acceptedReplacements = nonNegative(state.acceptedReplacements);
-	const repeatedSameContextReplacements = nonNegative(
-		state.repeatedSameContextReplacements
-	);
+	const safe = normalizeState(state);
+	const attempts = safe.attempts;
+	const allowedActions = safe.allowedActions;
+	const acceptedReplacements = safe.acceptedReplacements;
+	const repeatedSameContextReplacements = safe.repeatedSameContextReplacements;
 	return {
 		attempts,
 		allowedActions,
-		rejectedActions: nonNegative(state.rejectedActions),
-		ignoredActions: nonNegative(state.ignoredActions),
-		allowanceRate: attempts <= 0 ? 0 : allowedActions / attempts,
-		cameraConflicts: nonNegative(state.cameraConflicts),
-		rejectedBeforeFirstBuild: nonNegative(state.rejectedBeforeFirstBuild),
-		ignoredBeforeFirstBuild: nonNegative(state.ignoredBeforeFirstBuild),
+		rejectedActions: safe.rejectedActions,
+		ignoredActions: safe.ignoredActions,
+		invalidObservations: safe.invalidObservations,
+		nonMonotonicObservations: safe.nonMonotonicObservations,
+		allowanceRate:
+			attempts <= 0 ? 0 : Math.min(1, allowedActions / attempts),
+		cameraConflicts: safe.cameraConflicts,
+		rejectedBeforeFirstBuild: safe.rejectedBeforeFirstBuild,
+		ignoredBeforeFirstBuild: safe.ignoredBeforeFirstBuild,
 		timeToFirstAllowedSeconds:
-			state.firstAllowedAtSeconds === null
+			safe.firstAllowedAtSeconds === null
 				? null
-				: Math.max(
-					0,
-					finite(state.firstAllowedAtSeconds) -
-						nonNegative(state.startedAtSeconds)
-				),
+				: Math.max(0, safe.firstAllowedAtSeconds - safe.startedAtSeconds),
 		timeToFirstBuildSeconds:
-			state.firstBuildAtSeconds === null
+			safe.firstBuildAtSeconds === null
 				? null
-				: Math.max(
-					0,
-					finite(state.firstBuildAtSeconds) -
-						nonNegative(state.startedAtSeconds)
-				),
+				: Math.max(0, safe.firstBuildAtSeconds - safe.startedAtSeconds),
 		acceptedReplacements,
 		repeatedSameContextReplacements,
 		repetitionRate:
 			acceptedReplacements <= 0
 				? 0
-				: repeatedSameContextReplacements / acceptedReplacements,
-		reasonCounts: copyReasonCounts(state.reasonCounts)
+				: Math.min(
+					1,
+					repeatedSameContextReplacements / acceptedReplacements
+				),
+		reasonCounts: copyReasonCounts(safe.reasonCounts)
 	};
 }


### PR DESCRIPTION
Refs #108, #133
Parent: #120
Related: #92, #112, #117, #135

## Purpose

Harden #120's passive comprehension observer so malformed or non-monotonic evidence cannot be silently coerced into apparently valid first-build/maintenance metrics.

This is a narrow child correction. #120 remains the provenance/design owner for the observation model.

Current head: `6c09f5fccfe16ff8bfd42a89d34e6e97b86c9cf5`.
Final observer blob: `c9d241342fcca33c589592a665d427c32f0a469e`.
Integrity story blob: `a7d24ef02dc3b17e928f0fd76925879d4065e2e7`.

## Corrections

### Non-monotonic timestamps fail closed

#120 currently computes each new timestamp as `max(lastObservedAtSeconds, observation.atSeconds)`. An event arriving with an earlier timestamp is therefore silently moved forward and still changes attempts, first-build timing, reason counts and context history.

This child instead:

- rejects non-finite observation timestamps;
- rejects timestamps earlier than session start or earlier than the last accepted observation;
- increments `invalidObservations`;
- increments `nonMonotonicObservations` for finite out-of-order evidence;
- does **not** count invalid evidence as an interaction attempt;
- does **not** alter first-build, first-allowed or replacement/context history.

Evidence is diagnosed rather than rewritten.

### Runtime type hardening

The numeric validity guard now requires `typeof value === "number"` in addition to finite-number checks. This matters because the integrity fixture deliberately exercises malformed/rehydrated state through `unknown`; values such as runtime `undefined` must fail closed rather than pass an equality-only NaN guard and propagate `NaN` into summaries.

### Malformed persisted state is sanitized

State normalization now:

- bounds numeric counters to finite non-negative integers;
- keeps per-attempt counters no greater than valid attempts;
- bounds replacement repetition to accepted replacement count;
- sanitizes missing/non-finite/non-number reason counters;
- filters malformed accepted-context entries;
- discards invalid/out-of-history first-allowed/first-build timestamps;
- bounds exposed rates to `[0, 1]`.

The observer remains local/passive and still does not change interaction authority.

### Historical TypeScript syntax

The root module's `import type` syntax is replaced with an ordinary type-only-used import so the file is syntactically acceptable to the historical TypeScript 3.2 compiler. Runtime emission still requires local certification.

## Storybook

Adds `Arena/Interaction/Tower Observation Integrity`.

The fixture verifies:

- one valid event followed by an earlier event and `NaN` leaves one valid attempt;
- both invalid observations are surfaced;
- only the earlier finite timestamp counts as non-monotonic;
- the original first-build time is not rewritten;
- a deliberately malformed state with NaN/Infinity/oversized counters and missing reason/context structures summarizes without throwing;
- resulting rates remain finite and bounded;
- invalid historical first-action timestamps become null;
- missing reason counts normalize to zero.

No analytics transport, persistence, browser listener, gameplay mutation, RAF, timer, Worker or AudioContext is introduced.

## Scope

Base: #120 exact head `3a42427574d14874f1cf87dcfcd4800e28443cbb`.

Relative to #120:

- one modified root observer module;
- one added Storybook integrity fixture;
- no changes to #112/#117 authority;
- no live production call sites;
- no package/dependency changes;
- no frozen #95/#97/#105 changes.

## Validation

Keep draft until a post-freeze root + Storybook campaign confirms:

```sh
npm run lint
npm run build
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Also test equal timestamps (allowed), valid monotonic sequences, non-monotonic timestamps before/after first build, runtime non-number values via malformed/rehydrated state, malformed counters/context arrays, and unchanged results for #120's existing legible/opaque fixtures.

## Cadence relationship

The former #135 ancestry was based on the pre-`typeof` #134 head and must not be treated as the final certification target. Reassemble the unchanged cadence slice on this exact head before freezing the post-freeze batch.