### PR TITLE
Pin Rust 1.98.1 after compiler miscompilation fix

### DIFF
--- a/crates/defend-core/Cargo.toml
+++ b/crates/defend-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "defend-core"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.98.1"
 publish = false
 
 [lib]

--- a/experiments/hybrid-engine/rust/Cargo.toml
+++ b/experiments/hybrid-engine/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "defend-hybrid-runtime"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.98"
+rust-version = "1.98.1"
 publish = false
 
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.98.1"
+profile = "minimal"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Refs #145
Parent direction: #66
Related: #67, #143, #144

## Why this is urgent

Rust 1.98.1 was released on 2026-09-03 to fix a 1.98.0 compiler miscompilation in trait-object vtable generation. The Rust release team states that 1.98.0 could emit a null pointer where a function pointer should be, leading to undefined behavior.

Upstream: https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/

Defend's modern hybrid lab was established against Rust 1.98.0. This PR prevents local/runtime certification from accidentally using the affected compiler while keeping the change independent from broader Cargo workspace/dependency work.

## Scope

- add root `rust-toolchain.toml` pinned to `1.98.1`;
- use rustup `minimal` profile;
- ensure `clippy` and `rustfmt` components are available;
- ensure the `wasm32-unknown-unknown` target used by the hybrid WASM path is available;
- set `defend-core`'s private project MSRV to `1.98.1`;
- raise the hybrid runtime's existing `rust-version` from `1.98` to `1.98.1`.

## Deliberately unchanged

- no Rust source code;
- no workspace membership changes;
- no `Cargo.lock` synthesis;
- no Bevy, wasm-bindgen, Rapier, or other crate version changes;
- no release-profile changes;
- no JS package/workspace files (that work is isolated in #144).

The hybrid README currently mentions 1.98.0. I am intentionally not touching that file here because #144 already owns it; whichever lane lands second should reconcile the documentation without creating a cross-PR conflict.

## Local certification required

Keep draft until local evidence is attached to this exact head:

1. `rustup show active-toolchain` resolves 1.98.1 from the repository toolchain file;
2. `rustc -Vv` and `cargo -V` confirm the expected compiler/toolchain;
3. `rustup component list --installed` includes rustfmt and clippy;
4. `rustup target list --installed` includes `wasm32-unknown-unknown`;
5. root `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` succeed or blockers are documented;
6. hybrid-runtime fmt/clippy/test succeed;
7. the existing wasm-pack build succeeds;
8. compare the resulting hybrid WASM/browser fixture against the current baseline and confirm no regression attributable to the compiler point release;
9. record exact commands, exit codes, head SHA, and final working-tree status.

## Follow-up

#145 separately tracks Cargo workspace membership, release-profile ownership, dependency unification, and a real committed `Cargo.lock`. Do not broaden this safety patch into that migration.