### PR TITLE
Remove broken legacy ESLint config-check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "queryVersion": "node ./node/queryVersion.js",
         "lint": "eslint ./src/js/** --quiet",
         "lint:fix": "eslint ./src/js/** --quiet --fix",
-        "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
         "dev": "webpack-dev-server --config webpack.configDev.js --mode development --hot",
         "soundTest": "webpack-dev-server --config webpack.configSoundTest.js --mode development --hot",
         "preexportp": "npm run queryVersion && node ./node/rmDir.js && node ./node/cpDir.js",


### PR DESCRIPTION
Refs #49
Parent: #31
Related: #35, #160

## Purpose

Remove an unreachable/broken lint helper from the historical root package surface.

`eslint-check` runs:

```sh
eslint --print-config .eslintrc.js | eslint-config-prettier-check
```

The repository has `.eslintrc.json`; `.eslintrc.js` does not exist. Ordinary historical linting is already owned by the `lint` / `lint:fix` scripts, while new modern workspace code uses Biome.

## Change

Delete only the `eslint-check` script entry from root `package.json`.

## Deliberately unchanged

- historical `lint` and `lint:fix`;
- all dependencies, including the old ESLint/Prettier graph needed for baseline reconstruction;
- build/dev/export/runtime/gameplay code.

## Validation

Static one-line script deletion. No runtime certification required.