### PR TITLE
Add intervention cadence diagnostics on hardened observation evidence

### DIFF
--- a/experiments/storybook/src/Arena/Interaction/InterventionCadence.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/InterventionCadence.stories.ts
@@ -1,0 +1,264 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	summarizeInterventionCadence,
+	type InterventionAction,
+	type InterventionCadenceInput,
+	type InterventionCadenceSummary,
+	type InterventionOpportunity
+} from "@defend/gameplay/interventionCadence";
+import { createLabShell } from "../../labTheme";
+
+function opportunity(
+	id: string,
+	startSeconds: number,
+	endSeconds: number
+): InterventionOpportunity {
+	return {
+		id,
+		kind: "other",
+		startSeconds,
+		endSeconds,
+		contextKey: id
+	};
+}
+
+function linkedAction(
+	atSeconds: number,
+	opportunityId: string
+): InterventionAction {
+	return {
+		atSeconds,
+		kind: "other",
+		opportunityId
+	};
+}
+
+function unlinkedAction(atSeconds: number): InterventionAction {
+	return {
+		atSeconds,
+		kind: "other",
+		opportunityId: null
+	};
+}
+
+const ENGAGED_OPPORTUNITIES: InterventionOpportunity[] = [
+	opportunity("e1", 4, 14),
+	opportunity("e2", 16, 28),
+	opportunity("e3", 31, 42),
+	opportunity("e4", 44, 56),
+	opportunity("e5", 59, 70),
+	opportunity("e6", 73, 85)
+];
+
+const SPARSE_OPPORTUNITIES: InterventionOpportunity[] = [
+	opportunity("s1", 5, 12),
+	opportunity("s2", 43, 50),
+	opportunity("s3", 78, 84)
+];
+
+const ENGAGED_ACTIONS: InterventionAction[] = [
+	linkedAction(6, "e1"),
+	linkedAction(18, "e2"),
+	linkedAction(34, "e3"),
+	linkedAction(47, "e4"),
+	linkedAction(61, "e5"),
+	unlinkedAction(52)
+];
+
+const SPECTATOR_ACTIONS: InterventionAction[] = [
+	linkedAction(7, "s1"),
+	linkedAction(81, "s3")
+];
+
+const BUSYWORK_ACTIONS: InterventionAction[] = [
+	linkedAction(7, "s1"),
+	unlinkedAction(14),
+	unlinkedAction(18),
+	unlinkedAction(22),
+	unlinkedAction(27),
+	unlinkedAction(31),
+	unlinkedAction(36),
+	unlinkedAction(41),
+	unlinkedAction(54),
+	unlinkedAction(59),
+	unlinkedAction(64),
+	unlinkedAction(70),
+	unlinkedAction(74),
+	linkedAction(81, "s3")
+];
+
+function session(
+	opportunities: InterventionOpportunity[],
+	actions: InterventionAction[]
+): InterventionCadenceInput {
+	return {
+		sessionStartSeconds: 0,
+		sessionEndSeconds: 90,
+		opportunities,
+		actions
+	};
+}
+
+function percent(value: number): string {
+	return `${(value * 100).toFixed(0)}%`;
+}
+
+function seconds(value: number | null): string {
+	return value === null ? "—" : `${value.toFixed(1)} s`;
+}
+
+function card(
+	id: string,
+	label: string,
+	description: string,
+	summary: InterventionCadenceSummary
+): string {
+	return `
+		<article
+			class="cadence-card"
+			data-session="${id}"
+			data-opportunities="${summary.opportunities}"
+			data-response-rate="${summary.responseRate}"
+			data-actions-per-minute="${summary.actionsPerMinute}"
+			data-coverage="${summary.opportunityCoverageShare}"
+			data-longest-gap="${summary.longestNoOpportunityGapSeconds}"
+			data-unlinked-share="${summary.unlinkedActionShare}"
+		>
+			<header>
+				<small>decision-cadence fixture</small>
+				<strong>${label}</strong>
+			</header>
+			<p>${description}</p>
+			<div class="cadence-metrics">
+				<div><span>meaningful opportunities</span><strong>${summary.opportunities}</strong></div>
+				<div><span>response rate</span><strong>${percent(summary.responseRate)}</strong></div>
+				<div><span>opportunity coverage</span><strong>${percent(summary.opportunityCoverageShare)}</strong></div>
+				<div><span>longest no-opportunity gap</span><strong>${seconds(summary.longestNoOpportunityGapSeconds)}</strong></div>
+				<div><span>actions / minute</span><strong>${summary.actionsPerMinute.toFixed(1)}</strong></div>
+				<div><span>unlinked input share</span><strong>${percent(summary.unlinkedActionShare)}</strong></div>
+				<div><span>mean response</span><strong>${seconds(summary.meanResponseSeconds)}</strong></div>
+				<div><span>missed opportunities</span><strong>${summary.missedOpportunities}</strong></div>
+			</div>
+		</article>
+	`;
+}
+
+const meta = {
+	title: "Arena/Interaction/Intervention Cadence",
+	tags: ["test", "visual"],
+	render: () => {
+		const engaged = summarizeInterventionCadence(
+			session(ENGAGED_OPPORTUNITIES, ENGAGED_ACTIONS)
+		);
+		const spectator = summarizeInterventionCadence(
+			session(SPARSE_OPPORTUNITIES, SPECTATOR_ACTIONS)
+		);
+		const busywork = summarizeInterventionCadence(
+			session(SPARSE_OPPORTUNITIES, BUSYWORK_ACTIONS)
+		);
+		const shell = createLabShell(
+			"Arena / interaction",
+			"Meaningful intervention cadence",
+			"Decision density is not input density. These deterministic evidence shapes measure when the simulation presents a meaningful chance to alter the physical future, separately from how often the player clicks."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.cadence-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(270px,1fr)); gap:14px; }
+				.cadence-card { padding:14px; border:1px solid rgba(228,185,128,.2); background:rgba(10,3,17,.42); }
+				.cadence-card header { display:grid; gap:3px; margin-bottom:9px; }
+				.cadence-card header small { opacity:.45; text-transform:uppercase; letter-spacing:.08em; font-size:9px; }
+				.cadence-card p { min-height:58px; margin:0 0 12px; opacity:.6; font-size:10px; line-height:1.5; }
+				.cadence-metrics { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+				.cadence-metrics div { border-top:1px solid rgba(244,237,247,.08); padding-top:7px; }
+				.cadence-metrics span { display:block; font-size:9px; opacity:.48; text-transform:uppercase; }
+				.cadence-metrics strong { display:block; margin-top:3px; font-size:13px; }
+				.cadence-note { margin-top:14px; padding:11px; border:1px dashed rgba(244,237,247,.16); opacity:.68; font-size:10px; line-height:1.55; }
+			</style>
+			<div class="cadence-grid">
+				${card(
+					"engaged",
+					"Systemic engagement",
+					"Frequent physical/economic decision windows, most answered deliberately, with little unrelated input.",
+					engaged
+				)}
+				${card(
+					"spectator",
+					"Spectator-prone",
+					"Autonomous play continues, but meaningful opportunities are sparse and long passive gaps dominate the session.",
+					spectator
+				)}
+				${card(
+					"busywork",
+					"High-input busywork",
+					"The same sparse opportunity structure as spectator-prone play, masked by many actions that are not attributed to meaningful decision windows.",
+					busywork
+				)}
+			</div>
+			<div class="cadence-note">Illustrative evidence shapes only. Opportunity classification is caller-owned and must come from observable tactical state; these metrics must never feed back into gameplay authority or reward raw actions-per-minute.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DecisionDensityNotInputDensity: Story = {
+	play: async ({ canvasElement }) => {
+		const engaged = canvasElement.querySelector<HTMLElement>(
+			'[data-session="engaged"]'
+		);
+		const spectator = canvasElement.querySelector<HTMLElement>(
+			'[data-session="spectator"]'
+		);
+		const busywork = canvasElement.querySelector<HTMLElement>(
+			'[data-session="busywork"]'
+		);
+		await expect(engaged).not.toBeNull();
+		await expect(spectator).not.toBeNull();
+		await expect(busywork).not.toBeNull();
+		if (!engaged || !spectator || !busywork) return;
+
+		const engagedCoverage = Number(engaged.dataset.coverage);
+		const spectatorCoverage = Number(spectator.dataset.coverage);
+		const busyworkCoverage = Number(busywork.dataset.coverage);
+		const engagedGap = Number(engaged.dataset.longestGap);
+		const spectatorGap = Number(spectator.dataset.longestGap);
+		const busyworkGap = Number(busywork.dataset.longestGap);
+		const engagedApm = Number(engaged.dataset.actionsPerMinute);
+		const busyworkApm = Number(busywork.dataset.actionsPerMinute);
+		const busyworkUnlinked = Number(busywork.dataset.unlinkedShare);
+
+		await expect(engagedCoverage).toBeGreaterThan(spectatorCoverage);
+		await expect(engagedGap).toBeLessThan(spectatorGap);
+		await expect(busyworkCoverage).toBeCloseTo(spectatorCoverage, 8);
+		await expect(busyworkGap).toBeCloseTo(spectatorGap, 8);
+		await expect(busyworkApm).toBeGreaterThan(engagedApm);
+		await expect(busyworkUnlinked).toBeGreaterThan(0.5);
+
+		const malformed = summarizeInterventionCadence({
+			sessionStartSeconds: 0,
+			sessionEndSeconds: 90,
+			opportunities: [
+				opportunity("valid", 10, 20),
+				opportunity("valid", 30, 40),
+				opportunity("reversed", 50, 45),
+				opportunity("zero-width", 55, 55),
+				opportunity("nonfinite", NaN, 60)
+			],
+			actions: [
+				linkedAction(12, "valid"),
+				linkedAction(NaN, "valid"),
+				linkedAction(120, "valid")
+			]
+		});
+		await expect(malformed.opportunities).toBe(1);
+		await expect(malformed.duplicateOpportunityIds).toBe(1);
+		await expect(malformed.invalidOpportunities).toBe(3);
+		await expect(malformed.respondedOpportunities).toBe(1);
+		await expect(malformed.actions).toBe(1);
+		await expect(malformed.invalidActions).toBe(2);
+	}
+};

--- a/src/js/gameplay/interventionCadence.ts
+++ b/src/js/gameplay/interventionCadence.ts
@@ -1,0 +1,300 @@
+export type InterventionOpportunityKind =
+	| "edge-ejection"
+	| "route-change"
+	| "mixed-threat"
+	| "reserve-spend"
+	| "tower-lifecycle"
+	| "energy-flow"
+	| "breach-response"
+	| "other";
+
+export type InterventionActionKind =
+	| "place"
+	| "upgrade"
+	| "replace"
+	| "maintain"
+	| "redirect"
+	| "other";
+
+export interface InterventionOpportunity {
+	/** Stable unique id within one observation session. */
+	id: string;
+	kind: InterventionOpportunityKind;
+	startSeconds: number;
+	endSeconds: number;
+	contextKey: string;
+}
+
+export interface InterventionAction {
+	atSeconds: number;
+	kind: InterventionActionKind;
+	/**
+	 * Optional opportunity id this action intentionally answers. Null means the
+	 * action is not attributed to a measured decision window.
+	 */
+	opportunityId: string | null;
+}
+
+export interface InterventionCadenceInput {
+	sessionStartSeconds: number;
+	sessionEndSeconds: number;
+	opportunities: InterventionOpportunity[];
+	actions: InterventionAction[];
+}
+
+export interface InterventionCadenceSummary {
+	durationSeconds: number;
+	opportunities: number;
+	invalidOpportunities: number;
+	duplicateOpportunityIds: number;
+	respondedOpportunities: number;
+	missedOpportunities: number;
+	responseRate: number;
+	actions: number;
+	invalidActions: number;
+	linkedActions: number;
+	lateLinkedActions: number;
+	unlinkedActions: number;
+	unlinkedActionShare: number;
+	actionsPerMinute: number;
+	opportunitiesPerMinute: number;
+	meanResponseSeconds: number | null;
+	longestResponseSeconds: number | null;
+	opportunityCoverageSeconds: number;
+	opportunityCoverageShare: number;
+	longestNoOpportunityGapSeconds: number;
+}
+
+interface NormalizedOpportunity {
+	id: string;
+	startSeconds: number;
+	endSeconds: number;
+}
+
+interface Interval {
+	start: number;
+	end: number;
+}
+
+function isFiniteNumber(value: number): boolean {
+	return value === value && value !== Infinity && value !== -Infinity;
+}
+
+function finite(value: number, fallback = 0): number {
+	return isFiniteNumber(value) ? value : fallback;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.min(maximum, Math.max(minimum, value));
+}
+
+function normalizeBounds(startSeconds: number, endSeconds: number): Interval {
+	const start = Math.max(0, finite(startSeconds));
+	const end = Math.max(start, finite(endSeconds, start));
+	return { start, end };
+}
+
+function normalizeOpportunity(
+	opportunity: InterventionOpportunity,
+	bounds: Interval
+): NormalizedOpportunity | null {
+	if (
+		!isFiniteNumber(opportunity.startSeconds) ||
+		!isFiniteNumber(opportunity.endSeconds) ||
+		opportunity.endSeconds <= opportunity.startSeconds ||
+		opportunity.endSeconds <= bounds.start ||
+		opportunity.startSeconds >= bounds.end
+	) {
+		return null;
+	}
+	const start = clamp(opportunity.startSeconds, bounds.start, bounds.end);
+	const end = clamp(opportunity.endSeconds, start, bounds.end);
+	if (end <= start) return null;
+	return {
+		id: opportunity.id,
+		startSeconds: start,
+		endSeconds: end
+	};
+}
+
+function containsOpportunityId(
+	opportunities: NormalizedOpportunity[],
+	id: string
+): boolean {
+	for (let index = 0; index < opportunities.length; index += 1) {
+		if (opportunities[index].id === id) return true;
+	}
+	return false;
+}
+
+function mergeIntervals(intervals: Interval[]): Interval[] {
+	if (intervals.length === 0) return [];
+	const ordered = intervals
+		.map(interval => ({ start: interval.start, end: interval.end }))
+		.sort((a, b) => a.start - b.start || a.end - b.end);
+	const merged: Interval[] = [ordered[0]];
+	for (let index = 1; index < ordered.length; index += 1) {
+		const current = ordered[index];
+		const previous = merged[merged.length - 1];
+		if (current.start <= previous.end) {
+			previous.end = Math.max(previous.end, current.end);
+		} else {
+			merged.push(current);
+		}
+	}
+	return merged;
+}
+
+function coverageSeconds(intervals: Interval[]): number {
+	let total = 0;
+	for (let index = 0; index < intervals.length; index += 1) {
+		total += Math.max(0, intervals[index].end - intervals[index].start);
+	}
+	return total;
+}
+
+function longestNoOpportunityGap(bounds: Interval, intervals: Interval[]): number {
+	if (bounds.end <= bounds.start) return 0;
+	if (intervals.length === 0) return bounds.end - bounds.start;
+	let longest = Math.max(0, intervals[0].start - bounds.start);
+	for (let index = 1; index < intervals.length; index += 1) {
+		longest = Math.max(longest, intervals[index].start - intervals[index - 1].end);
+	}
+	return Math.max(longest, bounds.end - intervals[intervals.length - 1].end);
+}
+
+function firstOpportunityById(
+	opportunities: NormalizedOpportunity[],
+	id: string
+): NormalizedOpportunity | null {
+	for (let index = 0; index < opportunities.length; index += 1) {
+		if (opportunities[index].id === id) return opportunities[index];
+	}
+	return null;
+}
+
+/**
+ * Summarize how often the simulation presents meaningful opportunities to alter
+ * the physical future, independently from raw input volume.
+ *
+ * The caller owns opportunity classification. This module does not decide that
+ * a click is meaningful, reward action-per-minute, or feed metrics back into
+ * simulation authority. It only measures supplied decision windows and whether
+ * actions were attributed to them while they were still open.
+ *
+ * Malformed evidence fails closed: invalid/out-of-session/zero-width opportunity
+ * windows do not contribute decision coverage, duplicate ids do not double-count,
+ * and invalid/out-of-session action timestamps cannot inflate response or APM.
+ */
+export function summarizeInterventionCadence(
+	input: InterventionCadenceInput
+): InterventionCadenceSummary {
+	const bounds = normalizeBounds(input.sessionStartSeconds, input.sessionEndSeconds);
+	const durationSeconds = Math.max(0, bounds.end - bounds.start);
+	const opportunities: NormalizedOpportunity[] = [];
+	let invalidOpportunities = 0;
+	let duplicateOpportunityIds = 0;
+	for (let index = 0; index < input.opportunities.length; index += 1) {
+		const normalized = normalizeOpportunity(input.opportunities[index], bounds);
+		if (normalized === null) {
+			invalidOpportunities += 1;
+			continue;
+		}
+		if (containsOpportunityId(opportunities, normalized.id)) {
+			duplicateOpportunityIds += 1;
+			continue;
+		}
+		opportunities.push(normalized);
+	}
+
+	const mergedWindows = mergeIntervals(
+		opportunities.map(opportunity => ({
+			start: opportunity.startSeconds,
+			end: opportunity.endSeconds
+		}))
+	);
+	const opportunityCoverageSeconds = coverageSeconds(mergedWindows);
+
+	let invalidActions = 0;
+	let linkedActions = 0;
+	let lateLinkedActions = 0;
+	let unlinkedActions = 0;
+	const firstResponses: { [id: string]: number } = {};
+
+	for (let index = 0; index < input.actions.length; index += 1) {
+		const action = input.actions[index];
+		if (
+			!isFiniteNumber(action.atSeconds) ||
+			action.atSeconds < bounds.start ||
+			action.atSeconds > bounds.end
+		) {
+			invalidActions += 1;
+			continue;
+		}
+		const atSeconds = action.atSeconds;
+		if (action.opportunityId === null) {
+			unlinkedActions += 1;
+			continue;
+		}
+		const opportunity = firstOpportunityById(opportunities, action.opportunityId);
+		if (opportunity === null) {
+			unlinkedActions += 1;
+			continue;
+		}
+		linkedActions += 1;
+		if (atSeconds < opportunity.startSeconds || atSeconds > opportunity.endSeconds) {
+			lateLinkedActions += 1;
+			continue;
+		}
+		if (firstResponses[opportunity.id] === undefined) {
+			firstResponses[opportunity.id] = atSeconds;
+		}
+	}
+
+	let respondedOpportunities = 0;
+	let responseTotal = 0;
+	let longestResponseSeconds: number | null = null;
+	for (let index = 0; index < opportunities.length; index += 1) {
+		const opportunity = opportunities[index];
+		const responseAt = firstResponses[opportunity.id];
+		if (responseAt === undefined) continue;
+		respondedOpportunities += 1;
+		const responseSeconds = Math.max(0, responseAt - opportunity.startSeconds);
+		responseTotal += responseSeconds;
+		longestResponseSeconds =
+			longestResponseSeconds === null
+				? responseSeconds
+				: Math.max(longestResponseSeconds, responseSeconds);
+	}
+
+	const opportunityCount = opportunities.length;
+	const validActionCount = Math.max(0, input.actions.length - invalidActions);
+	return {
+		durationSeconds,
+		opportunities: opportunityCount,
+		invalidOpportunities,
+		duplicateOpportunityIds,
+		respondedOpportunities,
+		missedOpportunities: Math.max(0, opportunityCount - respondedOpportunities),
+		responseRate:
+			opportunityCount <= 0 ? 0 : respondedOpportunities / opportunityCount,
+		actions: validActionCount,
+		invalidActions,
+		linkedActions,
+		lateLinkedActions,
+		unlinkedActions,
+		unlinkedActionShare:
+			validActionCount <= 0 ? 0 : unlinkedActions / validActionCount,
+		actionsPerMinute:
+			durationSeconds <= 0 ? 0 : validActionCount / (durationSeconds / 60),
+		opportunitiesPerMinute:
+			durationSeconds <= 0 ? 0 : opportunityCount / (durationSeconds / 60),
+		meanResponseSeconds:
+			respondedOpportunities <= 0 ? null : responseTotal / respondedOpportunities,
+		longestResponseSeconds,
+		opportunityCoverageSeconds,
+		opportunityCoverageShare:
+			durationSeconds <= 0 ? 0 : opportunityCoverageSeconds / durationSeconds,
+		longestNoOpportunityGapSeconds: longestNoOpportunityGap(bounds, mergedWindows)
+	};
+}


### PR DESCRIPTION
Refs #108, #133
Parent chain: #112 → #117 → #120 → #134
Supersedes #129 for integration/certification; #129 remains provenance for the unchanged cadence slice.
Related: #29, #30, #72, #86, #92

## Why this reassembly exists

#129 introduced the meaningful-intervention/spectatorship diagnostic on top of #120. Static review then found evidence-integrity problems in #120, now corrected by #134.

This PR reapplies the **exact #129 two-file cadence delta** on top of #134 rather than leaving the future top-of-stack target dependent on the older observer behavior.

No cadence logic was rewritten during reassembly.

Source #129 head: `8fb16755e5fd0260191e41c7b7388cd8435d7121`.

Copied blob SHAs:

- `src/js/gameplay/interventionCadence.ts` → `966bea1b0f497b199bcc08844b4c7223818cb3a0`;
- `experiments/storybook/src/Arena/Interaction/InterventionCadence.stories.ts` → `4b7f3037c2b3cb94190d79d191b95efe0de0ebc4`.

These match #129 exactly.

## Purpose

Operationalize #108's intervention-cadence / spectatorship gate without rewarding raw input volume.

The observer measures caller-supplied meaningful decision windows separately from actions, including:

- opportunities/minute;
- responded/missed opportunities;
- response timing;
- union opportunity coverage;
- longest no-opportunity gap;
- linked/late/unlinked actions;
- actions/minute;
- malformed/duplicate evidence diagnostics.

The key invariant remains:

> Decision density is not input density.

The Storybook witness contrasts systemic engagement, spectator-prone sparse opportunities, and high-input busywork with the same sparse opportunity structure.

## Evidence integrity inherited from #134

The surrounding interaction observation stack now also fails closed on malformed/non-monotonic first-build/maintenance evidence rather than silently rewriting timestamps. This PR does not couple the two observers, but a future study/certification head can consume both without carrying the known #120 timestamp issue forward.

## Scope

Base: #134 exact head `665475725ee75c1b093129125e609361b985274e`.

Relative to #134:

- 2 commits ahead / 0 behind;
- exactly 2 added files;
- exact source blobs from #129;
- no edits to #112/#117/#120/#134 files;
- no live gameplay/input/physics/economy call sites;
- no package/dependency changes;
- no frozen #95/#97/#105 changes.

## Validation

Keep draft until the future post-freeze interaction campaign can run root compatibility plus Storybook typecheck/build/test for the whole chain.

Cadence-specific checks remain:

- empty/zero-duration sessions;
- overlapping windows;
- clipped/out-of-session windows;
- duplicate IDs;
- reversed/zero-width/non-finite windows;
- invalid/out-of-session actions;
- before/inside/after-window linked actions;
- multiple actions linked to one opportunity count one response;
- higher raw APM can coexist with unchanged sparse opportunity coverage and passive gaps.

## Promotion

Prefer this PR over #129 once #134 is accepted/certified. Do not reuse #129 exact-head evidence as evidence for this ancestry without testing this exact head.

This remains outside the frozen #92 campaign.