### PR TITLE
Register the Babylon side effects the pure barrel does not apply

### DIFF
--- a/experiments/hybrid-engine/rust/Cargo.toml
+++ b/experiments/hybrid-engine/rust/Cargo.toml
@@ -20,3 +20,12 @@ lto = true
 opt-level = "s"
 panic = "abort"
 strip = "symbols"
+
+# wasm-pack 0.13.1 downloads Binaryen 117, whose wasm-opt does not enable
+# bulk memory or non-trapping float-to-int conversions by default. rustc emits
+# both for wasm32-unknown-unknown, so the default `-O` invocation fails
+# validation with "Bulk memory operations require bulk memory". Enabling the
+# features rustc already targets keeps the optimization pass running instead of
+# disabling it.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-O', '--enable-bulk-memory', '--enable-nontrapping-float-to-int']

--- a/experiments/hybrid-engine/src/geothermalPrototype.ts
+++ b/experiments/hybrid-engine/src/geothermalPrototype.ts
@@ -6,10 +6,16 @@ import {
   Mesh,
   MeshBuilder,
   PointLight,
+  RegisterStandardEngineExtensions,
   Scene,
   StandardMaterial,
   Vector3,
 } from "@babylonjs/core/pure";
+
+// "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but
+// registers none of the prototype extensions they rely on at runtime. Register
+// what this prototype uses explicitly, or the failure only appears in a browser.
+RegisterStandardEngineExtensions();
 
 type SourcePhase = "active" | "retreating" | "erupting";
 type TowerTier = 1 | 2 | 3;

