### PR TITLE
Point Dependabot at the maintained modern workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /experiments
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 8
+    versioning-strategy: increase
+    groups:
+      babylon:
+        applies-to: version-updates
+        patterns:
+          - "@babylonjs/*"
+      storybook:
+        applies-to: version-updates
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      vite-vitest-browser-tooling:
+        applies-to: version-updates
+        patterns:
+          - "vite"
+          - "vitest"
+          - "@vitest/*"
+          - "playwright"
+        update-types:
+          - patch
+          - minor
+      type-and-lint-tooling:
+        applies-to: version-updates
+        patterns:
+          - "typescript"
+          - "@types/*"
+          - "@biomejs/biome"
+        update-types:
+          - patch
+          - minor

--- a/experiments/package.json
+++ b/experiments/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "packageManager": "pnpm@11.25.0",
   "engines": {
-    "node": "24.20.x"
+    "node": "24.20.x",
+    "pnpm": "11.25.0"
   },
   "scripts": {
     "typecheck": "pnpm -r --workspace-concurrency=1 run typecheck",

--- a/experiments/pnpm-workspace.yaml
+++ b/experiments/pnpm-workspace.yaml
@@ -5,3 +5,6 @@ packages:
 saveExact: true
 sharedWorkspaceLockfile: true
 engineStrict: true
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false

--- a/experiments/pnpm-workspace.yaml
+++ b/experiments/pnpm-workspace.yaml
@@ -8,3 +8,7 @@ engineStrict: true
 minimumReleaseAge: 1440
 minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
+strictDepBuilds: true
+verifyDepsBeforeRun: error
+blockExoticSubdeps: true
+trustLockfile: false


### PR DESCRIPTION
Refs #154
Parent: #144 / #143
Related: #31, #66, #149, #152, #158

## Purpose

Move automated JavaScript dependency discovery onto the maintained modern pnpm workspace and stop using the historical root/generated PWA trees as the modernization surface.

This PR is intentionally stacked on #144 because `/experiments` becomes a real workspace/lockfile root there. Do not retarget/merge it to `master` before #144 lands and its lockfile is locally certified.

Current exact head: `b6cdabd116aab21a3a5f29a297d7eac5ee04a8f1`.

It has been reassembled on #144 exact head `e367d1abad6018ccd884adda4220de4f5d37b49a` with a normal merge commit preserving the original policy commit as ancestry. Comparison against the current parent is exactly one added file: `.github/dependabot.yml`.

## Configuration

Adds one npm ecosystem rooted at `/experiments`, checked weekly.

Groups:

- `babylon`: all `@babylonjs/*` packages move together;
- `storybook`: `storybook` + `@storybook/*` move together;
- `vite-vitest-browser-tooling`: Vite, Vitest, `@vitest/*`, Playwright patch/minor updates grouped;
- `type-and-lint-tooling`: TypeScript, `@types/*`, Biome patch/minor updates grouped.

Tooling major versions are intentionally not folded into those broad groups; they should surface as separate migration PRs. Babylon/Storybook remain family-grouped because package-family alignment is itself part of compatibility.

`versioning-strategy: increase` is used because the modern workspace is an application/test workspace with exact direct pins rather than a published compatibility-range library.

## Deliberately absent

- no root `/` npm update entry;
- no `release/pwa/**` Cordova update entry;
- no Cargo automation yet;
- no auto-merge;
- no dependency changes in this PR;
- no pnpm catalog migration while Dependabot catalog/lockfile correctness remains under observation.

Rust automation waits for #145 to decide Cargo workspace/profile/lockfile ownership. Legacy dependency risk is tracked by #152 rather than continuously upgrading the 2019 graph. pnpm-major migration is #158.

## Validation / promotion

Current GitHub Dependabot configuration docs support `version: 2`, `directory`, weekly schedules, `groups.patterns`, and group `update-types`.

After #144 merges:

1. retarget/reassemble this one-file delta onto current `master` without changing config semantics;
2. confirm GitHub accepts the configuration in the Dependency graph / Dependabot surface;
3. trigger or wait for the first version-update cycle;
4. verify generated PRs touch only `/experiments` manifests/shared lockfile;
5. verify Babylon and Storybook family grouping behaves as intended;
6. verify tooling majors remain separate from ordinary patch/minor churn;
7. verify update PRs preserve #144's strict pnpm lockfile/supply-chain policy;
8. keep draft until those repository-level checks are recorded.

This config supplies dependency intelligence; it does not replace pnpm's shared lockfile, release-maturation/build-script policy, or local browser/build certification.