### PR TITLE
Remove dead destructive node_modules cleanup helper

### DIFF
--- a/node/clean.js
+++ b/node/clean.js
@@ -1,5 +1,0 @@
-const fsExtra = require("fs-extra");
-
-fsExtra.remove("./node_modules", error => {
-  Error(error);
-});


### PR DESCRIPTION
Refs #49
Parent: #31
Related: #151, #152

## Purpose

Remove a dead helper whose only behavior is recursively deleting the repository's `node_modules` directory.

`node/clean.js` is not exposed through the root `package.json`, and repository search finds no caller. Keeping an unreferenced destructive helper adds risk for automated executors without preserving a maintained workflow.

## Change

Delete exactly `node/clean.js`.

## Deliberately unchanged

- `preexportp` / `node/rmDir.js` remain because they are still referenced by the legacy export path;
- `archive` / `node/archive.js` remain because the package script still references them;
- no dependencies, lockfiles, builds, generated output, gameplay, or runtime code change.

## Validation

Static-only change. Search of current `master` finds no reference to `clean.js`, and the deleted file only invoked `fs-extra.remove("./node_modules")`.

No local runtime certification is required for deletion of an unreachable destructive helper.