--- a/experiments/hybrid-engine/src/main.ts
+++ b/experiments/hybrid-engine/src/main.ts
@@ -4,6 +4,8 @@ import {
   Engine,
   HemisphericLight,
   MeshBuilder,
+  RegisterInstancedMesh,
+  RegisterStandardEngineExtensions,
   Scene,
   StandardMaterial,
   Vector3,
@@ -14,6 +16,13 @@ import {
   advanceFixedStep,
   type FixedStepPolicy,
 } from "./fixedStep";
+
+// "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but
+// registers none of the prototype extensions or mesh capabilities they rely on
+// at runtime. Everything this lab actually uses has to be registered explicitly,
+// or the failure only appears in a browser.
+RegisterStandardEngineExtensions();
+RegisterInstancedMesh();
 
 const BODY_COUNT = 128;
 const ARENA_RADIUS = 72;

--- a/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
@@ -6,11 +6,17 @@ import {
   Mesh,
   MeshBuilder,
   PointLight,
+  RegisterStandardEngineExtensions,
   Scene,
   StandardMaterial,
   TransformNode,
   Vector3,
 } from "@babylonjs/core/pure";
+
+// "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but
+// registers none of the prototype extensions they rely on at runtime. Register
+// what this prototype uses explicitly, or the failure only appears in a browser.
+RegisterStandardEngineExtensions();
 
 type CameraMode = "raider" | "defender";
 type NavigationPhase = "stable" | "warning" | "critical" | "captured";

--- a/experiments/hybrid-engine/src/mothershipPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipPrototype.ts
@@ -5,11 +5,17 @@ import {
   HemisphericLight,
   MeshBuilder,
   PointLight,
+  RegisterStandardEngineExtensions,
   Scene,
   StandardMaterial,
   TransformNode,
   Vector3,
 } from "@babylonjs/core/pure";
+
+// "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but
+// registers none of the prototype extensions they rely on at runtime. Register
+// what this prototype uses explicitly, or the failure only appears in a browser.
+RegisterStandardEngineExtensions();
 
 type MothershipPhase = "stable" | "low-reserve" | "critical" | "falling" | "hulk";
 type CameraMode = "raider" | "defender";

--- a/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
+++ b/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
@@ -5,10 +5,16 @@ import {
   HemisphericLight,
   Mesh,
   MeshBuilder,
+  RegisterStandardEngineExtensions,
   Scene,
   StandardMaterial,
   Vector3,
 } from "@babylonjs/core/pure";
+
+// "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but
+// registers none of the prototype extensions they rely on at runtime. Register
+// what this prototype uses explicitly, or the failure only appears in a browser.
+RegisterStandardEngineExtensions();
 
 type RaiderTier = 1 | 2 | 3;
 type RaiderState = "moving" | "blocked" | "reached";

--- a/experiments/hybrid-engine/src/towerTerrainPrototype.ts
+++ b/experiments/hybrid-engine/src/towerTerrainPrototype.ts
@@ -5,6 +5,7 @@ import {
   HemisphericLight,
   Mesh,
   MeshBuilder,
+  RegisterStandardEngineExtensions,
   Scene,
   StandardMaterial,
   TransformNode,
@@ -19,6 +20,11 @@ import {
   terrainImpactProfile,
   type TerrainDeformationCalibration,
 } from "../../../src/js/gameplay/terrainDeformation";
+
+// "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but
+// registers none of the prototype extensions they rely on at runtime. Register
+// what this prototype uses explicitly, or the failure only appears in a browser.
+RegisterStandardEngineExtensions();
 
 type TowerPhase = "foundation" | "base" | "drilling" | "assembly" | "calibrating" | "ready" | "dry" | "renovating";
 


### PR DESCRIPTION
## Scope

Linked issue: closes #176

Ownership boundary: the six Babylon entry modules under `experiments/hybrid-engine/src/`. Import lists and one registration block each — no gameplay logic, no rendering behavior, no dependency changes.

**Stacked on #178.** Base is `agent/wasm-opt-bulk-memory`, because a working WASM build is a precondition for browser-verifying this at all. The diff against that parent contains only the six source files.

## Change

Every page in this lab fails at runtime, not just `index.html` as originally reported in #176:

| Page | Before |
| --- | --- |
| `index.html` | `InstancedMesh needs to be imported before as it contains a side-effect required by your code` — never renders |
| `mothership.html` | `engine.getStencilBuffer is not a function` — never renders |
| `navigation.html` | same — never renders |
| `geothermal.html` | same — never renders |
| `routing.html` | renders, but throws the same stencil error from the render path |
| `tower-terrain.html` | renders, but throws the same stencil error from the render path |

The five prototypes import from `@babylonjs/core/pure`, which exports classes but registers none of the prototype extensions they depend on at runtime. `Rendering/renderingGroup.js` calls `engine.getStencilBuffer()` on the render path, and that method only exists once `abstractEngine.stencil` has been registered.

Babylon 9 splits each module into `X.pure.js` (no side effects), `X.js` (imports pure, calls `RegisterX()`) and `X.types.js`. The pure barrel re-exports the `Register*` functions along with the tiered helpers in `Engines/engineRegistration.pure.js`, which is the supported way to opt in from a pure build. This uses those rather than individual side-effect import paths, so the registrations stay visible and greppable right next to the imports that need them, and the modules keep a single import specifier.

### Why `RegisterStandardEngineExtensions` uniformly

`RegisterCoreEngineExtensions()` is enough for `index.html`, but leaves the other five pages throwing `engine.setAlphaMode is not a function`. Both configurations were built and measured: because the registration chunk is shared across entry points, a split configuration came out **10 bytes larger** than uniform Standard. There is no payload argument for the narrower tier, so the uniform one wins on consistency.

Cost of the fix on `index.html` eager JS: **1221829 B → 1253089 B (+31260 B, +2.6%)**.

## Gameplay impact

- [x] No intended gameplay/balance change

No #29 invariant is affected — the simulation is owned by the Rust/WASM runtime and is untouched. What changes is that the prototypes demonstrating #79/#80/#82/#83/#86/#89 can now actually be looked at.

## Validation

macOS 26.5.2 aarch64, Node 24.20.0, Chromium 151.0.7922.34, rustc 1.98.1.

A headless six-page smoke run asserting **zero console errors** and a render loop that leaves `initializing…`:

- **before: 6 of 6 pages FAIL** (4 never reach a first frame, 2 throw every frame);
- **after: 6 of 6 pages PASS**, `index.html` steady at 33.4 fps with the HUD reporting `bodies: 128`, 120 Hz fixed tick.

Other checks:

- `tsc --noEmit` → clean;
- `pnpm test` (vitest) → 5 passed;
- `pnpm build` (wasm + tsc + vite) → green;
- `?inspect=1` → Inspector loads, scene keeps rendering, no new errors;
- `biome check ./src` → 19 errors, unchanged from before this PR; all pre-existing and owned by #174.

Not validated online / requires local Codex:

- [x] build/install — done locally
- [x] browser interaction — done locally, all six pages
- [ ] physics behavior
- [ ] performance/profile — 33.4 fps headless is a smoke number, not a profile
- [ ] touch/input
- [ ] audio
- [ ] PWA/offline

## Concurrency

Known overlapping PRs/issues: #178 (parent), #174 (the biome diagnostics in these same files — this PR deliberately does not touch them), #163 (its browser gate depends on this), #66, #162.

Integration notes for other executors:

- The smoke run was a throwaway Playwright script, not committed. Making it a permanent gate needs a browser-test dependency in `experiments/hybrid-engine`, which is a dependency decision that belongs with the workspace/CI work in #162 rather than here. **Strongly recommended** — this whole class of failure is invisible to every static check the project currently has.
- The Inspector CLI bridge still retries `ws://127.0.0.1:4400` forever with no server to talk to. Unrelated to the pure barrel; left in #176's notes.
- No lockfile is added. A package-local `pnpm install` was used for verification because `master` has no workspace root yet; its generated lockfile was deliberately not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
