### PR TITLE
Drop the removed baseUrl option from the Storybook lab tsconfig

### DIFF
--- a/experiments/storybook/tsconfig.json
+++ b/experiments/storybook/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"],
-    "baseUrl": ".",
     "paths": {
       "@defend/*": ["../../src/js/*"]
     },


### PR DESCRIPTION
## Scope

Linked issue: closes #172

Ownership boundary: one line in `experiments/storybook/tsconfig.json`. No source, dependency, or build-config changes.

## Change

The lab pins `typescript@7.0.2`, which removed `baseUrl`, so every type check failed before reaching a single source file:

```
tsconfig.json(8,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
  Use '"paths": {"*": ["./*"]}' instead.
```

`paths` entries resolve relative to the tsconfig's own directory when no `baseUrl` is set, and this project's single alias was already written that way (`"@defend/*": ["../../src/js/*"]`), so removing the line is sufficient — no `paths` rewrite is needed.

Runtime resolution is unaffected either way: Vite owns it through the `resolve.alias` entry in `vite.config.ts`, which `tsconfig.json` only mirrors for type checking.

TypeScript's suggested `"paths": {"*": ["./*"]}` replacement is deliberately **not** applied. That reproduces the old implicit-baseUrl behaviour of resolving every bare specifier against the project directory, which this lab never relied on and which would silently widen module resolution.

## Gameplay impact

- [x] No intended gameplay/balance change

No #29 invariant is touched. Type-checking configuration only.

## Validation

macOS 26.5.2 aarch64, Node 24.20.0, typescript 7.0.2, package-local install.

- `tsc --noEmit` → **exit 0** (was exit 1);
- `storybook build` → completes successfully;
- `vitest run --project=storybook` → 5 files / 5 tests passed.

The alias was verified to still be genuinely resolved and type-checked, not silently degraded to a missing-module failure that `skipLibCheck` might mask: adding a bogus member to an existing `@defend/gameplay/terrainDeformation` import produces

```
error TS2305: Module '"@defend/gameplay/terrainDeformation"' has no exported member 'thisSymbolDoesNotExist'.
```

and removing it returns to exit 0. Several stories import through this alias (`@defend/audio/acoustics`, `@defend/audio/spatialAudio`, `@defend/gameplay/terrainDeformation`), so it is exercised by the checked file set rather than being dead configuration.

Not validated online / requires local Codex:

- [x] build/install — done locally
- [x] browser interaction — Storybook browser tests, done locally
- [ ] physics behavior
- [ ] performance/profile
- [ ] touch/input
- [ ] audio
- [ ] PWA/offline

## Concurrency

Known overlapping PRs/issues: #163 (its `pnpm typecheck` gate fails until this lands), #173 (the other independent cause of that gate failing, in the hybrid lab), #64.

Integration notes for other executors: no lockfile is committed. Verification used a package-local `pnpm install` because `master` has no workspace root yet; the generated `pnpm-lock.yaml` and pnpm's auto-written `pnpm-workspace.yaml` were both left untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
