### PR TITLE
Make the hybrid Rust lab explicitly standalone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 members = ["crates/defend-core"]
+exclude = ["experiments/hybrid-engine/rust"]
 resolver = "2"


### PR DESCRIPTION
Refs #165
Parent: #145
Related: #66, #67, #147

## Purpose

Make Cargo ownership match the architecture already intended by the hybrid-engine lab.

The root is a virtual Cargo workspace containing only `crates/defend-core`, while `experiments/hybrid-engine/rust` sits beneath the workspace root but owns its own package/release profile. Current Cargo validation explicitly errors when such a package discovers an ancestor workspace but is not a member, and recommends `workspace.exclude` or a nested `[workspace]`.

## Change

Add exactly:

```toml
exclude = ["experiments/hybrid-engine/rust"]
```

to the root `[workspace]`.

This makes the existing standalone intent explicit at the repository boundary.

## Why exclusion rather than membership

The hybrid runtime currently owns:

```toml
[profile.release]
codegen-units = 1
lto = true
opt-level = "s"
panic = "abort"
strip = "symbols"
```

Making it a root workspace member would move profile ownership to the root and change lockfile/target-directory/dependency-resolution semantics. #145 owns that later consolidation decision. This PR does not pre-commit to it.

A nested empty `[workspace]` in the hybrid manifest would also solve Cargo discovery, but root `exclude` is the clearer repository-wide declaration of intentional non-membership.

## Deliberately unchanged

- root workspace `members`;
- `resolver = "2"`;
- all Cargo package/dependency versions;
- hybrid release profile;
- Rust source;
- Cargo.lock state;
- #147 Rust 1.98.1 toolchain lane.

Resolver 2 -> 3 is deliberately separate. Rust 2024 recommends resolver 3 for virtual workspaces, but that changes dependency selection and should be measured with a real lockfile rather than bundled into this structural correction.

## Local certification required

Keep draft until the local executor records against this exact head:

1. `cargo metadata --manifest-path experiments/hybrid-engine/rust/Cargo.toml` succeeds rather than reporting workspace-membership mismatch;
2. the returned workspace root for that manifest is the hybrid crate itself / it is not a root-workspace member;
3. hybrid `cargo fmt --check`, clippy, test and wasm-pack build succeed under the pinned Rust 1.98.1 lane where practical;
4. root `cargo metadata` still lists only `defend-core`;
5. hybrid release-profile/build-output behavior is unchanged;
6. no Cargo.lock is committed as an incidental side effect.

## Promotion

If this passes, merge before broader #145 workspace consolidation so the current architecture is internally valid while the final runtime workspace layout remains under evaluation.