### PR TITLE
Reformat the hybrid runtime crate with the pinned rustfmt

### DIFF
--- a/experiments/hybrid-engine/rust/src/lib.rs
+++ b/experiments/hybrid-engine/rust/src/lib.rs
@@ -234,7 +234,10 @@ mod tests {
         assert_eq!(one_batch.tick(), 240);
         assert_eq!(split_batches.tick(), 240);
         assert_eq!(one_batch.positions(), split_batches.positions());
-        assert_eq!(one_batch.state_fingerprint(), split_batches.state_fingerprint());
+        assert_eq!(
+            one_batch.state_fingerprint(),
+            split_batches.state_fingerprint()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Scope

Linked issue: closes #177

Ownership boundary: `experiments/hybrid-engine/rust/src/lib.rs`, one hunk, formatting only.

## Change

`cargo fmt --all -- --check` in `experiments/hybrid-engine/rust` exits 1 on a single `assert_eq!` in the fixed-step partitioning test that rustfmt wants split across lines. The crate had been formatted by a rustfmt other than the one the repository pins.

The drift was **unreachable** until #166 landed — while the crate believed it was in the root workspace, `cargo fmt` failed with `current package believes it's in a workspace when it's not` and never reached rustfmt at all.

This is formatting only. The file is byte-identical with all whitespace stripped:

```
sha256 (whitespace-stripped), before: 9560d8b641383a8db42e5e4743230202c1d15a3a192214dc27e476398fba8502
sha256 (whitespace-stripped), after:  9560d8b641383a8db42e5e4743230202c1d15a3a192214dc27e476398fba8502
```

## Gameplay impact

- [x] No intended gameplay/balance change

No #29 invariant is touched. The reformatted statement is a test assertion; no runtime code is affected.

## Validation

macOS 26.5.2 aarch64, rustfmt 1.9.0-stable (48a229ceae 2026-09-01) from Rust 1.98.1, selected externally with `RUSTUP_TOOLCHAIN` — this head still carries the nested 1.98.0 toolchain file that #159 removes, and #92's preflight forbids using 1.98.0 for evidence.

- `cargo fmt --all -- --check` → **exit 0** (was exit 1);
- `cargo test` → 3 passed, 0 failed;
- `cargo clippy --all-targets -- -D warnings` → exit 0;
- root workspace untouched: `cargo fmt --all -- --check` exit 0, `cargo test -p defend-core` 4 passed.

Not validated online / requires local Codex:

- [x] build/install — done locally
- [ ] browser interaction — not applicable, no runtime change
- [ ] physics behavior
- [ ] performance/profile
- [ ] touch/input
- [ ] audio
- [ ] PWA/offline

One note for whoever reviews: the repository's *current* nested pin is still 1.98.0, so a developer running `cargo fmt` in that directory today gets 1.98.0's rustfmt rather than the one used here. The two agree on this hunk — 1.98.1 was a compiler codegen patch, not a rustfmt change — and the point becomes moot once #147/#159 land the single 1.98.1 authority. Flagging it rather than leaving it implicit.

## Concurrency

Known overlapping PRs/issues: #145 and #147/#159 (toolchain pin), #163 (its hybrid `cargo fmt` gate fails until this lands). No overlap with #178 (`Cargo.toml`) or #179 (`src/*.ts` in the same lab but a different language and directory).

Integration notes for other executors: no `Cargo.lock` is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
