### PR TITLE
Harden intervention-cadence runtime evidence types

### DIFF
--- a/experiments/storybook/src/Arena/Interaction/InterventionCadence.stories.ts
+++ b/experiments/storybook/src/Arena/Interaction/InterventionCadence.stories.ts
@@ -260,5 +260,28 @@ export const DecisionDensityNotInputDensity: Story = {
 		await expect(malformed.respondedOpportunities).toBe(1);
 		await expect(malformed.actions).toBe(1);
 		await expect(malformed.invalidActions).toBe(2);
+
+		const runtimeMalformed = summarizeInterventionCadence({
+			sessionStartSeconds: undefined as unknown as number,
+			sessionEndSeconds: 90,
+			opportunities: [
+				opportunity(
+					"runtime-invalid",
+					undefined as unknown as number,
+					20
+				)
+			],
+			actions: [
+				linkedAction(undefined as unknown as number, "runtime-invalid")
+			]
+		});
+		await expect(runtimeMalformed.durationSeconds).toBe(90);
+		await expect(runtimeMalformed.opportunities).toBe(0);
+		await expect(runtimeMalformed.invalidOpportunities).toBe(1);
+		await expect(runtimeMalformed.actions).toBe(0);
+		await expect(runtimeMalformed.invalidActions).toBe(1);
+		await expect(Number.isFinite(runtimeMalformed.responseRate)).toBe(true);
+		await expect(Number.isFinite(runtimeMalformed.actionsPerMinute)).toBe(true);
+		await expect(Number.isFinite(runtimeMalformed.opportunityCoverageShare)).toBe(true);
 	}
 };

--- a/src/js/gameplay/interventionCadence.ts
+++ b/src/js/gameplay/interventionCadence.ts
@@ -77,7 +77,12 @@ interface Interval {
 }
 
 function isFiniteNumber(value: number): boolean {
-	return value === value && value !== Infinity && value !== -Infinity;
+	return (
+		typeof value === "number" &&
+		value === value &&
+		value !== Infinity &&
+		value !== -Infinity
+	);
 }
 
 function finite(value: number, fallback = 0): number {


### PR DESCRIPTION
Refs #108, #133
Parent: #139
Related: #129, #134, #135, #138

## Purpose

Close the same runtime-boundary class already fixed in #134's observation evidence before the interaction certification batch is frozen again.

`interventionCadence.ts` documents that malformed evidence fails closed, but its `isFiniteNumber(value: number)` predicate only checked NaN/±Infinity. A runtime non-number crossing the typed boundary after rehydration (for example `undefined`) could satisfy those equality checks, causing session normalization such as `Math.max(0, undefined)` to become `NaN` and poison duration/rate evidence.

## Change

Relative to #139 head:

- require `typeof value === "number"` in the cadence finite predicate;
- runtime non-number session bounds now use the documented finite fallback;
- runtime non-number opportunity/action timestamps are rejected as invalid evidence;
- no cadence metric semantics or gameplay authority change.

The Storybook cadence witness adds a runtime-`undefined` case and verifies:

- session start safely falls back to zero;
- malformed opportunity/action timestamps do not enter valid counts;
- duration, response rate, APM and opportunity coverage remain finite.

## Scope

Exactly two additional files relative to #139:

- `src/js/gameplay/interventionCadence.ts`;
- `experiments/storybook/src/Arena/Interaction/InterventionCadence.stories.ts`.

No production gameplay, balance, input routing, dependencies, persistence, or frozen #95/#97/#105 heads change.

## Certification consequence

If accepted, the next direct-on-master interaction certification batch should use this branch's corrected cadence blobs together with #139's corrected interaction-authority blobs and the unchanged remaining #138 provenance. Keep draft until that exact replacement batch receives root + Storybook local PASS evidence.