### PR TITLE
Ignore Cargo target build artifacts repository-wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build directory
 dist/
+target/
 
 # Logs
 logs


### PR DESCRIPTION
Refs #145
Related: #147, #165, #166, #167

## Purpose

Keep Rust build output from polluting repository/certification status while preserving lockfile visibility.

The root Cargo workspace writes compiled artifacts to the workspace-root `target/` directory. The repository-wide `.gitignore` did not ignore `target/`, and `crates/defend-core` has no local `.gitignore`. Ordinary root `cargo test`/`cargo check` can therefore create a large untracked tree during certification.

## Change

Add exactly:

```gitignore
target/
```

to the global build-output section.

Because the pattern is not anchored, it also safely covers nested Cargo `target/` directories. Existing hybrid-specific ignores can remain redundant without harm.

## Deliberately unchanged

- `Cargo.lock` remains visible/committable;
- `pnpm-lock.yaml` remains visible/committable;
- no source, manifest, dependency, build command, or runtime behavior changes.

## Validation

Static ignore-policy change only. Safe to merge after exact-head review.