### PR TITLE
experiment: model bounded physical world residue

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/WorldResidue.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/WorldResidue.stories.ts
@@ -1,0 +1,284 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	appendWorldResidueEvent,
+	buildWorldResidueState,
+	createWorldResidueState,
+	summarizeWorldResidue,
+	type WorldResidueEvent,
+	type WorldResidueState,
+	type WorldResidueSummary
+} from "@defend/gameplay/worldResidue";
+import { createLabShell } from "../../labTheme";
+
+type HistoryFixture = {
+	id: string;
+	label: string;
+	description: string;
+	state: WorldResidueState;
+	summary: WorldResidueSummary;
+};
+
+function event(
+	id: string,
+	regionId: string,
+	kind: WorldResidueEvent["kind"],
+	occurredAtSeconds: number,
+	magnitude: number,
+	gameplayConsequence = false
+): WorldResidueEvent {
+	return { id, regionId, kind, occurredAtSeconds, magnitude, gameplayConsequence };
+}
+
+function repeatedHeavyFire(): WorldResidueEvent[] {
+	const events: WorldResidueEvent[] = [];
+	for (let index = 0; index < 10; index += 1) {
+		events.push(
+			event(
+				`heavy-${index}`,
+				index % 2 === 0 ? "east-approach" : "north-east-approach",
+				index % 3 === 0 ? "heavy-impact" : "minor-impact",
+				12 + index * 4,
+				index % 3 === 0 ? 0.5 : 0.24,
+				true
+			)
+		);
+	}
+	return events;
+}
+
+function fixture(
+	id: string,
+	label: string,
+	description: string,
+	events: WorldResidueEvent[]
+): HistoryFixture {
+	const state = buildWorldResidueState(events, { maxRecords: 12 });
+	return { id, label, description, state, summary: summarizeWorldResidue(state) };
+}
+
+function fixtures(): HistoryFixture[] {
+	return [
+		fixture("pristine", "Pristine", "No consequential history has accumulated yet.", []),
+		fixture(
+			"contested",
+			"Repeated heavy fire",
+			"The same approaches have absorbed repeated projectile impacts and now read as contested terrain.",
+			repeatedHeavyFire()
+		),
+		fixture(
+			"crash",
+			"Failed mothership",
+			"A large embodied commitment lost lift and remained as a recognizable landmark after impact.",
+			[
+				event("hulk-alpha", "west-edge", "mothership-hulk", 42, 0.96, true),
+				event("crash-impact", "west-edge", "heavy-impact", 42.2, 0.9, true),
+				event("secondary-impact", "west-approach", "heavy-impact", 42.4, 0.58, true)
+			]
+		),
+		fixture(
+			"eruption",
+			"Geothermal exhaustion",
+			"Sustained draw and eruption leave a geological history distinct from ordinary weapon impacts.",
+			[
+				event("dry-source", "south-source", "geothermal-depletion", 22, 0.7, true),
+				event("eruption-main", "south-source", "eruption", 38, 0.92, true),
+				event("eruption-edge", "south-approach", "eruption", 39, 0.46, false)
+			]
+		),
+		fixture(
+			"extracted",
+			"Recently extracted",
+			"The geometry is familiar, but the target carries a visible economic aftermath rather than only a lower hidden number.",
+			[
+				event("extraction-main", "core", "extraction-depletion", 55, 0.88, true),
+				event("breach-impact", "core-approach", "minor-impact", 54.5, 0.28, true)
+			]
+		),
+		fixture(
+			"abandoned",
+			"Abandoned fortress",
+			"The defended system has changed lifecycle state, leaving recognizable rooted infrastructure behind.",
+			[
+				event("fortress-origin", "core", "fortress-remnant", 72, 0.95, true),
+				event("dry-source", "north-source", "geothermal-depletion", 70, 0.62, true),
+				event("old-impact", "east-approach", "minor-impact", 31, 0.22, false)
+			]
+		)
+	];
+}
+
+function stressHistory(): WorldResidueState {
+	let state = createWorldResidueState();
+	for (let index = 0; index < 180; index += 1) {
+		const familyIndex = index % 4;
+		const kind: WorldResidueEvent["kind"] =
+			familyIndex === 0
+				? "minor-impact"
+				: familyIndex === 1
+					? "heavy-impact"
+					: familyIndex === 2
+						? "geothermal-depletion"
+						: "extraction-depletion";
+		state = appendWorldResidueEvent(
+			state,
+			event(
+				`stress-${index}`,
+				`region-${index % 18}`,
+				kind,
+				index * 3,
+				0.08 + (index % 7) * 0.06,
+				index % 5 === 0
+			),
+			{ maxRecords: 6 }
+		);
+	}
+	state = appendWorldResidueEvent(
+		state,
+		event("late-hulk", "far-edge", "mothership-hulk", 800, 0.98, true),
+		{ maxRecords: 6 }
+	);
+	return state;
+}
+
+function familyMarks(history: HistoryFixture): string {
+	if (history.state.records.length === 0) {
+		return `<span class="residue-empty">No residue</span>`;
+	}
+	return history.state.records
+		.map(record => {
+			const short =
+				record.family === "impact"
+					? "impact"
+					: record.family === "wreck"
+						? "hulk"
+						: record.family === "fortress"
+							? "remnant"
+							: record.family === "geology"
+								? "geology"
+								: "depletion";
+			return `<span class="residue-mark residue-mark--${record.family}" style="opacity:${Math.max(0.35, record.intensity)}" title="${record.regionId}: ${record.dominantKind} (${record.eventCount} event${record.eventCount === 1 ? "" : "s"})">${short}</span>`;
+		})
+		.join("");
+}
+
+function signature(summary: WorldResidueSummary): string {
+	return [
+		summary.hasWreckHistory ? "wreck" : "-",
+		summary.hasFortressRemnant ? "fortress" : "-",
+		summary.impactIntensity.toFixed(2),
+		summary.geologyIntensity.toFixed(2),
+		summary.energyIntensity.toFixed(2)
+	].join("|");
+}
+
+function historyCard(history: HistoryFixture): string {
+	const summary = history.summary;
+	return `
+		<article class="residue-card" data-history="${history.id}" data-signature="${signature(summary)}" data-impact="${summary.impactIntensity}" data-geology="${summary.geologyIntensity}" data-energy="${summary.energyIntensity}" data-hulk="${summary.hasMothershipHulk}" data-fortress="${summary.hasFortressRemnant}">
+			<header>
+				<small>same arena · different past</small>
+				<h3>${history.label}</h3>
+			</header>
+			<div class="residue-arena" aria-label="Compressed physical history for ${history.label}">
+				<div class="residue-core">core</div>
+				<div class="residue-marks">${familyMarks(history)}</div>
+			</div>
+			<p>${history.description}</p>
+			<dl class="residue-metrics">
+				<div><dt>represented events</dt><dd>${summary.representedEventCount}</dd></div>
+				<div><dt>records</dt><dd>${summary.recordCount}</dd></div>
+				<div><dt>impact</dt><dd>${summary.impactIntensity.toFixed(2)}</dd></div>
+				<div><dt>geology</dt><dd>${summary.geologyIntensity.toFixed(2)}</dd></div>
+				<div><dt>energy aftermath</dt><dd>${summary.energyIntensity.toFixed(2)}</dd></div>
+			</dl>
+		</article>
+	`;
+}
+
+const meta = {
+	title: "Foundations/Strategy/World Residue",
+	tags: ["test", "visual", "experimental"],
+	render: () => {
+		const histories = fixtures();
+		const stress = stressHistory();
+		const stressSummary = summarizeWorldResidue(stress);
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"World history without a history log",
+			"Compare one identical abstract arena after different systemic histories. The experiment tests whether consequential events can leave bounded, lossy, causally meaningful residue rather than disappearing into score text or unbounded debris."
+		);
+
+		shell.frame.innerHTML = `
+			<style>
+				.residue-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:14px; }
+				.residue-card { border:1px solid rgba(244,237,247,.14); border-radius:12px; padding:14px; background:rgba(12,7,18,.48); display:grid; gap:10px; }
+				.residue-card header small { opacity:.5; letter-spacing:.08em; text-transform:uppercase; }
+				.residue-card h3 { margin:3px 0 0; font-size:17px; }
+				.residue-card p { margin:0; opacity:.68; min-height:3.2em; line-height:1.45; }
+				.residue-arena { position:relative; min-height:126px; border:1px solid rgba(244,237,247,.12); border-radius:10px; overflow:hidden; background:repeating-linear-gradient(0deg,transparent 0 24px,rgba(244,237,247,.035) 24px 25px),repeating-linear-gradient(90deg,transparent 0 24px,rgba(244,237,247,.035) 24px 25px); }
+				.residue-core { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); width:52px; height:34px; display:grid; place-items:center; border:2px solid currentColor; opacity:.55; font-size:10px; text-transform:uppercase; letter-spacing:.08em; }
+				.residue-marks { position:absolute; inset:8px; display:flex; align-content:flex-start; align-items:flex-start; flex-wrap:wrap; gap:5px; pointer-events:none; }
+				.residue-mark,.residue-empty { padding:3px 6px; border:1px solid currentColor; border-radius:999px; font-size:9px; text-transform:uppercase; letter-spacing:.07em; background:rgba(8,4,12,.76); }
+				.residue-mark--wreck { border-style:double; border-width:3px; }
+				.residue-mark--fortress { border-radius:2px; border-style:double; }
+				.residue-mark--impact { border-style:dashed; }
+				.residue-mark--geology { border-style:dotted; }
+				.residue-mark--energy { border-left-width:5px; }
+				.residue-empty { opacity:.3; border-style:dashed; }
+				.residue-metrics { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:6px 12px; margin:0; }
+				.residue-metrics div { display:flex; justify-content:space-between; gap:8px; }
+				.residue-metrics dt { opacity:.5; }
+				.residue-metrics dd { margin:0; font-variant-numeric:tabular-nums; }
+				.residue-stress { margin-top:14px; padding:14px; border:1px solid rgba(244,237,247,.14); border-radius:12px; }
+				.residue-stress strong { font-variant-numeric:tabular-nums; }
+			</style>
+			<div class="residue-grid">${histories.map(historyCard).join("")}</div>
+			<section class="residue-stress" data-stress-records="${stressSummary.recordCount}" data-stress-compacted="${stressSummary.compactedEventCount}" data-stress-events="${stressSummary.representedEventCount}" data-stress-hulk="${stressSummary.hasMothershipHulk}">
+				<strong>Compaction stress:</strong>
+				180+ deterministic events are represented by ${stressSummary.recordCount} live semantic records plus a fixed-size compacted summary; ${stressSummary.compactedEventCount} event histories have already been folded out of detailed records. A late major hulk remains explicit: ${stressSummary.hasMothershipHulk ? "yes" : "no"}.
+			</section>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DifferentHistories: Story = {
+	play: async ({ canvasElement }) => {
+		const cards = Array.from(canvasElement.querySelectorAll<HTMLElement>("[data-history]"));
+		await expect(cards.length).toBe(6);
+		const signatures = cards.map(card => card.dataset.signature || "");
+		await expect(new Set(signatures).size).toBe(6);
+
+		const pristine = canvasElement.querySelector<HTMLElement>("[data-history='pristine']");
+		const contested = canvasElement.querySelector<HTMLElement>("[data-history='contested']");
+		const crash = canvasElement.querySelector<HTMLElement>("[data-history='crash']");
+		const eruption = canvasElement.querySelector<HTMLElement>("[data-history='eruption']");
+		const extracted = canvasElement.querySelector<HTMLElement>("[data-history='extracted']");
+		const abandoned = canvasElement.querySelector<HTMLElement>("[data-history='abandoned']");
+		await expect(pristine).not.toBeNull();
+		await expect(contested).not.toBeNull();
+		await expect(crash).not.toBeNull();
+		await expect(eruption).not.toBeNull();
+		await expect(extracted).not.toBeNull();
+		await expect(abandoned).not.toBeNull();
+		if (!pristine || !contested || !crash || !eruption || !extracted || !abandoned) return;
+		await expect(Number(pristine.dataset.impact)).toBe(0);
+		await expect(Number(contested.dataset.impact)).toBeGreaterThan(0.72);
+		await expect(crash.dataset.hulk).toBe("true");
+		await expect(Number(eruption.dataset.geology)).toBeGreaterThan(0.8);
+		await expect(Number(extracted.dataset.energy)).toBeGreaterThan(0.8);
+		await expect(abandoned.dataset.fortress).toBe("true");
+
+		const stress = canvasElement.querySelector<HTMLElement>("[data-stress-records]");
+		await expect(stress).not.toBeNull();
+		if (!stress) return;
+		await expect(Number(stress.dataset.stressRecords)).toBeLessThanOrEqual(6);
+		await expect(Number(stress.dataset.stressCompacted)).toBeGreaterThan(0);
+		await expect(Number(stress.dataset.stressEvents)).toBe(181);
+		await expect(stress.dataset.stressHulk).toBe("true");
+	}
+};

--- a/src/js/gameplay/worldResidue.ts
+++ b/src/js/gameplay/worldResidue.ts
@@ -1,0 +1,342 @@
+export type WorldResidueFamily = "impact" | "wreck" | "fortress" | "geology" | "energy";
+
+export type WorldResidueKind =
+	| "minor-impact"
+	| "heavy-impact"
+	| "mothership-hulk"
+	| "fortress-remnant"
+	| "eruption"
+	| "geothermal-depletion"
+	| "extraction-depletion";
+
+export interface WorldResidueEvent {
+	id: string;
+	regionId: string;
+	kind: WorldResidueKind;
+	occurredAtSeconds: number;
+	magnitude: number;
+	gameplayConsequence: boolean;
+}
+
+export interface WorldResidueRecord {
+	key: string;
+	regionId: string;
+	family: WorldResidueFamily;
+	dominantKind: WorldResidueKind;
+	eventCount: number;
+	firstOccurredAtSeconds: number;
+	lastOccurredAtSeconds: number;
+	intensity: number;
+	peakMagnitude: number;
+	landmark: boolean;
+	gameplayConsequence: boolean;
+}
+
+export interface CompactedWorldResidue {
+	totalEvents: number;
+	impactEvents: number;
+	wreckEvents: number;
+	fortressEvents: number;
+	geologyEvents: number;
+	energyEvents: number;
+	impactIntensity: number;
+	wreckIntensity: number;
+	fortressIntensity: number;
+	geologyIntensity: number;
+	energyIntensity: number;
+}
+
+export interface WorldResidueState {
+	records: WorldResidueRecord[];
+	compacted: CompactedWorldResidue;
+}
+
+export interface WorldResidueConfig {
+	maxRecords: number;
+}
+
+export interface WorldResidueSummary {
+	recordCount: number;
+	representedEventCount: number;
+	compactedEventCount: number;
+	hasMothershipHulk: boolean;
+	hasWreckHistory: boolean;
+	hasFortressRemnant: boolean;
+	impactIntensity: number;
+	geologyIntensity: number;
+	energyIntensity: number;
+	heavilyContested: boolean;
+}
+
+export const DEFAULT_WORLD_RESIDUE_CONFIG: WorldResidueConfig = {
+	maxRecords: 16
+};
+
+function finite(value: number, fallback: number): number {
+	if (value !== value || value === Infinity || value === -Infinity) return fallback;
+	return value;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
+}
+
+function clamp01(value: number): number {
+	return clamp(value, 0, 1);
+}
+
+function safeText(value: string, fallback: string): string {
+	if (typeof value !== "string") return fallback;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function normalizedConfig(config: WorldResidueConfig): WorldResidueConfig {
+	return {
+		maxRecords: Math.max(1, Math.min(128, Math.floor(finite(config.maxRecords, 16))))
+	};
+}
+
+function normalizedEvent(event: WorldResidueEvent): WorldResidueEvent {
+	return {
+		id: safeText(event.id, "unknown-event"),
+		regionId: safeText(event.regionId, "unknown-region"),
+		kind: event.kind,
+		occurredAtSeconds: Math.max(0, finite(event.occurredAtSeconds, 0)),
+		magnitude: clamp01(event.magnitude),
+		gameplayConsequence: event.gameplayConsequence === true
+	};
+}
+
+export function worldResidueFamily(kind: WorldResidueKind): WorldResidueFamily {
+	if (kind === "minor-impact" || kind === "heavy-impact") return "impact";
+	if (kind === "mothership-hulk") return "wreck";
+	if (kind === "fortress-remnant") return "fortress";
+	if (kind === "eruption" || kind === "geothermal-depletion") return "geology";
+	return "energy";
+}
+
+export function worldResidueIsLandmark(kind: WorldResidueKind): boolean {
+	return kind === "mothership-hulk" || kind === "fortress-remnant";
+}
+
+function emptyCompacted(): CompactedWorldResidue {
+	return {
+		totalEvents: 0,
+		impactEvents: 0,
+		wreckEvents: 0,
+		fortressEvents: 0,
+		geologyEvents: 0,
+		energyEvents: 0,
+		impactIntensity: 0,
+		wreckIntensity: 0,
+		fortressIntensity: 0,
+		geologyIntensity: 0,
+		energyIntensity: 0
+	};
+}
+
+export function createWorldResidueState(): WorldResidueState {
+	return { records: [], compacted: emptyCompacted() };
+}
+
+function copyCompacted(source: CompactedWorldResidue): CompactedWorldResidue {
+	return {
+		totalEvents: Math.max(0, Math.floor(finite(source.totalEvents, 0))),
+		impactEvents: Math.max(0, Math.floor(finite(source.impactEvents, 0))),
+		wreckEvents: Math.max(0, Math.floor(finite(source.wreckEvents, 0))),
+		fortressEvents: Math.max(0, Math.floor(finite(source.fortressEvents, 0))),
+		geologyEvents: Math.max(0, Math.floor(finite(source.geologyEvents, 0))),
+		energyEvents: Math.max(0, Math.floor(finite(source.energyEvents, 0))),
+		impactIntensity: clamp01(source.impactIntensity),
+		wreckIntensity: clamp01(source.wreckIntensity),
+		fortressIntensity: clamp01(source.fortressIntensity),
+		geologyIntensity: clamp01(source.geologyIntensity),
+		energyIntensity: clamp01(source.energyIntensity)
+	};
+}
+
+function saturatedMerge(current: number, incoming: number): number {
+	const a = clamp01(current);
+	const b = clamp01(incoming);
+	return 1 - (1 - a) * (1 - b);
+}
+
+function recordKey(event: WorldResidueEvent): string {
+	if (worldResidueIsLandmark(event.kind)) {
+		return `landmark:${event.kind}:${event.id}`;
+	}
+	return `aggregate:${event.regionId}:${worldResidueFamily(event.kind)}`;
+}
+
+function recordFromEvent(event: WorldResidueEvent): WorldResidueRecord {
+	return {
+		key: recordKey(event),
+		regionId: event.regionId,
+		family: worldResidueFamily(event.kind),
+		dominantKind: event.kind,
+		eventCount: 1,
+		firstOccurredAtSeconds: event.occurredAtSeconds,
+		lastOccurredAtSeconds: event.occurredAtSeconds,
+		intensity: event.magnitude,
+		peakMagnitude: event.magnitude,
+		landmark: worldResidueIsLandmark(event.kind),
+		gameplayConsequence: event.gameplayConsequence
+	};
+}
+
+function mergeRecord(record: WorldResidueRecord, event: WorldResidueEvent): WorldResidueRecord {
+	const eventMagnitude = clamp01(event.magnitude);
+	const dominantKind = eventMagnitude >= record.peakMagnitude ? event.kind : record.dominantKind;
+	return {
+		key: record.key,
+		regionId: record.regionId,
+		family: record.family,
+		dominantKind,
+		eventCount: Math.max(1, record.eventCount) + 1,
+		firstOccurredAtSeconds: Math.min(record.firstOccurredAtSeconds, event.occurredAtSeconds),
+		lastOccurredAtSeconds: Math.max(record.lastOccurredAtSeconds, event.occurredAtSeconds),
+		intensity: saturatedMerge(record.intensity, eventMagnitude),
+		peakMagnitude: Math.max(record.peakMagnitude, eventMagnitude),
+		landmark: record.landmark,
+		gameplayConsequence: record.gameplayConsequence || event.gameplayConsequence
+	};
+}
+
+function foldRecord(compacted: CompactedWorldResidue, record: WorldResidueRecord): void {
+	const events = Math.max(1, Math.floor(finite(record.eventCount, 1)));
+	compacted.totalEvents += events;
+	if (record.family === "impact") {
+		compacted.impactEvents += events;
+		compacted.impactIntensity = saturatedMerge(compacted.impactIntensity, record.intensity);
+	} else if (record.family === "wreck") {
+		compacted.wreckEvents += events;
+		compacted.wreckIntensity = saturatedMerge(compacted.wreckIntensity, record.intensity);
+	} else if (record.family === "fortress") {
+		compacted.fortressEvents += events;
+		compacted.fortressIntensity = saturatedMerge(compacted.fortressIntensity, record.intensity);
+	} else if (record.family === "geology") {
+		compacted.geologyEvents += events;
+		compacted.geologyIntensity = saturatedMerge(compacted.geologyIntensity, record.intensity);
+	} else {
+		compacted.energyEvents += events;
+		compacted.energyIntensity = saturatedMerge(compacted.energyIntensity, record.intensity);
+	}
+}
+
+function retentionScore(record: WorldResidueRecord, newestTime: number): number {
+	const age = Math.max(0, newestTime - record.lastOccurredAtSeconds);
+	const recency = 1 / (1 + age / 60);
+	return (
+		(record.landmark ? 8 : 0) +
+		(record.gameplayConsequence ? 2 : 0) +
+		record.intensity * 3 +
+		recency
+	);
+}
+
+function lowestRetentionIndex(records: WorldResidueRecord[], newestTime: number): number {
+	let selected = 0;
+	let selectedScore = retentionScore(records[0], newestTime);
+	for (let index = 1; index < records.length; index += 1) {
+		const score = retentionScore(records[index], newestTime);
+		if (score < selectedScore) {
+			selected = index;
+			selectedScore = score;
+		}
+	}
+	return selected;
+}
+
+export function appendWorldResidueEvent(
+	state: WorldResidueState,
+	eventInput: WorldResidueEvent,
+	configInput: WorldResidueConfig = DEFAULT_WORLD_RESIDUE_CONFIG
+): WorldResidueState {
+	const config = normalizedConfig(configInput);
+	const event = normalizedEvent(eventInput);
+	const records = state.records.slice();
+	const compacted = copyCompacted(state.compacted);
+	const key = recordKey(event);
+	let found = -1;
+	for (let index = 0; index < records.length; index += 1) {
+		if (records[index].key === key) {
+			found = index;
+			break;
+		}
+	}
+	if (found >= 0) records[found] = mergeRecord(records[found], event);
+	else records.push(recordFromEvent(event));
+
+	while (records.length > config.maxRecords) {
+		const victim = lowestRetentionIndex(records, event.occurredAtSeconds);
+		foldRecord(compacted, records[victim]);
+		records.splice(victim, 1);
+	}
+
+	return { records, compacted };
+}
+
+export function buildWorldResidueState(
+	events: WorldResidueEvent[],
+	config: WorldResidueConfig = DEFAULT_WORLD_RESIDUE_CONFIG
+): WorldResidueState {
+	let state = createWorldResidueState();
+	for (let index = 0; index < events.length; index += 1) {
+		state = appendWorldResidueEvent(state, events[index], config);
+	}
+	return state;
+}
+
+function recordFamilyIntensity(records: WorldResidueRecord[], family: WorldResidueFamily): number {
+	let intensity = 0;
+	for (let index = 0; index < records.length; index += 1) {
+		if (records[index].family === family) {
+			intensity = saturatedMerge(intensity, records[index].intensity);
+		}
+	}
+	return intensity;
+}
+
+function recordEventCount(records: WorldResidueRecord[]): number {
+	let total = 0;
+	for (let index = 0; index < records.length; index += 1) {
+		total += Math.max(1, Math.floor(finite(records[index].eventCount, 1)));
+	}
+	return total;
+}
+
+export function summarizeWorldResidue(state: WorldResidueState): WorldResidueSummary {
+	let hasMothershipHulk = false;
+	let hasFortressRemnant = false;
+	for (let index = 0; index < state.records.length; index += 1) {
+		const record = state.records[index];
+		if (record.dominantKind === "mothership-hulk") hasMothershipHulk = true;
+		if (record.dominantKind === "fortress-remnant") hasFortressRemnant = true;
+	}
+	const impactIntensity = saturatedMerge(
+		recordFamilyIntensity(state.records, "impact"),
+		state.compacted.impactIntensity
+	);
+	const geologyIntensity = saturatedMerge(
+		recordFamilyIntensity(state.records, "geology"),
+		state.compacted.geologyIntensity
+	);
+	const energyIntensity = saturatedMerge(
+		recordFamilyIntensity(state.records, "energy"),
+		state.compacted.energyIntensity
+	);
+	const representedEventCount = recordEventCount(state.records) + state.compacted.totalEvents;
+	return {
+		recordCount: state.records.length,
+		representedEventCount,
+		compactedEventCount: state.compacted.totalEvents,
+		hasMothershipHulk,
+		hasWreckHistory: hasMothershipHulk || state.compacted.wreckEvents > 0,
+		hasFortressRemnant: hasFortressRemnant || state.compacted.fortressEvents > 0,
+		impactIntensity,
+		geologyIntensity,
+		energyIntensity,
+		heavilyContested: impactIntensity >= 0.72
+	};
+}


### PR DESCRIPTION
Refs #137, #103
Related: #73, #76, #79, #89, #113, #92

## Purpose

Make #137's environmental-history idea executable without adding production persistence, Babylon objects, physics bodies, save-state migration, or narrative exposition.

This experiment asks a narrow question:

> Can consequential play leave a bounded semantic residue that preserves qualitative causal history after detailed simulation objects are compacted away?

## Scope

Base: current `master` `e9852845601606db97fc7a2931b69fd7d1af6d23`.

Exactly two added files:

- `src/js/gameplay/worldResidue.ts`;
- `experiments/storybook/src/Foundations/Strategy/WorldResidue.stories.ts`.

No production call sites, balance constants, Babylon/Cannon objects, terrain meshes, save/load formats, package/dependency metadata, or frozen #92 certification heads are changed.

## Pure residue model

`worldResidue.ts` separates detailed current records from compacted history.

Semantic event families:

- impact;
- wreck;
- fortress;
- geology;
- energy.

Representative event kinds include minor/heavy impacts, mothership hulks, fortress remnants, eruptions, geothermal depletion and extraction depletion.

### Aggregation

Ordinary events aggregate by region + causal family. Repeated events increase a saturating qualitative intensity rather than creating one permanent record per collision.

Landmarks currently include:

- mothership hulk;
- fortress remnant.

They retain stable event identity and receive higher retention priority than ordinary aggregate residue.

### Bounded compaction

`WorldResidueConfig.maxRecords` places a hard bound on detailed semantic records.

When the detailed budget is exceeded, the lowest-retention record is folded into a fixed-size `CompactedWorldResidue` summary that preserves:

- represented event count by family;
- strongest retained qualitative intensity by family.

The compacted layer intentionally loses exact event order, identity and location. This is the desired distinction between **historical meaning** and a perfect forensic log.

Retention preference considers:

- landmark status;
- current gameplay consequence;
- qualitative intensity;
- recency.

This is an experiment policy, not a final save/persistence algorithm.

## Storybook witness

Adds `Foundations/Strategy/World Residue`.

It presents the **same abstract arena after six different histories**:

1. pristine;
2. repeated heavy fire;
3. failed mothership crash;
4. geothermal exhaustion/eruption;
5. recent extraction;
6. abandoned fortress.

The layouts are intentionally geometrically equivalent. Only systemic residue differs, so reviewers can judge whether history is inferable without a log or explanatory cutscene.

The visual grammar uses redundant border/pattern/shape distinctions; color is not required for the semantic comparison.

### Compaction stress

A deterministic stress witness submits 180 ordinary events across many regions under a six-record cap, then adds a late mothership hulk.

The test verifies:

- detailed records remain `<= 6`;
- compacted history is non-empty;
- all 181 events remain represented between detailed + compacted state;
- the late major hulk remains explicit.

## Automated Storybook invariants

The story verifies:

- six histories render and have distinct semantic signatures;
- pristine carries no impact residue;
- repeated heavy fire crosses the contested-impact threshold;
- crash history preserves a mothership-hulk landmark;
- eruption produces strong geological history;
- extraction produces strong energy aftermath;
- abandoned fortress preserves a fortress-remnant landmark;
- compaction remains bounded while represented-event accounting is preserved.

## Design boundary

This model is **not** simulation authority.

It does not decide:

- crater geometry;
- collision/obstruction;
- exact visual meshes;
- hulk physics;
- terrain recovery;
- how long a residue should persist in campaign time;
- what save format should store it;
- whether a residue affects gameplay or is presentation-only.

Those remain with #79/#89/#76 and future adapters. This PR only supplies a compact semantic history seam that those systems could feed.

## Why this matters to the inversion

If later adapters preserve the same semantic causes, the player can encounter failed motherships, depleted targets and abandoned rooted defenses before fully understanding them, then reinterpret those traces after becoming a mothership themselves.

That strengthens the defender → raider reveal through recognition rather than exposition.

## Validation / promotion

Keep draft and outside all currently frozen certification cuts.

A later post-freeze campaign should run:

```sh
npm run lint
npm run build
cd experiments/storybook
pnpm typecheck
pnpm build
pnpm test
```

Also inspect `World Residue` at representative compact/desktop viewports and grayscale/reduced visual conditions where useful.

Before production use:

- calibrate event inputs from #79/#89/#76 rather than inventing duplicate physics/economy facts;
- test many-landmark overflow, event-time discontinuities and malformed/rehydrated state;
- decide which residues are gameplay-consequential versus presentation-only;
- measure long-horizon state/render budgets;
- add reload/reconstruction evidence;
- run #137's human comprehension/reinterpretation tests.

This is a semantic feasibility experiment, not a persistence-system commitment.