### PR TITLE
Fail closed on unusable attacker belief evidence

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/RaidBeliefEvidenceValidity.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/RaidBeliefEvidenceValidity.stories.ts
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	ageRaidBelief,
+	createRaidBelief,
+	DEFAULT_RAID_BELIEF_CALIBRATION,
+	DEFAULT_RAID_BELIEF_PRIOR,
+	observeRaidOpportunitySignature,
+	observeRaidOutcome,
+	observeRaidSignature,
+	type RaidBeliefState
+} from "@defend/gameplay/raidBelief";
+import { createLabShell } from "../../labTheme";
+
+function sameApproach(left: RaidBeliefState, right: RaidBeliefState): boolean {
+	return (
+		left.approach.expectedBreachProbability === right.approach.expectedBreachProbability &&
+		left.approach.expectedArrivalViability === right.approach.expectedArrivalViability &&
+		left.approach.uncertainty === right.approach.uncertainty &&
+		left.approach.directObservations === right.approach.directObservations &&
+		left.approach.secondsSinceDirectObservation ===
+			right.approach.secondsSinceDirectObservation
+	);
+}
+
+const meta = {
+	title: "Foundations/Strategy/Raid Belief Evidence Validity",
+	tags: ["test", "visual"],
+	render: () => {
+		const calibration = DEFAULT_RAID_BELIEF_CALIBRATION;
+		const initial = createRaidBelief(DEFAULT_RAID_BELIEF_PRIOR, calibration);
+		const stale = ageRaidBelief(initial, 60, calibration);
+		const zeroReliability = observeRaidOutcome(
+			stale,
+			{ breached: false, remainingViability: 0, reliability: 0 },
+			calibration
+		);
+		const malformedViability = observeRaidOutcome(
+			stale,
+			{ breached: false, remainingViability: NaN, reliability: 1 },
+			calibration
+		);
+		const missingSignature = observeRaidSignature(
+			stale,
+			undefined as unknown as number,
+			30,
+			calibration
+		);
+		const validOutcome = observeRaidOutcome(
+			stale,
+			{ breached: false, remainingViability: 0.2, reliability: 1 },
+			calibration
+		);
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Evidence validity is not evidence failure",
+			"Missing, malformed or zero-reliability observations do not teach the attacker that a target is empty or an approach failed. Valid elapsed time may still make old knowledge stale; valid direct evidence alone refreshes the approach history."
+		);
+		shell.frame.innerHTML = `
+			<style>
+				.validity-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:10px; }
+				.validity-card { padding:12px; border:1px solid rgba(228,185,128,.18); background:rgba(10,3,17,.4); }
+				.validity-card small { display:block; opacity:.48; }
+				.validity-card strong { display:block; margin:4px 0 9px; }
+				.validity-card dl { display:grid; grid-template-columns:1fr auto; gap:5px 9px; margin:0; font-size:9px; }
+				.validity-card dd { margin:0; }
+			</style>
+			<div class="validity-grid">
+				${[
+					["stale", "Baseline stale belief", stale],
+					["zero", "Zero-reliability direct sample", zeroReliability],
+					["malformed", "Malformed direct sample", malformedViability],
+					["missing-signature", "Missing passive signature + time", missingSignature],
+					["valid", "Valid direct evidence", validOutcome]
+				]
+					.map(entry => {
+						const id = entry[0] as string;
+						const label = entry[1] as string;
+						const state = entry[2] as RaidBeliefState;
+						return `<article class="validity-card" data-case="${id}"><small>belief evidence</small><strong>${label}</strong><dl><dt>target</dt><dd>${state.opportunity.perceivedTargetEnergy.toFixed(0)}</dd><dt>breach</dt><dd>${state.approach.expectedBreachProbability.toFixed(3)}</dd><dt>viability</dt><dd>${state.approach.expectedArrivalViability.toFixed(3)}</dd><dt>uncertainty</dt><dd>${state.approach.uncertainty.toFixed(3)}</dd><dt>observations</dt><dd>${state.approach.directObservations}</dd><dt>age</dt><dd>${state.approach.secondsSinceDirectObservation.toFixed(1)} s</dd></dl></article>`;
+					})
+					.join("")}
+			</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FailClosedEvidence: Story = {
+	play: async ({ canvasElement }) => {
+		const calibration = DEFAULT_RAID_BELIEF_CALIBRATION;
+		const initial = createRaidBelief(DEFAULT_RAID_BELIEF_PRIOR, calibration);
+		const stale = ageRaidBelief(initial, 60, calibration);
+
+		const invalidSignatures = [
+			NaN,
+			-1,
+			Infinity,
+			-Infinity,
+			undefined as unknown as number
+		];
+		for (let index = 0; index < invalidSignatures.length; index += 1) {
+			const next = observeRaidOpportunitySignature(
+				stale.opportunity,
+				invalidSignatures[index],
+				20,
+				calibration
+			);
+			await expect(next.perceivedTargetEnergy).toBe(
+				stale.opportunity.perceivedTargetEnergy
+			);
+		}
+
+		const zeroReliability = observeRaidOutcome(
+			stale,
+			{ breached: false, remainingViability: 0, reliability: 0 },
+			calibration
+		);
+		await expect(sameApproach(zeroReliability, stale)).toBe(true);
+
+		const malformedViability = observeRaidOutcome(
+			stale,
+			{ breached: false, remainingViability: NaN, reliability: 1 },
+			calibration
+		);
+		await expect(sameApproach(malformedViability, stale)).toBe(true);
+
+		const malformedBreach = observeRaidOutcome(
+			stale,
+			{
+				breached: undefined as unknown as boolean,
+				remainingViability: 0.3,
+				reliability: 1
+			},
+			calibration
+		);
+		await expect(sameApproach(malformedBreach, stale)).toBe(true);
+
+		const missingSignatureWithTime = observeRaidSignature(
+			stale,
+			undefined as unknown as number,
+			30,
+			calibration
+		);
+		await expect(missingSignatureWithTime.opportunity.perceivedTargetEnergy).toBe(
+			stale.opportunity.perceivedTargetEnergy
+		);
+		await expect(
+			missingSignatureWithTime.approach.expectedBreachProbability
+		).toBe(stale.approach.expectedBreachProbability);
+		await expect(missingSignatureWithTime.approach.uncertainty).toBeGreaterThan(
+			stale.approach.uncertainty
+		);
+		await expect(
+			missingSignatureWithTime.approach.secondsSinceDirectObservation
+		).toBe(90);
+
+		const validDirect = observeRaidOutcome(
+			stale,
+			{ breached: false, remainingViability: 0.2, reliability: 1 },
+			calibration
+		);
+		await expect(validDirect.approach.directObservations).toBe(
+			stale.approach.directObservations + 1
+		);
+		await expect(validDirect.approach.secondsSinceDirectObservation).toBe(0);
+		await expect(validDirect.approach.uncertainty).toBeLessThan(
+			stale.approach.uncertainty
+		);
+
+		const validSignature = observeRaidOpportunitySignature(
+			stale.opportunity,
+			29000,
+			20,
+			calibration
+		);
+		await expect(validSignature.perceivedTargetEnergy).toBeGreaterThan(
+			stale.opportunity.perceivedTargetEnergy
+		);
+
+		await expect(canvasElement.querySelectorAll("[data-case]").length).toBe(5);
+	}
+};

--- a/src/js/gameplay/raidBelief.ts
+++ b/src/js/gameplay/raidBelief.ts
@@ -48,9 +48,17 @@ export interface RaidBeliefExpectedValueInputs {
 	expectedArrivalViability: number;
 }
 
+function isFiniteNumber(value: number): boolean {
+	return (
+		typeof value === "number" &&
+		value === value &&
+		value !== Infinity &&
+		value !== -Infinity
+	);
+}
+
 function finite(value: number, fallback = 0): number {
-	if (value !== value || value === Infinity || value === -Infinity) return fallback;
-	return value;
+	return isFiniteNumber(value) ? value : fallback;
 }
 
 function positive(value: number): number {
@@ -80,11 +88,41 @@ function normalizeCalibration(
 	};
 }
 
+function normalizeApproach(approach: RaidApproachBelief): RaidApproachBelief {
+	return {
+		expectedBreachProbability: clamp01(approach.expectedBreachProbability),
+		expectedArrivalViability: clamp01(approach.expectedArrivalViability),
+		uncertainty: clamp01(approach.uncertainty),
+		directObservations: Math.max(
+			0,
+			Math.floor(positive(approach.directObservations))
+		),
+		secondsSinceDirectObservation: positive(
+			approach.secondsSinceDirectObservation
+		)
+	};
+}
+
 function timeAlpha(deltaSeconds: number, halfLifeSeconds: number): number {
 	const delta = positive(deltaSeconds);
 	if (delta <= 0) return 0;
 	if (halfLifeSeconds <= 0) return 1;
 	return 1 - Math.pow(0.5, delta / halfLifeSeconds);
+}
+
+function validSignatureObservation(observedTargetEnergy: number): boolean {
+	return isFiniteNumber(observedTargetEnergy) && observedTargetEnergy >= 0;
+}
+
+function validOutcomeObservation(observation: RaidOutcomeObservation): boolean {
+	return (
+		typeof observation.breached === "boolean" &&
+		isFiniteNumber(observation.reliability) &&
+		observation.reliability > 0 &&
+		isFiniteNumber(observation.remainingViability) &&
+		observation.remainingViability >= 0 &&
+		observation.remainingViability <= 1
+	);
 }
 
 export function createRaidOpportunityBelief(
@@ -137,24 +175,22 @@ export function ageRaidApproachBelief(
 	calibrationInput: RaidBeliefCalibration
 ): RaidApproachBelief {
 	const calibration = normalizeCalibration(calibrationInput);
+	const normalized = normalizeApproach(approach);
 	const delta = positive(deltaSeconds);
 	const staleAlpha = timeAlpha(
 		delta,
 		calibration.uncertaintyStaleHalfLifeSeconds
 	);
-	const uncertainty = clamp01(approach.uncertainty);
 	return {
-		expectedBreachProbability: clamp01(approach.expectedBreachProbability),
-		expectedArrivalViability: clamp01(approach.expectedArrivalViability),
+		expectedBreachProbability: normalized.expectedBreachProbability,
+		expectedArrivalViability: normalized.expectedArrivalViability,
 		uncertainty: clamp01(
-			uncertainty + (1 - uncertainty) * staleAlpha
+			normalized.uncertainty +
+				(1 - normalized.uncertainty) * staleAlpha
 		),
-		directObservations: Math.max(
-			0,
-			Math.floor(positive(approach.directObservations))
-		),
+		directObservations: normalized.directObservations,
 		secondsSinceDirectObservation:
-			positive(approach.secondsSinceDirectObservation) + delta
+			normalized.secondsSinceDirectObservation + delta
 	};
 }
 
@@ -177,8 +213,9 @@ export function ageRaidBelief(
 }
 
 /**
- * Update target-global opportunity from a lossy teal signature. This function
- * knows nothing about a route, raider tier or defense quality.
+ * Update target-global opportunity from a lossy teal signature. Invalid/missing
+ * samples are not evidence that the target is empty: they leave the opportunity
+ * mean unchanged. Values above capacity may still saturate at capacity.
  */
 export function observeRaidOpportunitySignature(
 	opportunity: RaidOpportunityBelief,
@@ -192,10 +229,12 @@ export function observeRaidOpportunitySignature(
 		0,
 		calibration.targetEnergyCapacity
 	);
-	const target = clamp(
-		observedTargetEnergy,
-		0,
-		calibration.targetEnergyCapacity
+	if (!validSignatureObservation(observedTargetEnergy)) {
+		return { perceivedTargetEnergy: current };
+	}
+	const target = Math.min(
+		calibration.targetEnergyCapacity,
+		observedTargetEnergy
 	);
 	const alpha = timeAlpha(deltaSeconds, calibration.signatureHalfLifeSeconds);
 	return {
@@ -203,8 +242,8 @@ export function observeRaidOpportunitySignature(
 	};
 }
 
-/** Convenience composite: time passes for this approach while the target-wide
- * passive signature updates opportunity only. */
+/** Convenience composite: time passes for this approach even when a passive
+ * signature sample is unusable; invalid sensor data does not become knowledge. */
 export function observeRaidSignature(
 	state: RaidBeliefState,
 	observedTargetEnergy: number,
@@ -227,9 +266,9 @@ export function observeRaidSignature(
 }
 
 /**
- * Direct raid evidence updates one contextual approach belief only. A failed R1
- * path therefore need not change the belief for a different R3 insertion unless
- * the caller intentionally shares that context.
+ * Direct raid evidence updates one contextual approach belief only. Invalid
+ * physical evidence or reliability <= 0 is an epistemic no-op: it does not
+ * update means, reduce uncertainty, increment evidence count, or reset age.
  */
 export function observeRaidApproachOutcome(
 	approach: RaidApproachBelief,
@@ -237,28 +276,31 @@ export function observeRaidApproachOutcome(
 	calibrationInput: RaidBeliefCalibration
 ): RaidApproachBelief {
 	const calibration = normalizeCalibration(calibrationInput);
+	const normalized = normalizeApproach(approach);
+	if (!validOutcomeObservation(observation)) {
+		return normalized;
+	}
+
 	const reliability = clamp01(observation.reliability);
 	const breachAlpha = calibration.breachObservationWeight * reliability;
 	const viabilityAlpha = calibration.viabilityObservationWeight * reliability;
 	const breachEvidence = observation.breached ? 1 : 0;
-	const viabilityEvidence = clamp01(observation.remainingViability);
-	const currentBreach = clamp01(approach.expectedBreachProbability);
-	const currentViability = clamp01(approach.expectedArrivalViability);
-	const uncertainty = clamp01(approach.uncertainty);
+	const viabilityEvidence = observation.remainingViability;
 	const uncertaintyRetention =
 		1 - calibration.directUncertaintyReduction * reliability;
 
 	return {
 		expectedBreachProbability: clamp01(
-			currentBreach + (breachEvidence - currentBreach) * breachAlpha
+			normalized.expectedBreachProbability +
+				(breachEvidence - normalized.expectedBreachProbability) * breachAlpha
 		),
 		expectedArrivalViability: clamp01(
-			currentViability +
-				(viabilityEvidence - currentViability) * viabilityAlpha
+			normalized.expectedArrivalViability +
+				(viabilityEvidence - normalized.expectedArrivalViability) *
+					viabilityAlpha
 		),
-		uncertainty: clamp01(uncertainty * uncertaintyRetention),
-		directObservations:
-			Math.max(0, Math.floor(positive(approach.directObservations))) + 1,
+		uncertainty: clamp01(normalized.uncertainty * uncertaintyRetention),
+		directObservations: normalized.directObservations + 1,
 		secondsSinceDirectObservation: 0
 	};
 }


### PR DESCRIPTION
Refs #126, #128, #107
Parent: #127
Related: #76, #119, #125, #146

## Purpose

Make the attacker-belief seam distinguish **absence/invalidity of evidence** from evidence of physical failure.

#127's target/approach ownership split is retained. This child corrects only the external observation boundary.

Current #127 behavior can turn malformed data into knowledge:

- a non-finite passive target signature is clamped toward `0`, teaching that the target is empty;
- a direct observation with `reliability = 0` still increments observation count and resets evidence age;
- malformed viability can be clamped to `0`, teaching catastrophic physical survival.

Those outcomes make missing/bad telemetry behaviorally meaningful.

## Passive evidence

`observeRaidOpportunitySignature()` now requires a finite runtime-number, non-negative target-energy sample.

Invalid/missing samples leave the target-wide opportunity mean unchanged. Values above capacity may still saturate to capacity as a valid high signal.

The composite `observeRaidSignature()` still ages the contextual approach belief when valid positive time passes, even if the passive signature sample itself is unusable. Thus:

- missing sensor data is not evidence that the target is empty;
- time still makes old route knowledge stale.

## Direct evidence

`observeRaidApproachOutcome()` accepts evidence only when:

- `breached` is a runtime boolean;
- reliability is finite and `> 0`;
- remaining viability is finite and within `[0, 1]`.

Invalid or zero-information evidence is an epistemic no-op after ordinary state normalization. It does not:

- change breach/viability means;
- reduce uncertainty;
- increment direct-observation count;
- reset evidence age.

A valid direct outcome retains #127's weighted-learning behavior.

## Runtime hardening

The numeric finite guard now requires `typeof value === "number"`, consistent with the hardened evidence boundaries in #134/#141.

## Storybook witness

Adds `Foundations/Strategy/Raid Belief Evidence Validity` without rewriting #127's original learning/staleness story.

The deterministic fixture proves:

- NaN/negative/±Infinity/runtime-undefined passive samples do not move target opportunity;
- reliability `0` direct evidence is a no-op;
- malformed viability and malformed breach flag are no-ops;
- an unusable passive sample with 30 s elapsed time leaves the target estimate unchanged while uncertainty/age still grow;
- valid direct evidence increments count, refreshes age and reduces uncertainty;
- a valid bright target signature still raises perceived opportunity.

## Scope

Relative to #127 head `f420580def7077f9b421b7d46e1e5a7aff46daab`:

- one modified root belief module;
- one added Storybook validity fixture;
- no planner/tier selection;
- no production AI or world-state reads;
- no dependency changes;
- no frozen #95/#97/#105 changes.

## Integration gate

If accepted, #128 should consume this child (or equivalent fail-closed evidence semantics) instead of raw #127. The thin planner remains blocked on #114 chronology and the capital-at-risk revision #146 as well.

Keep draft until a later root + Storybook campaign validates this exact head.