### PR TITLE
Keep wasm-opt running on Rust's bulk-memory WASM output

### DIFF
--- a/experiments/hybrid-engine/rust/Cargo.toml
+++ b/experiments/hybrid-engine/rust/Cargo.toml
@@ -20,3 +20,12 @@ lto = true
 opt-level = "s"
 panic = "abort"
 strip = "symbols"
+
+# wasm-pack 0.13.1 downloads Binaryen 117, whose wasm-opt does not enable
+# bulk memory or non-trapping float-to-int conversions by default. rustc emits
+# both for wasm32-unknown-unknown, so the default `-O` invocation fails
+# validation with "Bulk memory operations require bulk memory". Enabling the
+# features rustc already targets keeps the optimization pass running instead of
+# disabling it.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-O', '--enable-bulk-memory', '--enable-nontrapping-float-to-int']


### PR DESCRIPTION
## Scope

Linked issue: closes #175

Ownership boundary: `experiments/hybrid-engine/rust/Cargo.toml` only — the `wasm-pack` release profile metadata. No dependency versions, no workspace membership, no source changes.

## Change

`wasm-pack build` fails in its optimization step:

```
[wasm-validator error in function 1] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory]
Fatal: error validating input
Error: failed to execute `wasm-opt`: exited with exit status: 1
```

rustc emits bulk-memory operations for `wasm32-unknown-unknown` by default, but the `wasm-opt` binary wasm-pack 0.13.1 downloads is Binaryen `version_117`, which does not enable that feature and rejects the module. The compile and `wasm-bindgen` steps both succeed — the unoptimized module is written before the failure — so only the optimization pass is broken.

This declares the features rustc already targets, so the pass keeps running. The alternative escape hatch wasm-pack suggests is `wasm-opt = false`, which would ship an unoptimized module and quietly cost 40 KB; that is the wrong trade for a lab whose purpose includes measuring payload.

Upgrading to wasm-pack 0.15.0 would also fix it, but there is no wasm-pack pin anywhere in the repository, so that fix would depend on whatever is on an operator's `PATH`. Worth doing deliberately later — see the note in #175 — but not as this change.

## Gameplay impact

- [x] No intended gameplay/balance change

No #29 invariant is touched. This is build tooling for an architecture experiment; the emitted WASM is byte-identical apart from optimization.

## Validation

Commands actually performed, macOS 26.5.2 aarch64, rustc 1.98.1 (48a229cea 2026-09-01) selected externally with `RUSTUP_TOOLCHAIN` — this head still carries the nested 1.98.0 toolchain file that #159 removes, and #92's preflight forbids using 1.98.0 for evidence:

- `wasm-pack build ./rust --target web` **without** this change → fails validation as quoted above;
- `wasm-pack build ./rust --target web` **with** it → `Done in 1.32s`, emits **431113 B**, down from the **471870 B** unoptimized module;
- `cargo test` → 3 passed, 0 failed;
- `cargo clippy --all-targets -- -D warnings` → exit 0;
- downstream: `pnpm build` (wasm + `tsc --noEmit` + `vite build`) completes, and the resulting module loads and runs in Chromium 151.0.7922.34 — see the stacked PR for the six-page browser evidence.

Not validated online / requires local Codex:

- [x] build/install — done locally, above
- [x] browser interaction — done locally, via the stacked PR
- [ ] physics behavior
- [ ] performance/profile
- [ ] touch/input
- [ ] audio
- [ ] PWA/offline

## Concurrency

Known overlapping PRs/issues: #175 (this), #145 (Cargo consolidation — whatever preserves the hybrid release profile must keep this `wasm-opt` invocation working, not just the `[profile.release]` keys), #163 (its `pnpm build` gate fails until this lands).

Integration notes for other executors: this is the parent of the #176 fix, which needs a working WASM build before it can be browser-verified. No `Cargo.lock` is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
