### PR TITLE
Make bounded world-residue replay deterministic

### DIFF
--- a/experiments/storybook/src/Foundations/Strategy/WorldResidueChronology.stories.ts
+++ b/experiments/storybook/src/Foundations/Strategy/WorldResidueChronology.stories.ts
@@ -1,0 +1,159 @@
+import type { Meta, StoryObj } from "@storybook/html-vite";
+import { expect } from "storybook/test";
+import {
+	appendWorldResidueEvent,
+	buildWorldResidueState,
+	createWorldResidueState,
+	summarizeWorldResidue,
+	type WorldResidueEvent,
+	type WorldResidueState
+} from "@defend/gameplay/worldResidue";
+import { createLabShell } from "../../labTheme";
+
+function event(
+	id: string,
+	regionId: string,
+	kind: WorldResidueEvent["kind"],
+	occurredAtSeconds: number,
+	magnitude: number,
+	gameplayConsequence = false
+): WorldResidueEvent {
+	return { id, regionId, kind, occurredAtSeconds, magnitude, gameplayConsequence };
+}
+
+const EVENT_SET: WorldResidueEvent[] = [
+	event("old-impact-a", "east", "minor-impact", 12, 0.18),
+	event("old-impact-b", "north", "heavy-impact", 18, 0.48, true),
+	event("dry-source", "south", "geothermal-depletion", 33, 0.6, true),
+	event("extracted", "core", "extraction-depletion", 47, 0.72, true),
+	event("equal-b", "west", "minor-impact", 60, 0.2),
+	event("equal-a", "west", "heavy-impact", 60, 0.2),
+	event("late-hulk", "far-edge", "mothership-hulk", 95, 0.98, true),
+	event("fortress", "core", "fortress-remnant", 110, 0.94, true)
+];
+
+function reversed<T>(items: T[]): T[] {
+	return items.slice().reverse();
+}
+
+function interleavedEvents(): WorldResidueEvent[] {
+	return [
+		EVENT_SET[6],
+		EVENT_SET[1],
+		EVENT_SET[4],
+		EVENT_SET[0],
+		EVENT_SET[7],
+		EVENT_SET[3],
+		EVENT_SET[5],
+		EVENT_SET[2]
+	];
+}
+
+function replayFingerprint(state: WorldResidueState): string {
+	return JSON.stringify({
+		records: state.records,
+		compacted: state.compacted,
+		latestOccurredAtSeconds: state.latestOccurredAtSeconds
+	});
+}
+
+const meta = {
+	title: "Foundations/Strategy/World Residue Chronology",
+	tags: ["test", "visual", "experimental"],
+	render: () => {
+		const chronological = buildWorldResidueState(EVENT_SET, { maxRecords: 4 });
+		const reverseReplay = buildWorldResidueState(reversed(EVENT_SET), {
+			maxRecords: 4
+		});
+		const interleavedReplay = buildWorldResidueState(interleavedEvents(), {
+			maxRecords: 4
+		});
+		const summary = summarizeWorldResidue(chronological);
+		const shell = createLabShell(
+			"Foundations / strategy",
+			"Residue replay chronology",
+			"Bounded live state keeps a monotonic newest-known world time. Full reconstruction sorts the semantic event set deterministically before compaction, so reload/replay does not depend on source-array ingestion order."
+		);
+		shell.frame.innerHTML = `
+			<style>
+				.replay-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:10px; }
+				.replay-card { padding:12px; border:1px solid rgba(244,237,247,.14); background:rgba(12,7,18,.48); }
+				.replay-card small { opacity:.48; text-transform:uppercase; letter-spacing:.06em; }
+				.replay-card strong { display:block; margin:4px 0 10px; }
+				.replay-card dl { display:grid; grid-template-columns:1fr auto; gap:5px 9px; margin:0; font-size:9px; }
+				.replay-card dd { margin:0; font-variant-numeric:tabular-nums; }
+				.replay-note { margin-top:12px; font-size:10px; line-height:1.5; opacity:.58; }
+				@media (max-width:760px) { .replay-grid { grid-template-columns:1fr; } }
+			</style>
+			<div class="replay-grid">
+				${[
+					["chronological", "Chronological input", chronological],
+					["reverse", "Reverse source order", reverseReplay],
+					["interleaved", "Interleaved source order", interleavedReplay]
+				]
+					.map(entry => {
+						const id = entry[0] as string;
+						const label = entry[1] as string;
+						const state = entry[2] as WorldResidueState;
+						return `<article class="replay-card" data-replay="${id}" data-fingerprint="${replayFingerprint(state).replace(/"/g, "&quot;")}"><small>same semantic event set</small><strong>${label}</strong><dl><dt>live records</dt><dd>${state.records.length}</dd><dt>compacted events</dt><dd>${state.compacted.totalEvents}</dd><dt>latest world time</dt><dd>${state.latestOccurredAtSeconds.toFixed(0)} s</dd><dt>represented events</dt><dd>${summarizeWorldResidue(state).representedEventCount}</dd></dl></article>`;
+					})
+					.join("")}
+			</div>
+			<div class="replay-note">All three reconstructions resolve to one bounded history (${summary.representedEventCount} represented events). Live append still cannot retroactively recover records already compacted before a backfilled event arrives; that limitation is explicit rather than hidden behind timestamp rewrites.</div>
+		`;
+		return shell.root;
+	}
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReplayIsDeterministic: Story = {
+	play: async ({ canvasElement }) => {
+		const chronological = buildWorldResidueState(EVENT_SET, { maxRecords: 4 });
+		const reverseReplay = buildWorldResidueState(reversed(EVENT_SET), {
+			maxRecords: 4
+		});
+		const interleavedReplay = buildWorldResidueState(interleavedEvents(), {
+			maxRecords: 4
+		});
+		const expected = replayFingerprint(chronological);
+		await expect(replayFingerprint(reverseReplay)).toBe(expected);
+		await expect(replayFingerprint(interleavedReplay)).toBe(expected);
+		await expect(chronological.latestOccurredAtSeconds).toBe(110);
+		await expect(summarizeWorldResidue(chronological).representedEventCount).toBe(
+			EVENT_SET.length
+		);
+
+		let live = createWorldResidueState();
+		live = appendWorldResidueEvent(
+			live,
+			event("newest", "core", "extraction-depletion", 100, 0.7, true),
+			{ maxRecords: 2 }
+		);
+		live = appendWorldResidueEvent(
+			live,
+			event("backfill", "old-edge", "minor-impact", 10, 0.2, false),
+			{ maxRecords: 2 }
+		);
+		await expect(live.latestOccurredAtSeconds).toBe(100);
+		await expect(summarizeWorldResidue(live).representedEventCount).toBe(2);
+
+		const runtimeMalformed = appendWorldResidueEvent(
+			createWorldResidueState(),
+			event(
+				"runtime-malformed",
+				"edge",
+				"minor-impact",
+				undefined as unknown as number,
+				undefined as unknown as number
+			)
+		);
+		await expect(Number.isFinite(runtimeMalformed.latestOccurredAtSeconds)).toBe(
+			true
+		);
+		await expect(Number.isFinite(runtimeMalformed.records[0].intensity)).toBe(true);
+
+		await expect(canvasElement.querySelectorAll("[data-replay]").length).toBe(3);
+	}
+};

--- a/src/js/gameplay/worldResidue.ts
+++ b/src/js/gameplay/worldResidue.ts
@@ -49,6 +49,8 @@ export interface CompactedWorldResidue {
 export interface WorldResidueState {
 	records: WorldResidueRecord[];
 	compacted: CompactedWorldResidue;
+	/** Monotonic newest world-event time observed by this bounded state. */
+	latestOccurredAtSeconds: number;
 }
 
 export interface WorldResidueConfig {
@@ -72,9 +74,17 @@ export const DEFAULT_WORLD_RESIDUE_CONFIG: WorldResidueConfig = {
 	maxRecords: 16
 };
 
+function isFiniteNumber(value: number): boolean {
+	return (
+		typeof value === "number" &&
+		value === value &&
+		value !== Infinity &&
+		value !== -Infinity
+	);
+}
+
 function finite(value: number, fallback: number): number {
-	if (value !== value || value === Infinity || value === -Infinity) return fallback;
-	return value;
+	return isFiniteNumber(value) ? value : fallback;
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {
@@ -108,6 +118,31 @@ function normalizedEvent(event: WorldResidueEvent): WorldResidueEvent {
 	};
 }
 
+function compareText(left: string, right: string): number {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+/**
+ * Deterministic replay ordering. Timestamp is primary; semantic identity breaks
+ * ties so reconstruction does not depend on source-array order for equal-time
+ * events.
+ */
+function compareWorldResidueEvents(
+	left: WorldResidueEvent,
+	right: WorldResidueEvent
+): number {
+	if (left.occurredAtSeconds !== right.occurredAtSeconds) {
+		return left.occurredAtSeconds - right.occurredAtSeconds;
+	}
+	const regionOrder = compareText(left.regionId, right.regionId);
+	if (regionOrder !== 0) return regionOrder;
+	const kindOrder = compareText(left.kind, right.kind);
+	if (kindOrder !== 0) return kindOrder;
+	return compareText(left.id, right.id);
+}
+
 export function worldResidueFamily(kind: WorldResidueKind): WorldResidueFamily {
 	if (kind === "minor-impact" || kind === "heavy-impact") return "impact";
 	if (kind === "mothership-hulk") return "wreck";
@@ -137,7 +172,11 @@ function emptyCompacted(): CompactedWorldResidue {
 }
 
 export function createWorldResidueState(): WorldResidueState {
-	return { records: [], compacted: emptyCompacted() };
+	return {
+		records: [],
+		compacted: emptyCompacted(),
+		latestOccurredAtSeconds: 0
+	};
 }
 
 function copyCompacted(source: CompactedWorldResidue): CompactedWorldResidue {
@@ -224,6 +263,17 @@ function foldRecord(compacted: CompactedWorldResidue, record: WorldResidueRecord
 	}
 }
 
+function recordNewestTime(records: WorldResidueRecord[]): number {
+	let newest = 0;
+	for (let index = 0; index < records.length; index += 1) {
+		newest = Math.max(
+			newest,
+			Math.max(0, finite(records[index].lastOccurredAtSeconds, 0))
+		);
+	}
+	return newest;
+}
+
 function retentionScore(record: WorldResidueRecord, newestTime: number): number {
 	const age = Math.max(0, newestTime - record.lastOccurredAtSeconds);
 	const recency = 1 / (1 + age / 60);
@@ -248,6 +298,14 @@ function lowestRetentionIndex(records: WorldResidueRecord[], newestTime: number)
 	return selected;
 }
 
+/**
+ * Append one already-occurring/live event to bounded residue state.
+ *
+ * Backfilled older events may be represented, but they never move the retention
+ * clock backward. A bounded state cannot retroactively undo information already
+ * compacted before a late historical event arrives; deterministic full replay is
+ * therefore owned by `buildWorldResidueState()`, which orders the event set first.
+ */
 export function appendWorldResidueEvent(
 	state: WorldResidueState,
 	eventInput: WorldResidueEvent,
@@ -257,6 +315,12 @@ export function appendWorldResidueEvent(
 	const event = normalizedEvent(eventInput);
 	const records = state.records.slice();
 	const compacted = copyCompacted(state.compacted);
+	const latestOccurredAtSeconds = Math.max(
+		0,
+		finite(state.latestOccurredAtSeconds, 0),
+		recordNewestTime(records),
+		event.occurredAtSeconds
+	);
 	const key = recordKey(event);
 	let found = -1;
 	for (let index = 0; index < records.length; index += 1) {
@@ -269,21 +333,28 @@ export function appendWorldResidueEvent(
 	else records.push(recordFromEvent(event));
 
 	while (records.length > config.maxRecords) {
-		const victim = lowestRetentionIndex(records, event.occurredAtSeconds);
+		const victim = lowestRetentionIndex(records, latestOccurredAtSeconds);
 		foldRecord(compacted, records[victim]);
 		records.splice(victim, 1);
 	}
 
-	return { records, compacted };
+	return { records, compacted, latestOccurredAtSeconds };
 }
 
+/**
+ * Deterministic reconstruction/replay path. The same normalized semantic event
+ * set yields the same compaction history regardless of source-array order.
+ */
 export function buildWorldResidueState(
 	events: WorldResidueEvent[],
 	config: WorldResidueConfig = DEFAULT_WORLD_RESIDUE_CONFIG
 ): WorldResidueState {
+	const ordered = events
+		.map(event => normalizedEvent(event))
+		.sort(compareWorldResidueEvents);
 	let state = createWorldResidueState();
-	for (let index = 0; index < events.length; index += 1) {
-		state = appendWorldResidueEvent(state, events[index], config);
+	for (let index = 0; index < ordered.length; index += 1) {
+		state = appendWorldResidueEvent(state, ordered[index], config);
 	}
 	return state;
 }


### PR DESCRIPTION
Refs #137, #103
Parent: #140
Related: #73, #76, #79, #89

## Purpose

Fix the event-time/compaction issue found during static review of #140 without expanding the experiment into a persistence system or causal-motif redesign.

#140 scores compaction recency using the timestamp of the **event currently being appended**. If an old event is replayed/backfilled after newer history, that incoming timestamp can move the effective retention clock backward and alter which detailed record is compacted.

A bounded state also cannot truthfully promise arbitrary ingestion-order independence after information has already been compacted away. This child makes those two responsibilities explicit instead of conflating them.

## Live bounded ingestion

`WorldResidueState` now carries a monotonic `latestOccurredAtSeconds`.

`appendWorldResidueEvent()` computes retention recency against the newest known world-event time from:

- the existing state clock;
- retained record timestamps;
- the incoming event.

A backfilled old event may still be represented, but it cannot move the retention clock backward.

This does **not** claim that a bounded already-compacted live state can retroactively reconstruct detail lost before a historical event arrived.

## Deterministic reconstruction/replay

`buildWorldResidueState()` now normalizes and deterministically orders the full supplied event set before bounded compaction.

Ordering uses:

1. occurrence timestamp;
2. region id;
3. kind;
4. event id.

Thus the same semantic timestamped event set reconstructs to the same detailed+compacted state regardless of source-array order, including equal-time events.

This is the correct path for reload/reconstruction where the complete persisted semantic event set is available.

## Runtime hardening

The finite-number boundary now requires runtime numeric type, preventing runtime `undefined`/non-number timestamps or magnitudes from propagating NaN into retention/intensity state.

## Storybook witness

Adds `Foundations/Strategy/World Residue Chronology`.

It rebuilds the same eight-event history from:

- chronological input;
- exact reverse input;
- interleaved input.

Under a four-record cap all three produce the exact same replay fingerprint, compacted counts and latest-known world time.

Additional assertions prove:

- a live event at t=100 followed by a backfilled t=10 event leaves the live retention clock at 100;
- all events remain represented;
- runtime non-number time/magnitude inputs remain finite after normalization.

## Deliberate non-goal

This child does not add the separate bounded causal-motif layer raised in review. #140's compacted family totals/intensities still preserve ambient qualitative history, while exact causal reinterpretation remains dependent on retained landmarks/current records until that design question is resolved explicitly.

## Scope

Relative to #140 head `bf6bf0166899b83ae6fb3410fbc57ba1326ddee2`:

- one modified root residue module;
- one added Storybook chronology fixture;
- no production persistence/save format;
- no Babylon/physics integration;
- no balance/timing promotion;
- no package/dependency changes;
- no frozen #95/#97/#105 changes.

Keep draft until root historical-TS/build plus Storybook typecheck/build/test validate this exact head.