### PR TITLE
Model post-breach evacuation capital risk

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/RaiderCapitalEconomy.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/RaiderCapitalEconomy.stories.ts
@@ -13,8 +13,10 @@ import { createLabShell } from "../../labTheme";
 type CapitalEconomyArgs = {
 	expectedBreachProbability: number;
 	expectedBreachViability: number;
+	expectedSuccessReturnViability: number;
 	expectedFailureReturnViability: number;
-	realizedViability: number;
+	realizedBreachViability: number;
+	realizedReturnViability: number;
 	travelAndOperatingCost: number;
 	defenderCaptureFraction: number;
 };
@@ -35,6 +37,7 @@ const MODES: RaiderCapitalMode[] = ["fully-sunk", "embodied-return"];
 const FIXED_WITNESS = {
 	expectedBreachProbability: 0.55,
 	expectedBreachViability: 0.55,
+	expectedSuccessReturnViability: 0.55,
 	expectedFailureReturnViability: 0.3,
 	travelAndOperatingCost: 500
 };
@@ -64,6 +67,7 @@ function estimateCell(
 		perceivedTargetEnergy: target.reserve,
 		expectedBreachProbability: args.expectedBreachProbability,
 		expectedArrivalViabilityOnBreach: args.expectedBreachViability,
+		expectedReturnViabilityAfterBreach: args.expectedSuccessReturnViability,
 		expectedReturnViabilityOnFailure: args.expectedFailureReturnViability,
 		travelAndOperatingCost: args.travelAndOperatingCost
 	});
