### PR TITLE
Make conserved raid exchange chronology explicit

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/ConservedRaidChronology.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/ConservedRaidChronology.stories.ts
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	collectRaidRecovery,
+	settleConservedRaidExchangeWithOrder,
+	settleRaidBreach,
+	type ConservedRaidExchangeResult
+} from "@defend/gameplay/conservedRaidExchange";
+import { createLabShell } from "../../labTheme";
+
+const INPUT = {
+	defenderReserve: 5000,
+	defenderCapacity: 30000,
+	requestedExtractionEnergy: 18000,
+	attackerEmbodiedEnergy: 4500,
+	requestedRecoveryEnergy: 4500,
+	collateralDissipationRatio: 0
+};
+
+function identityResidual(result: ConservedRaidExchangeResult): number {
+	return (
+		result.reserveBefore +
+		result.recoveredEnergy -
+		result.defenderEnergyLost -
+		result.reserveAfter
+	);
+}
+
+function card(label: string, result: ConservedRaidExchangeResult): string {
+	return `
+		<article class="chronology-card" data-order="${result.chronology}" data-extracted="${result.extractedEnergy}" data-final="${result.reserveAfter}">
+			<small>event chronology</small>
+			<h3>${label}</h3>
+			<dl>
+				<dt>start reserve</dt><dd>${result.reserveBefore.toFixed(0)}</dd>
+				<dt>recovery collected</dt><dd>${result.recoveredEnergy.toFixed(0)}</dd>
+				<dt>reserve at breach</dt><dd>${result.reserveAtBreach.toFixed(0)}</dd>
+				<dt>actual extraction</dt><dd>${result.extractedEnergy.toFixed(0)}</dd>
+				<dt>final reserve</dt><dd>${result.reserveAfter.toFixed(0)}</dd>
+			</dl>
+		</article>
+	`;
+}
+
+const meta = {
+	title: "Foundations/Strategy/Conserved Raid Chronology",
+	tags: ["test", "visual"],
+	render: () => {
+		const recoveryFirst = settleConservedRaidExchangeWithOrder(
+			INPUT,
+			"recovery-then-breach"
+		);
+		const breachFirst = settleConservedRaidExchangeWithOrder(
+			INPUT,
+			"breach-then-recovery"
+		);
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Conservation does not imply commutativity",
+			"The same starting reserve, recoverable attacker energy and breach demand can produce different target richness at contact depending on whether physically liberated recovery reaches the silo before or after extraction. Both histories conserve energy."
+		);
+		shell.frame.innerHTML = `
+			<style>
+				.chronology-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px; }
+				.chronology-card { padding:14px; border:1px solid rgba(228,185,128,.2); background:rgba(10,3,17,.42); }
+				.chronology-card small { opacity:.45; text-transform:uppercase; font-size:9px; letter-spacing:.07em; }
+				.chronology-card h3 { margin:4px 0 12px; font-size:14px; }
+				.chronology-card dl { display:grid; grid-template-columns:1fr auto; gap:6px 12px; margin:0; font-size:10px; }
+				.chronology-card dd { margin:0; font-variant-numeric:tabular-nums; }
+				.chronology-note { margin-top:12px; font-size:10px; line-height:1.5; opacity:.58; }
+				@media (max-width:720px) { .chronology-grid { grid-template-columns:1fr; } }
+			</style>
+			<div class="chronology-grid">
+				${card("Recovery arrives before breach", recoveryFirst)}
+				${card("Breach arrives before recovery", breachFirst)}
+			</div>
+			<div class="chronology-note">This is an ordering witness, not a production timing rule. #97/#86 should eventually provide physical packet/breach timing distributions.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OrderingChangesExtraction: Story = {
+	play: async ({ canvasElement }) => {
+		const recoveryFirst = settleConservedRaidExchangeWithOrder(
+			INPUT,
+			"recovery-then-breach"
+		);
+		const breachFirst = settleConservedRaidExchangeWithOrder(
+			INPUT,
+			"breach-then-recovery"
+		);
+
+		await expect(recoveryFirst.reserveBefore).toBe(5000);
+		await expect(recoveryFirst.recoveredEnergy).toBe(4500);
+		await expect(recoveryFirst.reserveAtBreach).toBe(9500);
+		await expect(recoveryFirst.extractedEnergy).toBe(9500);
+		await expect(recoveryFirst.reserveAfter).toBe(0);
+
+		await expect(breachFirst.reserveBefore).toBe(5000);
+		await expect(breachFirst.reserveAtBreach).toBe(5000);
+		await expect(breachFirst.extractedEnergy).toBe(5000);
+		await expect(breachFirst.recoveredEnergy).toBe(4500);
+		await expect(breachFirst.reserveAfter).toBe(4500);
+
+		await expect(recoveryFirst.extractedEnergy).toBeGreaterThan(
+			breachFirst.extractedEnergy
+		);
+		await expect(Math.abs(identityResidual(recoveryFirst))).toBeLessThan(0.000001);
+		await expect(Math.abs(identityResidual(breachFirst))).toBeLessThan(0.000001);
+
+		const limitedSource = collectRaidRecovery({
+			defenderReserve: 0,
+			defenderCapacity: 30000,
+			captureEligibleAttackerEnergy: 1000,
+			requestedRecoveryEnergy: 5000
+		});
+		await expect(limitedSource.sourceAvailableRecoveryEnergy).toBe(1000);
+		await expect(limitedSource.recoverySourceShortfall).toBe(4000);
+		await expect(limitedSource.recoveredEnergy).toBe(1000);
+
+		const breachOnly = settleRaidBreach({
+			defenderReserve: 5000,
+			defenderCapacity: 30000,
+			requestedExtractionEnergy: 18000,
+			collateralDissipationRatio: 0
+		});
+		await expect(breachOnly.extractedEnergy).toBe(5000);
+		await expect(breachOnly.reserveAfter).toBe(0);
+
+		await expect(canvasElement.querySelectorAll("[data-order]").length).toBe(2);
+	}
+};

--- a/src/js/gameplay/conservedRaidExchange.ts
+++ b/src/js/gameplay/conservedRaidExchange.ts
@@ -1,11 +1,19 @@
+export type RaidExchangeChronology =
+	| "breach-then-recovery"
+	| "recovery-then-breach";
+
 export interface ConservedRaidExchangeInput {
-	/** Defender energy physically stored before this exchange. */
+	/** Defender energy physically stored before this opportunity summary. */
 	defenderReserve: number;
 	/** Maximum defender storage capacity. */
 	defenderCapacity: number;
 	/** Energy the breaching raider would extract if the target were rich enough. */
 	requestedExtractionEnergy: number;
-	/** Raider energy physically embodied/committed and available to be captured. */
+	/**
+	 * Legacy aggregate name: energy eligible to source defender recovery.
+	 * New integrations should use `captureEligibleAttackerEnergy` on the
+	 * composable recovery primitive so surviving/escaped capital is explicit.
+	 */
 	attackerEmbodiedEnergy: number;
 	/** Defender collection demand derived from physical combat outcomes. */
 	requestedRecoveryEnergy: number;
@@ -14,7 +22,10 @@ export interface ConservedRaidExchangeInput {
 }
 
 export interface ConservedRaidExchangeResult {
+	chronology: RaidExchangeChronology;
 	reserveBefore: number;
+	/** Reserve physically present immediately before extraction. */
+	reserveAtBreach: number;
 	reserveAfterExtraction: number;
 	reserveAfterLoss: number;
 	reserveAfter: number;
@@ -32,11 +43,55 @@ export interface ConservedRaidExchangeResult {
 	defenderEnergyLost: number;
 }
 
+export interface RaidBreachSettlementInput {
+	defenderReserve: number;
+	defenderCapacity: number;
+	requestedExtractionEnergy: number;
+	collateralDissipationRatio: number;
+}
+
+export interface RaidBreachSettlementResult {
+	reserveBefore: number;
+	reserveAfterExtraction: number;
+	reserveAfter: number;
+	requestedExtractionEnergy: number;
+	extractedEnergy: number;
+	unmetExtractionEnergy: number;
+	requestedCollateralDissipation: number;
+	collateralDissipation: number;
+	unmetCollateralDissipation: number;
+	defenderEnergyLost: number;
+}
+
+export interface RaidRecoveryCollectionInput {
+	defenderReserve: number;
+	defenderCapacity: number;
+	/** Attacker energy physically lost/exposed and eligible for capture. */
+	captureEligibleAttackerEnergy: number;
+	requestedRecoveryEnergy: number;
+}
+
+export interface RaidRecoveryCollectionResult {
+	reserveBefore: number;
+	reserveAfter: number;
+	requestedRecoveryEnergy: number;
+	sourceAvailableRecoveryEnergy: number;
+	recoverySourceShortfall: number;
+	recoveredEnergy: number;
+	uncollectedRecoveryEnergy: number;
+}
+
+function isFiniteNumber(value: number): boolean {
+	return (
+		typeof value === "number" &&
+		value === value &&
+		value !== Infinity &&
+		value !== -Infinity
+	);
+}
+
 function finite(value: number, fallback = 0): number {
-	if (value !== value || value === Infinity || value === -Infinity) {
-		return fallback;
-	}
-	return value;
+	return isFiniteNumber(value) ? value : fallback;
 }
 
 function positive(value: number): number {
@@ -47,28 +102,29 @@ function clamp(value: number, minimum: number, maximum: number): number {
 	return Math.max(minimum, Math.min(maximum, finite(value, minimum)));
 }
 
-/**
- * Settle one abstract raid exchange without allowing either side to manufacture
- * energy through cap clipping.
- *
- * Event order is intentionally explicit:
- *
- * 1. a breaching body extracts from energy already stored in the defender silo;
- * 2. optional collateral loss may dissipate additional defender energy, but can
- *    never increase the attacker's extraction;
- * 3. defender recovery from damaged/destroyed attacker bodies is collected into
- *    the remaining storage headroom.
- *
- * Production event timing may later call the individual physical transitions at
- * different moments. This helper exists for headless deterrence/economy models
- * where those events are summarized into one opportunity.
- */
-export function settleConservedRaidExchange(
-	input: ConservedRaidExchangeInput
-): ConservedRaidExchangeResult {
-	const capacity = positive(input.defenderCapacity);
-	const reserveBefore = clamp(input.defenderReserve, 0, capacity);
+function normalizedReserve(
+	defenderReserve: number,
+	defenderCapacity: number
+): { reserve: number; capacity: number } {
+	const capacity = positive(defenderCapacity);
+	return {
+		reserve: clamp(defenderReserve, 0, capacity),
+		capacity
+	};
+}
 
+/**
+ * Settle only the physical breach/extraction portion of an exchange.
+ * Recovery packets are deliberately not part of this primitive.
+ */
+export function settleRaidBreach(
+	input: RaidBreachSettlementInput
+): RaidBreachSettlementResult {
+	const normalized = normalizedReserve(
+		input.defenderReserve,
+		input.defenderCapacity
+	);
+	const reserveBefore = normalized.reserve;
 	const requestedExtractionEnergy = positive(input.requestedExtractionEnergy);
 	const extractedEnergy = Math.min(reserveBefore, requestedExtractionEnergy);
 	const unmetExtractionEnergy = Math.max(
@@ -76,7 +132,6 @@ export function settleConservedRaidExchange(
 		requestedExtractionEnergy - extractedEnergy
 	);
 	const reserveAfterExtraction = reserveBefore - extractedEnergy;
-
 	const requestedCollateralDissipation =
 		extractedEnergy * positive(input.collateralDissipationRatio);
 	const collateralDissipation = Math.min(
@@ -87,31 +142,10 @@ export function settleConservedRaidExchange(
 		0,
 		requestedCollateralDissipation - collateralDissipation
 	);
-	const reserveAfterLoss = reserveAfterExtraction - collateralDissipation;
-
-	const requestedRecoveryEnergy = positive(input.requestedRecoveryEnergy);
-	const sourceAvailableRecoveryEnergy = Math.min(
-		requestedRecoveryEnergy,
-		positive(input.attackerEmbodiedEnergy)
-	);
-	const recoverySourceShortfall = Math.max(
-		0,
-		requestedRecoveryEnergy - sourceAvailableRecoveryEnergy
-	);
-	const recoveredEnergy = Math.min(
-		sourceAvailableRecoveryEnergy,
-		Math.max(0, capacity - reserveAfterLoss)
-	);
-	const uncollectedRecoveryEnergy = Math.max(
-		0,
-		sourceAvailableRecoveryEnergy - recoveredEnergy
-	);
-	const reserveAfter = reserveAfterLoss + recoveredEnergy;
-
+	const reserveAfter = reserveAfterExtraction - collateralDissipation;
 	return {
 		reserveBefore,
 		reserveAfterExtraction,
-		reserveAfterLoss,
 		reserveAfter,
 		requestedExtractionEnergy,
 		extractedEnergy,
@@ -119,13 +153,132 @@ export function settleConservedRaidExchange(
 		requestedCollateralDissipation,
 		collateralDissipation,
 		unmetCollateralDissipation,
+		defenderEnergyLost: extractedEnergy + collateralDissipation
+	};
+}
+
+/**
+ * Collect only defender recovery that has physically arrived. The recovery
+ * source is explicitly capture-eligible attacker energy, not total committed or
+ * surviving capital.
+ */
+export function collectRaidRecovery(
+	input: RaidRecoveryCollectionInput
+): RaidRecoveryCollectionResult {
+	const normalized = normalizedReserve(
+		input.defenderReserve,
+		input.defenderCapacity
+	);
+	const reserveBefore = normalized.reserve;
+	const requestedRecoveryEnergy = positive(input.requestedRecoveryEnergy);
+	const sourceAvailableRecoveryEnergy = Math.min(
+		requestedRecoveryEnergy,
+		positive(input.captureEligibleAttackerEnergy)
+	);
+	const recoverySourceShortfall = Math.max(
+		0,
+		requestedRecoveryEnergy - sourceAvailableRecoveryEnergy
+	);
+	const recoveredEnergy = Math.min(
+		sourceAvailableRecoveryEnergy,
+		Math.max(0, normalized.capacity - reserveBefore)
+	);
+	const uncollectedRecoveryEnergy = Math.max(
+		0,
+		sourceAvailableRecoveryEnergy - recoveredEnergy
+	);
+	return {
+		reserveBefore,
+		reserveAfter: reserveBefore + recoveredEnergy,
 		requestedRecoveryEnergy,
 		sourceAvailableRecoveryEnergy,
 		recoverySourceShortfall,
 		recoveredEnergy,
-		uncollectedRecoveryEnergy,
-		defenderEnergyLost: extractedEnergy + collateralDissipation
+		uncollectedRecoveryEnergy
 	};
+}
+
+/**
+ * Opportunity-level convenience composition with an explicit chronology.
+ * Conservation does not imply that breach and packet collection commute: the
+ * chosen order can change `reserveAtBreach`, actual extraction and final reserve.
+ */
+export function settleConservedRaidExchangeWithOrder(
+	input: ConservedRaidExchangeInput,
+	chronology: RaidExchangeChronology
+): ConservedRaidExchangeResult {
+	const initial = normalizedReserve(
+		input.defenderReserve,
+		input.defenderCapacity
+	);
+	let breach: RaidBreachSettlementResult;
+	let recovery: RaidRecoveryCollectionResult;
+
+	if (chronology === "recovery-then-breach") {
+		recovery = collectRaidRecovery({
+			defenderReserve: initial.reserve,
+			defenderCapacity: initial.capacity,
+			captureEligibleAttackerEnergy: input.attackerEmbodiedEnergy,
+			requestedRecoveryEnergy: input.requestedRecoveryEnergy
+		});
+		breach = settleRaidBreach({
+			defenderReserve: recovery.reserveAfter,
+			defenderCapacity: initial.capacity,
+			requestedExtractionEnergy: input.requestedExtractionEnergy,
+			collateralDissipationRatio: input.collateralDissipationRatio
+		});
+	} else {
+		breach = settleRaidBreach({
+			defenderReserve: initial.reserve,
+			defenderCapacity: initial.capacity,
+			requestedExtractionEnergy: input.requestedExtractionEnergy,
+			collateralDissipationRatio: input.collateralDissipationRatio
+		});
+		recovery = collectRaidRecovery({
+			defenderReserve: breach.reserveAfter,
+			defenderCapacity: initial.capacity,
+			captureEligibleAttackerEnergy: input.attackerEmbodiedEnergy,
+			requestedRecoveryEnergy: input.requestedRecoveryEnergy
+		});
+	}
+
+	return {
+		chronology,
+		reserveBefore: initial.reserve,
+		reserveAtBreach: breach.reserveBefore,
+		reserveAfterExtraction: breach.reserveAfterExtraction,
+		reserveAfterLoss: breach.reserveAfter,
+		reserveAfter:
+			chronology === "recovery-then-breach"
+				? breach.reserveAfter
+				: recovery.reserveAfter,
+		requestedExtractionEnergy: breach.requestedExtractionEnergy,
+		extractedEnergy: breach.extractedEnergy,
+		unmetExtractionEnergy: breach.unmetExtractionEnergy,
+		requestedCollateralDissipation: breach.requestedCollateralDissipation,
+		collateralDissipation: breach.collateralDissipation,
+		unmetCollateralDissipation: breach.unmetCollateralDissipation,
+		requestedRecoveryEnergy: recovery.requestedRecoveryEnergy,
+		sourceAvailableRecoveryEnergy: recovery.sourceAvailableRecoveryEnergy,
+		recoverySourceShortfall: recovery.recoverySourceShortfall,
+		recoveredEnergy: recovery.recoveredEnergy,
+		uncollectedRecoveryEnergy: recovery.uncollectedRecoveryEnergy,
+		defenderEnergyLost: breach.defenderEnergyLost
+	};
+}
+
+/**
+ * Backward-compatible aggregate hypothesis: breach/collateral first, then
+ * recovery collection. New headless integrations should choose chronology
+ * explicitly or call the primitives at their actual event times.
+ */
+export function settleConservedRaidExchange(
+	input: ConservedRaidExchangeInput
+): ConservedRaidExchangeResult {
+	return settleConservedRaidExchangeWithOrder(
+		input,
+		"breach-then-recovery"
+	);
 }
 
 /**


### PR DESCRIPTION
Refs #107, #128, #103
Parent: #114
Related: #97, #86, #125, #146

## Purpose

Separate conservation identities from event chronology in the raid exchange model.

#114 currently hard-codes one opportunity-level order:

`breach extraction → collateral dissipation → defender recovery collection`.

That is a valid hypothesis, but not a conservation law. In live play, #97 recovery packets may physically reach the silo before, after or between breach events, changing reserve available at contact and therefore actual extraction/attacker ROI.

This child keeps #114's existing aggregate API backward-compatible while adding composable primitives and explicit ordering for new integrations.

## Composable transitions

### `settleRaidBreach()`

Owns only:

- reserve physically present at breach;
- target-bounded extraction;
- optional dissipative collateral;
- actual defender energy lost.

It has no defender-recovery semantics.

### `collectRaidRecovery()`

Owns only recovery that has physically arrived at the target.

Its source is explicitly named `captureEligibleAttackerEnergy`, avoiding the ambiguity of treating total committed/surviving attacker energy as simultaneously recoverable.

It reports source shortfall and storage-headroom-limited uncollected recovery.

## Explicit aggregate chronology

Adds `settleConservedRaidExchangeWithOrder()` with:

- `recovery-then-breach`;
- `breach-then-recovery`.

The result now exposes `reserveAtBreach` and the chosen chronology.

The original `settleConservedRaidExchange()` remains available and delegates to `breach-then-recovery`, preserving #114/#125 ancestry while making that ordering an explicit convenience hypothesis rather than canonical physics.

## Runtime hardening

Finite-number handling now requires runtime numeric type, preventing malformed/rehydrated non-number state from propagating NaN through the experiment.

## Storybook chronology witness

Adds `Foundations/Strategy/Conserved Raid Chronology`.

With the same quantities:

- starting reserve: 5,000;
- physically recoverable/collected attacker energy: 4,500;
- requested breach extraction: 18,000;
- no collateral;

it proves:

### Recovery before breach
- reserve at breach = 9,500;
- extraction = 9,500;
- final defender reserve = 0.

### Breach before recovery
- reserve at breach = 5,000;
- extraction = 5,000;
- later recovery = 4,500;
- final defender reserve = 4,500.

Both histories satisfy the same conservation identity; they intentionally do not commute.

The witness also pins capture-source eligibility: a 5,000 recovery request with only 1,000 capture-eligible attacker energy can source at most 1,000.

## Scope

Relative to #114 head `11fa4384bd3a3e5c8d475a9da0311918d8d0f6cd`:

- one modified root settlement module;
- one added Storybook chronology fixture;
- no production wave/AI/packet call sites;
- no package/dependency changes;
- no final event timing distribution;
- no frozen #95/#97/#105 changes.

## Integration gate

If accepted, #128 should use these primitives (or equivalent timestamped event settlement) rather than treating #114's old aggregate order as authoritative chronology. #97/#86 should later calibrate packet-arrival versus breach timing.

The thin planner still remains gated on #146 capital semantics and #148 evidence validity. Keep draft until root + Storybook validation runs against this exact head.