### PR TITLE
Remove destructive legacy Git-push release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
         "exportp": "webpack --mode production && npm run favicon && npm run manifest",
         "build": "webpack --mode production",
         "build:watch": "webpack --mode production --watch",
-        "posttoTest": "npm config set sign-git-tag true && git add -A && npm version patch -s --force && npm run commits & npm run queryVersion && git push && git push --tags",
         "favicon": "real-favicon generate faviconDescription.json faviconData.json ./dist/ && real-favicon inject faviconData.json ./dist/ ./dist/index.html",
         "faviconUpdate": "real-favicon check-for-update --fail-on-update faviconData.json",
         "screenshot": "node ./node/puppeteer.js"


### PR DESCRIPTION
Refs #49
Parent: #31
Related: #35, #48, #143, #144

## Purpose

Remove the remaining root package command that can unexpectedly mutate and publish repository state.

`posttoTest` currently performs all of the following from an ordinary npm script:

- changes npm Git-tag configuration;
- `git add -A` across the entire checkout;
- force-bumps the package version;
- invokes `npm run commits`, which is not declared;
- pushes the current branch;
- pushes Git tags.

That behavior is incompatible with the repository's multi-executor safety model and is already effectively broken because the referenced `commits` script does not exist.

## Change

Delete only the `posttoTest` script entry from the historical root `package.json`.

## Deliberately unchanged

- no dependency versions or lockfiles;
- no build/lint/dev commands;
- no archive/PWA/export helpers yet;
- no gameplay, rendering, physics, audio, or generated output;
- no modern `experiments/` workspace metadata.

The remaining legacy packaging helpers stay tracked under #49 for deliberate quarantine/removal after their usage is characterized. This PR removes only the command that can stage/version/push caller state.

## Validation

Static scope is one deleted JSON property. `package.json` remains valid JSON, and no maintained script references `posttoTest`.

No runtime/browser certification is required because this removes an unused destructive publication command and does not alter any executable validation/build path.

## Promotion

Safe to merge after exact-head static review. Do not broaden this PR into historical dependency upgrades.