@@ -72,7 +76,7 @@ function estimateCell(
 		<div class="capital-cell" data-mode="${mode}" data-target="${target.reserve}" data-tier="${profile.tier}" data-positive="${positive}">
 			<header><strong>R${profile.tier}</strong><span>${positive ? "positive EV" : "negative EV"}</span></header>
 			<div class="capital-net">${signed(estimate.expectedNetReturn)}</div>
-			<small>extract ${fixed(estimate.expectedExtractedEnergy)} · return ${fixed(estimate.expectedReturnedCapital)} · capital loss ${fixed(estimate.expectedCapitalLoss)}</small>
+			<small>extract ${fixed(estimate.expectedExtractedEnergy)} · return ${fixed(estimate.expectedReturnedCapital)} · post-breach loss ${fixed(estimate.expectedPostBreachCapitalLoss)}</small>
 		</div>
 	`;
 }
@@ -85,7 +89,7 @@ function modePanel(mode: RaiderCapitalMode, args: CapitalEconomyArgs): string {
 				<p>${
 					mode === "fully-sunk"
 						? "Launch commitment is consumed immediately; surviving body state cannot return that commitment."
-						: "Launch commitment moves into the raider; surviving viability returns capital and damaged capital becomes capture/loss exposure."
+						: "Launch commitment remains physical capital. Breach viability limits extraction; later evacuation viability independently determines how much capital actually returns."
 				}</p>
 			</div>
 			<div class="capital-targets">
@@ -110,6 +114,8 @@ function fixedWitnessPositive(tierIndex: number, targetEnergy: number): boolean 
 			perceivedTargetEnergy: targetEnergy,
 			expectedBreachProbability: FIXED_WITNESS.expectedBreachProbability,
 			expectedArrivalViabilityOnBreach: FIXED_WITNESS.expectedBreachViability,
+			expectedReturnViabilityAfterBreach:
+				FIXED_WITNESS.expectedSuccessReturnViability,
 			expectedReturnViabilityOnFailure:
 				FIXED_WITNESS.expectedFailureReturnViability,
 			travelAndOperatingCost: FIXED_WITNESS.travelAndOperatingCost
@@ -123,16 +129,20 @@ const meta = {
 	args: {
 		expectedBreachProbability: 0.55,
 		expectedBreachViability: 0.55,
+		expectedSuccessReturnViability: 0.55,
 		expectedFailureReturnViability: 0.3,
-		realizedViability: 0.55,
+		realizedBreachViability: 0.7,
+		realizedReturnViability: 0.7,
 		travelAndOperatingCost: 500,
 		defenderCaptureFraction: 0.72
 	},
 	argTypes: {
 		expectedBreachProbability: { control: { type: "range", min: 0.05, max: 1, step: 0.05 } },
 		expectedBreachViability: { control: { type: "range", min: 0.05, max: 1, step: 0.05 } },
+		expectedSuccessReturnViability: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
 		expectedFailureReturnViability: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
-		realizedViability: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
+		realizedBreachViability: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
+		realizedReturnViability: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
 		travelAndOperatingCost: { control: { type: "range", min: 0, max: 3000, step: 100 } },
 		defenderCaptureFraction: { control: { type: "range", min: 0, max: 1, step: 0.05 } }
 	},
@@ -140,7 +150,7 @@ const meta = {
 		const shell = createLabShell(
 			"Foundations / strategy",
 			"Raider launch capital at risk",
-			"Compare fully sunk launch cost with a conservation-first hypothesis where launch energy remains embodied in the raider and returns only in proportion to physical survival. Controls are exploratory; the automated witness stays fixed."
+			"Compare fully sunk launch cost with embodied capital whose extraction-time integrity and later evacuation survival are independent. This keeps post-breach interception economically meaningful."
 		);
 		shell.frame.innerHTML = `
 			<style>
@@ -156,7 +166,6 @@ const meta = {
 				.capital-tier-grid { display:grid; gap:7px; }
 				.capital-cell { padding:9px; border:1px solid rgba(228,185,128,.16); background:rgba(10,3,17,.36); }
 				.capital-cell header { display:flex; justify-content:space-between; gap:8px; font-size:10px; }
-				.capital-cell[data-positive="true"] { border-style:solid; }
 				.capital-cell[data-positive="false"] { border-style:dashed; opacity:.68; }
 				.capital-net { margin:7px 0 4px; font-size:17px; font-variant-numeric:tabular-nums; }
 				.capital-cell small { display:block; font-size:9px; line-height:1.45; }
@@ -164,7 +173,7 @@ const meta = {
 				@media (max-width:900px) { .capital-targets { grid-template-columns:1fr; } .capital-mode__heading { grid-template-columns:1fr; } }
 			</style>
 			<div class="capital-layout">${MODES.map(mode => modePanel(mode, args)).join("")}</div>
-			<div class="capital-note">Expected value includes target-bounded extraction, launch-capital loss/return and travel/operating drain. Changing controls is meant to reveal regimes where the default contextual role pattern fails; those exploratory states do not invalidate the fixed automated witness.</div>
+			<div class="capital-note">The automated witness additionally compares clean evacuation, post-extraction interception, and failed-breach retreat. Extraction capability and return survival are deliberately non-identical quantities.</div>
 		`;
 		return shell.root;
 	}
@@ -202,23 +211,21 @@ export const CapitalAtRiskMatrix: Story = {
 						defenderReserve: target.reserve,
 						defenderCapacity: 30000,
 						breached: true,
-						remainingViability: args.realizedViability,
+						breachViability: args.realizedBreachViability,
+						returnViability: args.realizedReturnViability,
 						travelAndOperatingCost: args.travelAndOperatingCost,
 						defenderCaptureFraction: args.defenderCaptureFraction,
 						collateralDissipationRatio: 0
 					});
-					await expect(settlement.extractedEnergy).toBeLessThanOrEqual(
-						target.reserve
-					);
+					await expect(settlement.extractedEnergy).toBeLessThanOrEqual(target.reserve);
+					await expect(settlement.returnedCapital).toBeLessThanOrEqual(profile.committedEnergy);
 					await expect(settlement.returnedCapital).toBeLessThanOrEqual(
-						profile.committedEnergy
+						settlement.capitalPresentAtBreach || profile.committedEnergy
 					);
 					await expect(settlement.capturedCapital).toBeLessThanOrEqual(
 						settlement.capitalAtRiskLost
 					);
-					await expect(Math.abs(settlement.conservationResidual)).toBeLessThan(
-						0.000001
-					);
+					await expect(Math.abs(settlement.conservationResidual)).toBeLessThan(0.000001);
 					if (mode === "fully-sunk") {
 						await expect(settlement.returnedCapital).toBe(0);
 						await expect(settlement.capturedCapital).toBe(0);
@@ -226,5 +233,52 @@ export const CapitalAtRiskMatrix: Story = {
 				}
 			}
 		}
+
+		const profile = DEFAULT_RAIDER_CAPITAL_PROFILES[1];
+		const cleanReturn = settleRaiderCapitalEconomy({
+			mode: "embodied-return",
+			profile,
+			defenderReserve: 30000,
+			defenderCapacity: 30000,
+			breached: true,
+			breachViability: 0.8,
+			returnViability: 0.8,
+			travelAndOperatingCost: 500,
+			defenderCaptureFraction: 0.72,
+			collateralDissipationRatio: 0
+		});
+		const interceptedReturn = settleRaiderCapitalEconomy({
+			mode: "embodied-return",
+			profile,
+			defenderReserve: 30000,
+			defenderCapacity: 30000,
+			breached: true,
+			breachViability: 0.8,
+			returnViability: 0.2,
+			travelAndOperatingCost: 500,
+			defenderCaptureFraction: 0.72,
+			collateralDissipationRatio: 0
+		});
+		await expect(interceptedReturn.extractedEnergy).toBe(cleanReturn.extractedEnergy);
+		await expect(interceptedReturn.returnedCapital).toBeLessThan(cleanReturn.returnedCapital);
+		await expect(interceptedReturn.postBreachCapitalLoss).toBeGreaterThan(0);
+		await expect(interceptedReturn.attackerNetReturn).toBeLessThan(cleanReturn.attackerNetReturn);
+
+		const failedRetreat = settleRaiderCapitalEconomy({
+			mode: "embodied-return",
+			profile,
+			defenderReserve: 30000,
+			defenderCapacity: 30000,
+			breached: false,
+			breachViability: 0.8,
+			returnViability: 0.3,
+			travelAndOperatingCost: 500,
+			defenderCaptureFraction: 0.72,
+			collateralDissipationRatio: 0
+		});
+		await expect(failedRetreat.extractedEnergy).toBe(0);
+		await expect(failedRetreat.returnedCapital).toBeCloseTo(profile.committedEnergy * 0.3);
+		await expect(failedRetreat.postBreachCapitalLoss).toBe(0);
+		await expect(Math.abs(failedRetreat.conservationResidual)).toBeLessThan(0.000001);
 	}
 };

--- a/src/js/gameplay/raiderCapitalEconomy.ts
+++ b/src/js/gameplay/raiderCapitalEconomy.ts
@@ -18,7 +18,10 @@ export interface RaiderCapitalSettlementInput {
 	defenderReserve: number;
 	defenderCapacity: number;
 	breached: boolean;
-	remainingViability: number;
+	/** Physical viability/capability when extraction occurs. */
+	breachViability: number;
+	/** Capital fraction that actually survives the later retreat/evacuation. */
+	returnViability: number;
 	travelAndOperatingCost: number;
 	defenderCaptureFraction: number;
 	collateralDissipationRatio: number;
@@ -28,7 +31,11 @@ export interface RaiderCapitalSettlement {
 	mode: RaiderCapitalMode;
 	tier: RaiderCapitalTier;
 	committedEnergy: number;
-	remainingViability: number;
+	breachViability: number;
+	returnViability: number;
+	capitalPresentAtBreach: number;
+	preBreachCapitalLoss: number;
+	postBreachCapitalLoss: number;
 	requestedExtractionEnergy: number;
 	extractedEnergy: number;
 	returnedCapital: number;
@@ -48,7 +55,11 @@ export interface RaiderCapitalExpectedValueInput {
 	profile: RaiderCapitalProfile;
 	perceivedTargetEnergy: number;
 	expectedBreachProbability: number;
+	/** Expected body viability/capability at successful extraction. */
 	expectedArrivalViabilityOnBreach: number;
+	/** Expected capital fraction that returns after a successful breach. */
+	expectedReturnViabilityAfterBreach: number;
+	/** Expected capital fraction that returns after a failed breach/retreat. */
 	expectedReturnViabilityOnFailure: number;
 	travelAndOperatingCost: number;
 }
@@ -61,12 +72,20 @@ export interface RaiderCapitalExpectedValue {
 	expectedExtractedEnergy: number;
 	expectedReturnedCapital: number;
 	expectedCapitalLoss: number;
+	expectedPostBreachCapitalLoss: number;
 	expectedNetReturn: number;
 	expectedReturnOnCommitment: number;
 }
 
 function finite(value: number, fallback = 0): number {
-	if (value !== value || value === Infinity || value === -Infinity) return fallback;
+	if (
+		typeof value !== "number" ||
+		value !== value ||
+		value === Infinity ||
+		value === -Infinity
+	) {
+		return fallback;
+	}
 	return value;
 }
 
@@ -94,28 +113,44 @@ function normalizedProfile(profile: RaiderCapitalProfile): RaiderCapitalProfile 
  * therefore cannot also be a defender-recovery source without introducing an
  * additional embodied-energy source.
  *
- * `embodied-return` moves launch commitment into the raider. Surviving capital
- * returns in proportion to final viability; capital that does not return is
- * the only launch capital available for defender capture or dissipation.
+ * `embodied-return` moves launch commitment into the raider. Viability at breach
+ * limits extraction capability and capital still physically present at that
+ * moment. A separate return viability then allows post-breach interception,
+ * ejection, collision or failed evacuation to destroy/expose additional capital.
  */
 export function settleRaiderCapitalEconomy(
 	input: RaiderCapitalSettlementInput
 ): RaiderCapitalSettlement {
 	const profile = normalizedProfile(input.profile);
-	const viability = clamp01(input.remainingViability);
+	const breachViability = input.breached ? clamp01(input.breachViability) : 0;
+	const requestedReturnViability = clamp01(input.returnViability);
+	const returnViability = input.breached
+		? Math.min(requestedReturnViability, breachViability)
+		: requestedReturnViability;
 	const captureFraction = clamp01(input.defenderCaptureFraction);
 	const requestedExtractionEnergy = input.breached
-		? profile.extractionPotential * viability
+		? profile.extractionPotential * breachViability
 		: 0;
 
+	const capitalPresentAtBreach =
+		input.mode === "embodied-return" && input.breached
+			? profile.committedEnergy * breachViability
+			: 0;
 	const returnedCapital =
 		input.mode === "embodied-return"
-			? profile.committedEnergy * viability
+			? profile.committedEnergy * returnViability
 			: 0;
-	const capitalAtRiskLost =
-		input.mode === "embodied-return"
-			? profile.committedEnergy - returnedCapital
+	const preBreachCapitalLoss =
+		input.mode !== "embodied-return"
+			? 0
+			: input.breached
+				? Math.max(0, profile.committedEnergy - capitalPresentAtBreach)
+				: Math.max(0, profile.committedEnergy - returnedCapital);
+	const postBreachCapitalLoss =
+		input.mode === "embodied-return" && input.breached
+			? Math.max(0, capitalPresentAtBreach - returnedCapital)
 			: 0;
+	const capitalAtRiskLost = preBreachCapitalLoss + postBreachCapitalLoss;
 	const requestedRecoveryEnergy = capitalAtRiskLost * captureFraction;
 	const sunkAtLaunch =
 		input.mode === "fully-sunk" ? profile.committedEnergy : 0;
@@ -155,7 +190,11 @@ export function settleRaiderCapitalEconomy(
 		mode: input.mode,
 		tier: profile.tier,
 		committedEnergy: profile.committedEnergy,
-		remainingViability: viability,
+		breachViability,
+		returnViability,
+		capitalPresentAtBreach,
+		preBreachCapitalLoss,
+		postBreachCapitalLoss,
 		requestedExtractionEnergy,
 		extractedEnergy: exchange.extractedEnergy,
 		returnedCapital,
@@ -172,10 +211,9 @@ export function settleRaiderCapitalEconomy(
 }
 
 /**
- * Pre-commit expected value with the same target-richness cap used by #119,
- * extended to account for capital that can physically return from a surviving
- * raider. Failure viability represents a retreat/failed-breach survival
- * hypothesis and remains caller-owned.
+ * Pre-commit expected value with target-richness-bounded extraction and an
+ * explicit post-breach return phase. Successful extraction therefore does not
+ * imply that the same fraction of capital safely reaches the mothership.
  */
 export function estimateRaiderCapitalExpectedValue(
 	input: RaiderCapitalExpectedValueInput
@@ -184,6 +222,10 @@ export function estimateRaiderCapitalExpectedValue(
 	const perceivedTargetEnergy = positive(input.perceivedTargetEnergy);
 	const breachProbability = clamp01(input.expectedBreachProbability);
 	const breachViability = clamp01(input.expectedArrivalViabilityOnBreach);
+	const successReturnViability = Math.min(
+		clamp01(input.expectedReturnViabilityAfterBreach),
+		breachViability
+	);
 	const failureViability = clamp01(input.expectedReturnViabilityOnFailure);
 	const travelAndOperatingCost = positive(input.travelAndOperatingCost);
 	const extractionOnBreach = Math.min(
@@ -195,11 +237,17 @@ export function estimateRaiderCapitalExpectedValue(
 	const expectedReturnedCapital =
 		input.mode === "embodied-return"
 			? profile.committedEnergy *
-				(breachProbability * breachViability +
+				(breachProbability * successReturnViability +
 					(1 - breachProbability) * failureViability)
 			: 0;
 	const expectedCapitalLoss =
 		profile.committedEnergy - expectedReturnedCapital;
+	const expectedPostBreachCapitalLoss =
+		input.mode === "embodied-return"
+			? profile.committedEnergy *
+				breachProbability *
+				Math.max(0, breachViability - successReturnViability)
+			: 0;
 	const expectedNetReturn =
 		expectedExtractedEnergy - expectedCapitalLoss - travelAndOperatingCost;
 	const expectedReturnOnCommitment =
@@ -215,6 +263,7 @@ export function estimateRaiderCapitalExpectedValue(
 		expectedExtractedEnergy,
 		expectedReturnedCapital,
 		expectedCapitalLoss,
+		expectedPostBreachCapitalLoss,
 		expectedNetReturn,
 		expectedReturnOnCommitment
 	};


### PR DESCRIPTION
Refs #124, #128, #107
Parent: #125
Related: #114, #119, #72, #76, #86

## Purpose

Separate extraction-time physical viability from later evacuation/return survival in the embodied-capital experiment.

#125 currently uses one viability scalar both to determine how much extraction capability reaches the silo and how much launch capital ultimately returns to the mothership. That makes an important physical/economic outcome impossible to represent:

`successful extraction → interception/ejection/collision during evacuation → additional attacker capital loss`.

This child keeps #125 as provenance and changes only its capital contract + Storybook witness.

## Realized settlement

`RaiderCapitalSettlementInput` now separates:

- `breachViability` — body viability/capability when extraction occurs;
- `returnViability` — capital fraction that actually survives the later retreat/evacuation.

For a successful breach, return viability is bounded by breach viability. The settlement exposes:

- `capitalPresentAtBreach`;
- `preBreachCapitalLoss`;
- `postBreachCapitalLoss`;
- returned/captured/loose capital as before.

This makes defender action after silo contact economically meaningful without inventing a hidden penalty.

For a failed breach, no extraction occurs and return viability directly represents partial retreat survival; post-breach loss remains zero because there was no breach phase.

## Expected value

The pre-commit estimate now separately accepts:

- `expectedArrivalViabilityOnBreach` — limits extraction capability;
- `expectedReturnViabilityAfterBreach` — controls successful-raid capital return;
- `expectedReturnViabilityOnFailure` — controls failed-raid retreat capital return.

Expected post-breach capital loss is reported explicitly. A raid may therefore be expected to extract successfully while still losing capital on the way home.

## Robustness

The local finite-value sanitizer now also requires runtime numeric type, so rehydrated/runtime non-number inputs cannot propagate `NaN` through this experiment.

## Storybook witnesses

The existing poor→medium→rich fixed EV witness is preserved by keeping successful breach and return viability equal in that canonical case.

Additional deterministic settlements prove:

1. successful extraction + clean return;
2. the same successful extraction followed by severe evacuation interception — identical extraction, lower returned capital, positive post-breach loss, worse attacker net;
3. failed breach + partial retreat survival — zero extraction but non-zero returned capital.

Conservation residual remains near zero in all tracked exchanges.

## Scope

Relative to #125 head `e58226eed64ddcb44fd4673c4331ffb2424aee54`:

- exactly two modified files;
- no production AI/wave/physics integration;
- no package/dependency changes;
- no final viability or launch-cost constants;
- no frozen #95/#97/#105 changes.

## Integration gate

If this interpretation survives later root/Storybook validation, #128 should consume this child rather than #125's single-viability capital semantics. Physical distributions for breach and evacuation survival still need calibration from #72/#86.

Keep draft; do not begin the #128 planner merely because this seam exists. #114 chronology and #127 evidence-validity gates remain unresolved.