### PR TITLE
Remove stale nested Rust 1.98.0 toolchain override

### DIFF
--- a/experiments/hybrid-engine/rust/rust-toolchain.toml
+++ b/experiments/hybrid-engine/rust/rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "1.98.0"
-profile = "minimal"
-targets = ["wasm32-unknown-unknown"]
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Refs #145, #92
Parent PR: #147

## Purpose

Fix a safety hole in #147 without modifying its executor-owned branch in place.

#147 adds a repository-root `rust-toolchain.toml` pinned to Rust 1.98.1, but the hybrid runtime already contains a nearer:

`experiments/hybrid-engine/rust/rust-toolchain.toml`

still pinned to **1.98.0**.

Rustup resolves checked-in toolchain files by proximity while walking from the current directory toward the root. Therefore commands executed inside the hybrid crate would continue selecting the affected 1.98.0 compiler and bypass #147's root safety pin.

## Change

Delete only the stale nested hybrid `rust-toolchain.toml`.

The parent root toolchain then becomes authoritative for both:

- `crates/defend-core`;
- `experiments/hybrid-engine/rust`.

The root file already supplies the hybrid's required `wasm32-unknown-unknown` target plus `clippy` and `rustfmt`, so no capability is lost.

## Why deletion rather than updating both files

The modernization direction is one reproducible Rust baseline for the repository. Keeping two identical pins would recreate drift risk on the next point release and complicate the Cargo-workspace consolidation tracked in #145.

## Scope

Relative to #147 exact head `91543cf8a340f95caaa4e01c46c7bf00d5b3f7c7`:

- exactly one file deleted;
- no Rust source changes;
- no Cargo dependency/workspace/profile changes;
- no JS/package changes;
- no frozen #95/#97/#105 source changes.

## Local certification

Prefer certifying #147 with this child applied, or fold the deletion into #147 before its exact-head local gate.

From repository root **and** from `experiments/hybrid-engine/rust`, record:

```sh
rustup show active-toolchain
rustc -Vv
cargo -V
```

Both locations must resolve Rust 1.98.1. Then run #147's root/hybrid fmt/clippy/test/WASM checks.

If this child is not applied, hybrid-runtime certification performed from its crate directory must not be accepted as evidence that #147 successfully eliminated Rust 1.98.0.