### PR TITLE
Make 'pnpm check' reproducible in the hybrid lab and fix its diagnostics

### DIFF
--- a/experiments/hybrid-engine/biome.json
+++ b/experiments/hybrid-engine/biome.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
-    "includes": ["**", "!pkg", "!dist", "!node_modules"]
+    "includes": ["**"]
   },
   "formatter": {
     "enabled": true,
@@ -10,7 +15,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   }
 }

--- a/experiments/hybrid-engine/mothership.html
+++ b/experiments/hybrid-engine/mothership.html
@@ -61,7 +61,7 @@
   <body>
     <div id="app"><canvas id="renderCanvas"></canvas></div>
     <div id="metrics">initializing…</div>
-    <div id="controls" aria-label="Mothership prototype controls">
+    <div id="controls" role="toolbar" aria-label="Mothership prototype controls">
       <button id="reset" type="button">Reset [R]</button>
       <button id="pause" type="button">Pause drain [Space]</button>
       <button id="fast" type="button">Fast drain [F]</button>

--- a/experiments/hybrid-engine/src/fixedStep.test.ts
+++ b/experiments/hybrid-engine/src/fixedStep.test.ts
@@ -12,7 +12,10 @@ const policy: FixedStepPolicy = {
   maxFrameDeltaSeconds: 0.25,
 };
 
-function simulateFrames(frameCount: number, frameDeltaSeconds: number): {
+function simulateFrames(
+  frameCount: number,
+  frameDeltaSeconds: number,
+): {
   ticks: number;
   state: FixedStepState;
 } {
@@ -76,7 +79,10 @@ describe("advanceFixedStep", () => {
 
   it("sanitizes non-finite timing inputs", () => {
     const advance = advanceFixedStep(
-      { accumulatorSeconds: Number.NaN, droppedSeconds: Number.POSITIVE_INFINITY },
+      {
+        accumulatorSeconds: Number.NaN,
+        droppedSeconds: Number.POSITIVE_INFINITY,
+      },
       Number.NaN,
       {
         fixedDeltaSeconds: Number.NaN,

--- a/experiments/hybrid-engine/src/fixedStep.test.ts
+++ b/experiments/hybrid-engine/src/fixedStep.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
-  INITIAL_FIXED_STEP_STATE,
   advanceFixedStep,
   type FixedStepPolicy,
   type FixedStepState,
+  INITIAL_FIXED_STEP_STATE,
 } from "./fixedStep";
 
 const policy: FixedStepPolicy = {

--- a/experiments/hybrid-engine/src/geothermalPrototype.ts
+++ b/experiments/hybrid-engine/src/geothermalPrototype.ts
@@ -323,12 +323,23 @@ function createTower(
 
 function conduitPath(source: GeothermalSource, tower: TowerProxy): Vector3[] {
   const start = source.position.add(new Vector3(0, 1.2, 0));
-  const end = tower.mesh.position.add(new Vector3(0, -tower.mesh.getBoundingInfo().boundingBox.extendSizeWorld.y + 0.7, 0));
+  const end = tower.mesh.position.add(
+    new Vector3(
+      0,
+      -tower.mesh.getBoundingInfo().boundingBox.extendSizeWorld.y + 0.7,
+      0,
+    ),
+  );
   const lateral = end.subtract(start);
   const side = new Vector3(-lateral.z, 0, lateral.x);
-  if (side.lengthSquared() > 0.001) side.normalize().scaleInPlace(Math.min(5, lateral.length() * 0.12));
-  const p1 = Vector3.Lerp(start, end, 0.32).add(side).add(new Vector3(0, 1.4, 0));
-  const p2 = Vector3.Lerp(start, end, 0.68).subtract(side.scale(0.45)).add(new Vector3(0, 1.1, 0));
+  if (side.lengthSquared() > 0.001)
+    side.normalize().scaleInPlace(Math.min(5, lateral.length() * 0.12));
+  const p1 = Vector3.Lerp(start, end, 0.32)
+    .add(side)
+    .add(new Vector3(0, 1.4, 0));
+  const p2 = Vector3.Lerp(start, end, 0.68)
+    .subtract(side.scale(0.45))
+    .add(new Vector3(0, 1.1, 0));
   return [start, p1, p2, end];
 }
 
@@ -338,7 +349,7 @@ function connectTowers(
   sources: GeothermalSource[],
   conduitMaterial: StandardMaterial,
 ): void {
-  towers.forEach(tower => {
+  towers.forEach((tower) => {
     tower.conduit?.dispose();
     tower.conduit = null;
     tower.sourceId = null;
@@ -363,7 +374,12 @@ function connectTowers(
     tower.supported = true;
     tower.conduit = MeshBuilder.CreateTube(
       `tower-conduit-${tower.id}`,
-      { path: conduitPath(best, tower), radius: 0.42, tessellation: 6, cap: Mesh.CAP_ALL },
+      {
+        path: conduitPath(best, tower),
+        radius: 0.42,
+        tessellation: 6,
+        cap: Mesh.CAP_ALL,
+      },
       scene,
     );
     tower.conduit.material = conduitMaterial;
@@ -371,14 +387,18 @@ function connectTowers(
   });
 }
 
-function relocateSource(source: GeothermalSource, relocationIndex: number): void {
+function relocateSource(
+  source: GeothermalSource,
+  relocationIndex: number,
+): void {
   const relocationPoints = [
     new Vector3(-52, 0, 28),
     new Vector3(16, 0, 48),
     new Vector3(50, 0, -4),
     new Vector3(-8, 0, -52),
   ];
-  const point = relocationPoints[(source.id + relocationIndex) % relocationPoints.length];
+  const point =
+    relocationPoints[(source.id + relocationIndex) % relocationPoints.length];
   source.position.copyFrom(surfacePoint(point.x, point.z, -0.8));
   source.vent.position.copyFrom(source.position);
   source.bulge.position.copyFrom(surfacePoint(point.x, point.z, -4));
@@ -411,7 +431,11 @@ function createEruptionParticles(
     const speed = 5 + (index % 6) * 1.2;
     particles.push({
       mesh,
-      velocity: new Vector3(Math.cos(angle) * speed, 10 + (index % 5) * 2.2, Math.sin(angle) * speed),
+      velocity: new Vector3(
+        Math.cos(angle) * speed,
+        10 + (index % 5) * 2.2,
+        Math.sin(angle) * speed,
+      ),
       age: 0,
     });
   }
@@ -443,11 +467,22 @@ async function main(): Promise<void> {
   const pressureButton = document.querySelector<HTMLButtonElement>("#pressure");
   const eruptionButton = document.querySelector<HTMLButtonElement>("#eruption");
   const layersButton = document.querySelector<HTMLButtonElement>("#layers");
-  if (!canvas || !metrics || !resetButton || !fireButton || !pressureButton || !eruptionButton || !layersButton) {
+  if (
+    !canvas ||
+    !metrics ||
+    !resetButton ||
+    !fireButton ||
+    !pressureButton ||
+    !eruptionButton ||
+    !layersButton
+  ) {
     throw new Error("Geothermal lab DOM is incomplete");
   }
 
-  const engine = new Engine(canvas, true, { adaptToDeviceRatio: true, antialias: true });
+  const engine = new Engine(canvas, true, {
+    adaptToDeviceRatio: true,
+    antialias: true,
+  });
   const scene = new Scene(engine);
   scene.clearColor.set(0.02, 0.012, 0.034, 1);
 
@@ -465,7 +500,11 @@ async function main(): Promise<void> {
   camera.lowerBetaLimit = 0.38;
   camera.upperBetaLimit = 2.5;
 
-  const ambient = new HemisphericLight("geothermal-ambient", new Vector3(0.25, 1, 0.15), scene);
+  const ambient = new HemisphericLight(
+    "geothermal-ambient",
+    new Vector3(0.25, 1, 0.15),
+    scene,
+  );
   ambient.intensity = 0.7;
 
   const planet = createPlanet(scene);
@@ -499,10 +538,22 @@ async function main(): Promise<void> {
   ];
 
   const deepStreams = [
-    createSubsurfaceStream(scene, "deep-stream-0", sources[0].position, sources[1].position, tealMaterial),
-    createSubsurfaceStream(scene, "deep-stream-1", sources[1].position, sources[2].position, tealMaterial),
+    createSubsurfaceStream(
+      scene,
+      "deep-stream-0",
+      sources[0].position,
+      sources[1].position,
+      tealMaterial,
+    ),
+    createSubsurfaceStream(
+      scene,
+      "deep-stream-1",
+      sources[1].position,
+      sources[2].position,
+      tealMaterial,
+    ),
   ];
-  deepStreams.forEach(stream => {
+  deepStreams.forEach((stream) => {
     stream.visibility = 0.55;
   });
 
@@ -520,17 +571,24 @@ async function main(): Promise<void> {
       { diameter, segments: 5 + index },
       scene,
     );
-    mesh.position.copyFrom(surfacePoint(-46 + index * 34, 12 + index * 9, diameter / 2 + 0.4));
+    mesh.position.copyFrom(
+      surfacePoint(-46 + index * 34, 12 + index * 9, diameter / 2 + 0.4),
+    );
     mesh.material = refs.raiderMaterial;
     return { id: index, mesh, velocity: Vector3.Zero(), releasedEnergy: false };
   });
 
   connectTowers(scene, towers, sources, conduitMaterial);
-  towers.forEach(tower => {
-    if (!tower.supported && tower.tier > 1) tower.mesh.material = invalidMaterial;
+  towers.forEach((tower) => {
+    if (!tower.supported && tower.tier > 1)
+      tower.mesh.material = invalidMaterial;
   });
 
-  const ventLight = new PointLight("geothermal-vent-light", sources[1].position, scene);
+  const ventLight = new PointLight(
+    "geothermal-vent-light",
+    sources[1].position,
+    scene,
+  );
   ventLight.diffuse = new Color3(0.08, 0.92, 0.88);
   ventLight.intensity = 0.35;
   ventLight.range = 44;
@@ -551,9 +609,15 @@ async function main(): Promise<void> {
   }
 
   const updateButtons = () => {
-    fireButton.textContent = globalFiring ? "Stop tower draw [F]" : "Resume tower draw [F]";
-    pressureButton.textContent = acceleratedPressure ? "Normal pressure [P]" : "Accelerate pressure [P]";
-    layersButton.textContent = boostedLayers ? "Dim internal layers [L]" : "Boost internal layers [L]";
+    fireButton.textContent = globalFiring
+      ? "Stop tower draw [F]"
+      : "Resume tower draw [F]";
+    pressureButton.textContent = acceleratedPressure
+      ? "Normal pressure [P]"
+      : "Accelerate pressure [P]";
+    layersButton.textContent = boostedLayers
+      ? "Dim internal layers [L]"
+      : "Boost internal layers [L]";
   };
 
   const startEruption = (source: GeothermalSource) => {
@@ -565,14 +629,20 @@ async function main(): Promise<void> {
     eruptionParticles = createEruptionParticles(scene, source, tealMaterial);
 
     for (const tower of towers) {
-      if (horizontalDistance(tower.mesh.position, source.position) < 25 && !tower.melted) {
+      if (
+        horizontalDistance(tower.mesh.position, source.position) < 25 &&
+        !tower.melted
+      ) {
         tower.melted = true;
         tower.firing = false;
       }
     }
 
     for (const raider of raiders) {
-      const distance = horizontalDistance(raider.mesh.position, source.position);
+      const distance = horizontalDistance(
+        raider.mesh.position,
+        source.position,
+      );
       if (distance < 31) {
         const outward = raider.mesh.position.subtract(source.position);
         outward.y = 0;
@@ -583,7 +653,12 @@ async function main(): Promise<void> {
         if (!raider.releasedEnergy) {
           raider.releasedEnergy = true;
           collectedDroplets.push(
-            spawnCollectedDroplet(scene, raider.mesh.position, tealMaterial, collectedDroplets.length),
+            spawnCollectedDroplet(
+              scene,
+              raider.mesh.position,
+              tealMaterial,
+              collectedDroplets.length,
+            ),
           );
         }
       }
@@ -606,12 +681,20 @@ async function main(): Promise<void> {
     eruptionParticles = [];
     collectedDroplets = [];
 
-    const resetPoints = [new Vector3(-36, 0, -18), new Vector3(3, 0, 34), new Vector3(39, 0, -20)];
+    const resetPoints = [
+      new Vector3(-36, 0, -18),
+      new Vector3(3, 0, 34),
+      new Vector3(39, 0, -20),
+    ];
     sources.forEach((source, index) => {
-      source.position.copyFrom(surfacePoint(resetPoints[index].x, resetPoints[index].z, -0.8));
+      source.position.copyFrom(
+        surfacePoint(resetPoints[index].x, resetPoints[index].z, -0.8),
+      );
       source.vent.position.copyFrom(source.position);
       source.vent.setEnabled(true);
-      source.bulge.position.copyFrom(surfacePoint(resetPoints[index].x, resetPoints[index].z, -4));
+      source.bulge.position.copyFrom(
+        surfacePoint(resetPoints[index].x, resetPoints[index].z, -4),
+      );
       source.bulge.scaling.set(1, 0.08, 1);
       source.energy = 0.72 + index * 0.09;
       source.pressure = 0.25 + index * 0.1;
@@ -622,7 +705,7 @@ async function main(): Promise<void> {
       source.phase = "active";
     });
 
-    towers.forEach(tower => {
+    towers.forEach((tower) => {
       tower.firing = tower.tier > 1;
       tower.melted = false;
       tower.mesh.scaling.set(1, 1, 1);
@@ -631,7 +714,9 @@ async function main(): Promise<void> {
     });
     raiders.forEach((raider, index) => {
       const diameter = [6, 9, 14][index];
-      raider.mesh.position.copyFrom(surfacePoint(-46 + index * 34, 12 + index * 9, diameter / 2 + 0.4));
+      raider.mesh.position.copyFrom(
+        surfacePoint(-46 + index * 34, 12 + index * 9, diameter / 2 + 0.4),
+      );
       raider.velocity.set(0, 0, 0);
       raider.releasedEnergy = false;
     });
@@ -640,8 +725,9 @@ async function main(): Promise<void> {
     planet.mantleMaterial.alpha = 0.12;
     planet.coreMaterial.alpha = 0.22;
     connectTowers(scene, towers, sources, conduitMaterial);
-    towers.forEach(tower => {
-      if (!tower.supported && tower.tier > 1) tower.mesh.material = invalidMaterial;
+    towers.forEach((tower) => {
+      if (!tower.supported && tower.tier > 1)
+        tower.mesh.material = invalidMaterial;
     });
     updateButtons();
   };
@@ -686,20 +772,32 @@ async function main(): Promise<void> {
 
   let frame = 0;
   engine.runRenderLoop(() => {
-    const deltaSeconds = Math.min(MAX_FRAME_DELTA_SECONDS, engine.getDeltaTime() / 1000);
+    const deltaSeconds = Math.min(
+      MAX_FRAME_DELTA_SECONDS,
+      engine.getDeltaTime() / 1000,
+    );
 
-    sources.forEach(source => {
+    sources.forEach((source) => {
       source.drawRate = 0;
     });
 
-    towers.forEach(tower => {
+    towers.forEach((tower) => {
       if (tower.melted) {
-        tower.mesh.scaling.y += (0.22 - tower.mesh.scaling.y) * Math.min(1, deltaSeconds * 0.75);
+        tower.mesh.scaling.y +=
+          (0.22 - tower.mesh.scaling.y) * Math.min(1, deltaSeconds * 0.75);
         tower.mesh.rotation.z += deltaSeconds * 0.09;
         return;
       }
-      if (!globalFiring || !tower.firing || !tower.supported || tower.sourceId === null) return;
-      const source = sources.find(candidate => candidate.id === tower.sourceId);
+      if (
+        !globalFiring ||
+        !tower.firing ||
+        !tower.supported ||
+        tower.sourceId === null
+      )
+        return;
+      const source = sources.find(
+        (candidate) => candidate.id === tower.sourceId,
+      );
       if (!source || source.phase !== "active" || source.energy <= 0) return;
       const requested = towerDrawRate(tower.tier) * deltaSeconds;
       const actual = Math.min(source.energy, requested);
@@ -713,21 +811,33 @@ async function main(): Promise<void> {
       }
     });
 
-    sources.forEach(source => {
+    sources.forEach((source) => {
       if (source.phase === "active") {
-        source.energy = Math.min(1, source.energy + DEEP_REPLENISH_PER_SECOND * deltaSeconds);
-        if (source.energy < DEPLETED_THRESHOLD) source.depletedSeconds += deltaSeconds;
-        else source.depletedSeconds = Math.max(0, source.depletedSeconds - deltaSeconds * 0.5);
+        source.energy = Math.min(
+          1,
+          source.energy + DEEP_REPLENISH_PER_SECOND * deltaSeconds,
+        );
+        if (source.energy < DEPLETED_THRESHOLD)
+          source.depletedSeconds += deltaSeconds;
+        else
+          source.depletedSeconds = Math.max(
+            0,
+            source.depletedSeconds - deltaSeconds * 0.5,
+          );
 
         const quietRich = source.energy > 0.78 && source.drawRate < 0.003;
         if (quietRich) {
           const multiplier = acceleratedPressure ? 7 : 1;
           source.pressure = Math.min(
             1,
-            source.pressure + PRESSURE_BUILD_PER_SECOND * multiplier * deltaSeconds,
+            source.pressure +
+              PRESSURE_BUILD_PER_SECOND * multiplier * deltaSeconds,
           );
         } else if (source.drawRate > 0.008) {
-          source.pressure = Math.max(0.08, source.pressure - source.drawRate * 0.3 * deltaSeconds);
+          source.pressure = Math.max(
+            0.08,
+            source.pressure - source.drawRate * 0.3 * deltaSeconds,
+          );
         }
 
         if (source.depletedSeconds >= DEPLETION_RETREAT_SECONDS) {
@@ -736,12 +846,18 @@ async function main(): Promise<void> {
           source.vent.setEnabled(true);
           connectTowers(scene, towers, sources, conduitMaterial);
         }
-        if (source.pressure >= PRESSURE_ERUPTION_THRESHOLD && eruptionSourceId === null) {
+        if (
+          source.pressure >= PRESSURE_ERUPTION_THRESHOLD &&
+          eruptionSourceId === null
+        ) {
           startEruption(source);
         }
       } else if (source.phase === "retreating") {
         source.retreatSeconds += deltaSeconds;
-        source.vent.scaling.x = Math.max(0.05, 1 - source.retreatSeconds / RETREAT_SECONDS);
+        source.vent.scaling.x = Math.max(
+          0.05,
+          1 - source.retreatSeconds / RETREAT_SECONDS,
+        );
         source.vent.scaling.z = source.vent.scaling.x;
         source.vent.position.y -= deltaSeconds * 1.6;
         if (source.retreatSeconds >= RETREAT_SECONDS) {
@@ -749,16 +865,23 @@ async function main(): Promise<void> {
           source.vent.scaling.set(1, 0.35, 1);
           relocateSource(source, relocationIndex);
           connectTowers(scene, towers, sources, conduitMaterial);
-          towers.forEach(tower => {
-            tower.mesh.material = !tower.supported && tower.tier > 1 ? invalidMaterial : refs.defenderMaterial;
+          towers.forEach((tower) => {
+            tower.mesh.material =
+              !tower.supported && tower.tier > 1
+                ? invalidMaterial
+                : refs.defenderMaterial;
           });
         }
       } else if (source.phase === "erupting") {
         source.eruptionSeconds += deltaSeconds;
         source.energy = Math.max(0.08, source.energy - 0.055 * deltaSeconds);
         source.pressure = Math.max(0.08, source.pressure - 0.16 * deltaSeconds);
-        source.bulge.position.y += deltaSeconds * (source.eruptionSeconds < 1.4 ? 1.2 : -0.18);
-        source.bulge.scaling.y = Math.min(0.8, 0.15 + source.eruptionSeconds * 0.12);
+        source.bulge.position.y +=
+          deltaSeconds * (source.eruptionSeconds < 1.4 ? 1.2 : -0.18);
+        source.bulge.scaling.y = Math.min(
+          0.8,
+          0.15 + source.eruptionSeconds * 0.12,
+        );
         if (source.eruptionSeconds >= ERUPTION_SECONDS) {
           source.phase = "retreating";
           source.retreatSeconds = 0;
@@ -770,13 +893,23 @@ async function main(): Promise<void> {
       }
 
       const visibleEnergy = Math.max(0.12, source.energy);
-      source.vent.scaling.x = source.phase === "retreating" ? source.vent.scaling.x : 0.55 + visibleEnergy * 0.65;
+      source.vent.scaling.x =
+        source.phase === "retreating"
+          ? source.vent.scaling.x
+          : 0.55 + visibleEnergy * 0.65;
       source.vent.scaling.z = source.vent.scaling.x;
-      source.vent.scaling.y = source.phase === "erupting" ? 0.65 + source.pressure * 0.8 : 0.22 + source.pressure * 0.35;
+      source.vent.scaling.y =
+        source.phase === "erupting"
+          ? 0.65 + source.pressure * 0.8
+          : 0.22 + source.pressure * 0.35;
       const bulgePressure = Math.max(0, source.pressure - 0.58);
       if (source.phase === "active") {
         source.bulge.scaling.y = 0.08 + bulgePressure * 0.42;
-        source.bulge.position.y = surfaceY(source.position.x, source.position.z, -4 + bulgePressure * 2.2);
+        source.bulge.position.y = surfaceY(
+          source.position.x,
+          source.position.z,
+          -4 + bulgePressure * 2.2,
+        );
       }
     });
 
@@ -785,19 +918,27 @@ async function main(): Promise<void> {
       particle.age += deltaSeconds;
       particle.velocity.y -= 8.5 * deltaSeconds;
       particle.mesh.position.addInPlace(particle.velocity.scale(deltaSeconds));
-      const floor = surfaceY(particle.mesh.position.x, particle.mesh.position.z, 0.25);
+      const floor = surfaceY(
+        particle.mesh.position.x,
+        particle.mesh.position.z,
+        0.25,
+      );
       if (particle.mesh.position.y <= floor || particle.age > 4.2) {
         particle.mesh.dispose();
         eruptionParticles.splice(index, 1);
       }
     }
 
-    raiders.forEach(raider => {
+    raiders.forEach((raider) => {
       if (raider.velocity.lengthSquared() < 0.001) return;
       raider.velocity.y -= 7.5 * deltaSeconds;
       raider.mesh.position.addInPlace(raider.velocity.scale(deltaSeconds));
       const radius = raider.mesh.getBoundingInfo().boundingSphere.radiusWorld;
-      const floor = surfaceY(raider.mesh.position.x, raider.mesh.position.z, radius + 0.2);
+      const floor = surfaceY(
+        raider.mesh.position.x,
+        raider.mesh.position.z,
+        radius + 0.2,
+      );
       if (raider.mesh.position.y < floor) {
         raider.mesh.position.y = floor;
         raider.velocity.y *= -0.3;
@@ -822,10 +963,18 @@ async function main(): Promise<void> {
       const speed = 8 + Math.min(8, toSilo.length() * 0.08);
       droplet.mesh.position.x += horizontal.x * speed * deltaSeconds;
       droplet.mesh.position.z += horizontal.z * speed * deltaSeconds;
-      droplet.mesh.position.y = surfaceY(droplet.mesh.position.x, droplet.mesh.position.z, 0.55);
+      droplet.mesh.position.y = surfaceY(
+        droplet.mesh.position.x,
+        droplet.mesh.position.z,
+        0.55,
+      );
     }
 
-    const highlighted = eruptionSourceId === null ? sources[1] : sources.find(source => source.id === eruptionSourceId) ?? sources[1];
+    const highlighted =
+      eruptionSourceId === null
+        ? sources[1]
+        : (sources.find((source) => source.id === eruptionSourceId) ??
+          sources[1]);
     ventLight.position.copyFrom(highlighted.position.add(new Vector3(0, 3, 0)));
     ventLight.intensity = 0.18 + highlighted.pressure * 0.8;
 
@@ -833,11 +982,16 @@ async function main(): Promise<void> {
     frame += 1;
     if (frame % 10 === 0) {
       const sourceLines = sources.map(
-        source =>
+        (source) =>
           `S${source.id + 1} ${source.phase.padEnd(10)} energy ${(source.energy * 100).toFixed(0).padStart(3)}% pressure ${(source.pressure * 100).toFixed(0).padStart(3)}% draw ${source.drawRate.toFixed(3)}`,
       );
-      const supported = towers.filter(tower => tower.tier === 1 || tower.supported).length;
-      const firing = towers.filter(tower => tower.tier > 1 && tower.supported && !tower.melted && globalFiring).length;
+      const supported = towers.filter(
+        (tower) => tower.tier === 1 || tower.supported,
+      ).length;
+      const firing = towers.filter(
+        (tower) =>
+          tower.tier > 1 && tower.supported && !tower.melted && globalFiring,
+      ).length;
       metrics.textContent = [
         "Planetary geothermal / tower-power PoC",
         ...sourceLines,
@@ -871,7 +1025,9 @@ async function main(): Promise<void> {
     { once: true },
   );
 
-  (window as unknown as { __defendGeothermalPrototype?: unknown }).__defendGeothermalPrototype = {
+  (
+    window as unknown as { __defendGeothermalPrototype?: unknown }
+  ).__defendGeothermalPrototype = {
     sources,
     towers,
     raiders,

--- a/experiments/hybrid-engine/src/geothermalPrototype.ts
+++ b/experiments/hybrid-engine/src/geothermalPrototype.ts
@@ -597,8 +597,12 @@ async function main(): Promise<void> {
     relocationIndex = 0;
     collectedFromEruptions = 0;
     eruptionSourceId = null;
-    eruptionParticles.forEach(particle => particle.mesh.dispose());
-    collectedDroplets.forEach(droplet => droplet.mesh.dispose());
+    eruptionParticles.forEach((particle) => {
+      particle.mesh.dispose();
+    });
+    collectedDroplets.forEach((droplet) => {
+      droplet.mesh.dispose();
+    });
     eruptionParticles = [];
     collectedDroplets = [];
 

--- a/experiments/hybrid-engine/src/main.ts
+++ b/experiments/hybrid-engine/src/main.ts
@@ -57,7 +57,11 @@ async function main(): Promise<void> {
   camera.lowerRadiusLimit = 48;
   camera.upperRadiusLimit = 180;
 
-  const light = new HemisphericLight("ambient", new Vector3(0.2, 1, 0.1), scene);
+  const light = new HemisphericLight(
+    "ambient",
+    new Vector3(0.2, 1, 0.1),
+    scene,
+  );
   light.intensity = 0.8;
 
   const coreMaterial = new StandardMaterial("coreMaterial", scene);
@@ -82,7 +86,10 @@ async function main(): Promise<void> {
   bodyTemplate.isVisible = false;
 
   const runtime = new DefendRuntime();
-  const bodyInstances = new Map<number, ReturnType<typeof bodyTemplate.createInstance>>();
+  const bodyInstances = new Map<
+    number,
+    ReturnType<typeof bodyTemplate.createInstance>
+  >();
 
   for (let index = 0; index < BODY_COUNT; index += 1) {
     const angle = (index / BODY_COUNT) * Math.PI * 2;
@@ -110,7 +117,10 @@ async function main(): Promise<void> {
   }
 
   const snapshotIds = Array.from(runtime.body_ids());
-  if (snapshotIds.length !== BODY_COUNT || snapshotIds.some((id) => !bodyInstances.has(id))) {
+  if (
+    snapshotIds.length !== BODY_COUNT ||
+    snapshotIds.some((id) => !bodyInstances.has(id))
+  ) {
     throw new Error("Hybrid runtime body identity contract is inconsistent");
   }
 
@@ -147,17 +157,25 @@ async function main(): Promise<void> {
 
     const positions = runtime.positions();
     if (positions.length !== snapshotIds.length * 3) {
-      throw new Error("Hybrid runtime position snapshot changed without a lifecycle event");
+      throw new Error(
+        "Hybrid runtime position snapshot changed without a lifecycle event",
+      );
     }
 
     snapshotBytes = positions.length * Float32Array.BYTES_PER_ELEMENT;
     for (let index = 0; index < snapshotIds.length; index += 1) {
       const body = bodyInstances.get(snapshotIds[index]);
       if (!body) {
-        throw new Error(`Missing Babylon instance for body ${snapshotIds[index]}`);
+        throw new Error(
+          `Missing Babylon instance for body ${snapshotIds[index]}`,
+        );
       }
       const offset = index * 3;
-      body.position.set(positions[offset], positions[offset + 1], positions[offset + 2]);
+      body.position.set(
+        positions[offset],
+        positions[offset + 1],
+        positions[offset + 2],
+      );
     }
 
     scene.render();

--- a/experiments/hybrid-engine/src/main.ts
+++ b/experiments/hybrid-engine/src/main.ts
@@ -12,9 +12,9 @@ import {
 } from "@babylonjs/core/pure";
 import initRuntime, { DefendRuntime } from "../pkg/defend_hybrid_runtime.js";
 import {
-  INITIAL_FIXED_STEP_STATE,
   advanceFixedStep,
   type FixedStepPolicy,
+  INITIAL_FIXED_STEP_STATE,
 } from "./fixedStep";
 
 // "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but

--- a/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
@@ -315,7 +315,10 @@ function resetState(state: NavigationState, root: TransformNode): void {
   state.reserve = START_RESERVE;
   state.velocity.set(0, 0, 0);
   state.raidSector.set(52, 0.16, 42);
-  const initialTarget = desiredShipPositionForSector(state.raidSector, START_POSITION);
+  const initialTarget = desiredShipPositionForSector(
+    state.raidSector,
+    START_POSITION,
+  );
   state.desiredPosition.copyFrom(initialTarget.desired);
   state.cameraAnchor.copyFrom(START_POSITION);
   state.phase = "stable";
@@ -349,7 +352,8 @@ function setTargetSector(
 
 function siloAttraction(position: Vector3, phase: NavigationPhase): Vector3 {
   const distance = horizontalDistance(position);
-  if (distance >= SILO_WARNING_RADIUS || distance < 0.001) return Vector3.Zero();
+  if (distance >= SILO_WARNING_RADIUS || distance < 0.001)
+    return Vector3.Zero();
 
   const inward = new Vector3(-position.x, 0, -position.z).normalize();
   const normalized = 1 - distance / SILO_WARNING_RADIUS;
@@ -375,8 +379,11 @@ function movementAcceleration(
   const desiredDirection = error.normalize();
   const desiredSpeed = Math.min(MAX_SPEED, Math.max(4, distance * 0.38));
   const desiredVelocity = desiredDirection.scale(desiredSpeed);
-  const correction = desiredVelocity.subtract(new Vector3(velocity.x, 0, velocity.z));
-  if (correction.length() > MAX_ACCELERATION) correction.normalize().scaleInPlace(MAX_ACCELERATION);
+  const correction = desiredVelocity.subtract(
+    new Vector3(velocity.x, 0, velocity.z),
+  );
+  if (correction.length() > MAX_ACCELERATION)
+    correction.normalize().scaleInPlace(MAX_ACCELERATION);
   return correction;
 }
 
@@ -389,7 +396,9 @@ function updateCamera(
   if (state.cameraMode === "raider") {
     const followTarget = root.position.add(new Vector3(0, -5, 0));
     const smoothing = 1 - Math.exp(-deltaSeconds * 4.2);
-    state.cameraAnchor.copyFrom(Vector3.Lerp(state.cameraAnchor, followTarget, smoothing));
+    state.cameraAnchor.copyFrom(
+      Vector3.Lerp(state.cameraAnchor, followTarget, smoothing),
+    );
     camera.setTarget(state.cameraAnchor);
     camera.radius += (64 - camera.radius) * Math.min(1, deltaSeconds * 2.2);
     camera.beta += (0.93 - camera.beta) * Math.min(1, deltaSeconds * 1.4);
@@ -405,11 +414,21 @@ async function main(): Promise<void> {
   const nearButton = document.querySelector<HTMLButtonElement>("#near");
   const farButton = document.querySelector<HTMLButtonElement>("#far");
   const cameraButton = document.querySelector<HTMLButtonElement>("#camera");
-  if (!canvas || !metrics || !resetButton || !nearButton || !farButton || !cameraButton) {
+  if (
+    !canvas ||
+    !metrics ||
+    !resetButton ||
+    !nearButton ||
+    !farButton ||
+    !cameraButton
+  ) {
     throw new Error("Navigation lab DOM is incomplete");
   }
 
-  const engine = new Engine(canvas, true, { adaptToDeviceRatio: true, antialias: true });
+  const engine = new Engine(canvas, true, {
+    adaptToDeviceRatio: true,
+    antialias: true,
+  });
   const scene = new Scene(engine);
   scene.clearColor.set(0.02, 0.012, 0.034, 1);
 
@@ -427,12 +446,20 @@ async function main(): Promise<void> {
   camera.lowerBetaLimit = 0.35;
   camera.upperBetaLimit = 2.2;
 
-  const ambient = new HemisphericLight("navigation-ambient", new Vector3(0.15, 1, 0.2), scene);
+  const ambient = new HemisphericLight(
+    "navigation-ambient",
+    new Vector3(0.15, 1, 0.2),
+    scene,
+  );
   ambient.intensity = 0.74;
 
   const arena = createArena(scene);
   const mothership = createMothership(scene);
-  const coreLight = new PointLight("navigation-core-light", START_POSITION, scene);
+  const coreLight = new PointLight(
+    "navigation-core-light",
+    START_POSITION,
+    scene,
+  );
   coreLight.diffuse = new Color3(0.1, 0.92, 0.88);
   coreLight.intensity = 0.7;
   coreLight.range = 62;
@@ -451,8 +478,18 @@ async function main(): Promise<void> {
     new Color3(0.18, 0.07, 0.01),
     0.7,
   );
-  const raidMarker = createMarker("raid-sector-marker", scene, raidMarkerMaterial, 7);
-  const desiredMarker = createMarker("ship-target-marker", scene, desiredMarkerMaterial, 5);
+  const raidMarker = createMarker(
+    "raid-sector-marker",
+    scene,
+    raidMarkerMaterial,
+    7,
+  );
+  const desiredMarker = createMarker(
+    "ship-target-marker",
+    scene,
+    desiredMarkerMaterial,
+    5,
+  );
 
   const state: NavigationState = {
     reserve: START_RESERVE,
@@ -467,7 +504,13 @@ async function main(): Promise<void> {
     elapsedSeconds: 0,
   };
   resetState(state, mothership.root);
-  setTargetSector(state, mothership.root, raidMarker, desiredMarker, state.raidSector);
+  setTargetSector(
+    state,
+    mothership.root,
+    raidMarker,
+    desiredMarker,
+    state.raidSector,
+  );
 
   let inspectable: { dispose(): void } | undefined;
   if (new URLSearchParams(location.search).has("inspect")) {
@@ -476,12 +519,19 @@ async function main(): Promise<void> {
   }
 
   const updateCameraButton = () => {
-    cameraButton.textContent = state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
+    cameraButton.textContent =
+      state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
   };
 
   const doReset = () => {
     resetState(state, mothership.root);
-    setTargetSector(state, mothership.root, raidMarker, desiredMarker, state.raidSector);
+    setTargetSector(
+      state,
+      mothership.root,
+      raidMarker,
+      desiredMarker,
+      state.raidSector,
+    );
     camera.alpha = -Math.PI / 2.1;
     camera.beta = 0.93;
     camera.radius = 64;
@@ -489,10 +539,22 @@ async function main(): Promise<void> {
   };
 
   const setNearTarget = () => {
-    setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(4, 0, 3));
+    setTargetSector(
+      state,
+      mothership.root,
+      raidMarker,
+      desiredMarker,
+      new Vector3(4, 0, 3),
+    );
   };
   const setFarTarget = () => {
-    setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(-66, 0, 46));
+    setTargetSector(
+      state,
+      mothership.root,
+      raidMarker,
+      desiredMarker,
+      new Vector3(-66, 0, 46),
+    );
   };
   const toggleCamera = () => {
     state.cameraMode = state.cameraMode === "raider" ? "defender" : "raider";
@@ -514,8 +576,18 @@ async function main(): Promise<void> {
   cameraButton.addEventListener("click", toggleCamera);
 
   scene.onPointerDown = (_event, pickInfo) => {
-    if (pickInfo.hit && pickInfo.pickedPoint && pickInfo.pickedMesh === arena.ground) {
-      setTargetSector(state, mothership.root, raidMarker, desiredMarker, pickInfo.pickedPoint);
+    if (
+      pickInfo.hit &&
+      pickInfo.pickedPoint &&
+      pickInfo.pickedMesh === arena.ground
+    ) {
+      setTargetSector(
+        state,
+        mothership.root,
+        raidMarker,
+        desiredMarker,
+        pickInfo.pickedPoint,
+      );
     }
   };
 
@@ -529,7 +601,10 @@ async function main(): Promise<void> {
 
   let frame = 0;
   engine.runRenderLoop(() => {
-    const deltaSeconds = Math.min(MAX_FRAME_DELTA_SECONDS, engine.getDeltaTime() / 1000);
+    const deltaSeconds = Math.min(
+      MAX_FRAME_DELTA_SECONDS,
+      engine.getDeltaTime() / 1000,
+    );
     state.elapsedSeconds += deltaSeconds;
 
     if (state.phase !== "captured") {
@@ -549,13 +624,21 @@ async function main(): Promise<void> {
         new Vector3(state.velocity.x, 0, state.velocity.z),
         horizontalDirection(mothership.root.position, new Vector3(1, 0, 0)),
       );
-      if (horizontalDistance(mothership.root.position) < SILO_CRITICAL_RADIUS * 0.55 && inwardSpeed > 3) {
+      if (
+        horizontalDistance(mothership.root.position) <
+          SILO_CRITICAL_RADIUS * 0.55 &&
+        inwardSpeed > 3
+      ) {
         state.phase = "captured";
       }
     }
 
     if (state.phase === "captured") {
-      const inward = new Vector3(-mothership.root.position.x, -10, -mothership.root.position.z);
+      const inward = new Vector3(
+        -mothership.root.position.x,
+        -10,
+        -mothership.root.position.z,
+      );
       if (inward.lengthSquared() > 0.001) {
         inward.normalize().scaleInPlace(CAPTURE_PULL_STRENGTH * 1.35);
         acceleration.copyFrom(inward);
@@ -566,7 +649,8 @@ async function main(): Promise<void> {
     const damping = Math.exp(-LINEAR_DAMPING * deltaSeconds);
     state.velocity.x *= damping;
     state.velocity.z *= damping;
-    state.velocity.y = state.phase === "captured" ? state.velocity.y - 8 * deltaSeconds : 0;
+    state.velocity.y =
+      state.phase === "captured" ? state.velocity.y - 8 * deltaSeconds : 0;
 
     const horizontalSpeed = Math.sqrt(
       state.velocity.x * state.velocity.x + state.velocity.z * state.velocity.z,
@@ -578,12 +662,17 @@ async function main(): Promise<void> {
     }
 
     mothership.root.position.addInPlace(state.velocity.scale(deltaSeconds));
-    if (state.phase !== "captured") mothership.root.position.y = START_POSITION.y;
+    if (state.phase !== "captured")
+      mothership.root.position.y = START_POSITION.y;
     else mothership.root.position.y = Math.max(15, mothership.root.position.y);
 
-    const movementDrain = acceleration.length() * MOVEMENT_DRAIN_PER_ACCEL * deltaSeconds;
+    const movementDrain =
+      acceleration.length() * MOVEMENT_DRAIN_PER_ACCEL * deltaSeconds;
     state.totalMovementEnergy += movementDrain;
-    state.reserve = Math.max(0, state.reserve - HOVER_DRAIN_PER_SECOND * deltaSeconds - movementDrain);
+    state.reserve = Math.max(
+      0,
+      state.reserve - HOVER_DRAIN_PER_SECOND * deltaSeconds - movementDrain,
+    );
 
     const reserveScale = Math.max(0.3, Math.sqrt(state.reserve));
     mothership.core.scaling.set(reserveScale, reserveScale, reserveScale);
@@ -596,16 +685,35 @@ async function main(): Promise<void> {
     coreLight.intensity = 0.2 + state.reserve * 0.62;
 
     const speed = state.velocity.length();
-    const targetHeading = speed > 0.3 ? Math.atan2(state.velocity.x, state.velocity.z) : mothership.root.rotation.y;
-    mothership.root.rotation.y += (targetHeading - mothership.root.rotation.y) * Math.min(1, deltaSeconds * 1.8);
-    const stress = state.phase === "warning" ? 0.025 : state.phase === "critical" ? 0.06 : state.phase === "captured" ? 0.12 : 0.008;
-    mothership.root.rotation.z = Math.sin(state.elapsedSeconds * 1.8) * stress + state.velocity.x * -0.003;
-    mothership.root.rotation.x = Math.cos(state.elapsedSeconds * 1.4) * stress + state.velocity.z * 0.002;
+    const targetHeading =
+      speed > 0.3
+        ? Math.atan2(state.velocity.x, state.velocity.z)
+        : mothership.root.rotation.y;
+    mothership.root.rotation.y +=
+      (targetHeading - mothership.root.rotation.y) *
+      Math.min(1, deltaSeconds * 1.8);
+    const stress =
+      state.phase === "warning"
+        ? 0.025
+        : state.phase === "critical"
+          ? 0.06
+          : state.phase === "captured"
+            ? 0.12
+            : 0.008;
+    mothership.root.rotation.z =
+      Math.sin(state.elapsedSeconds * 1.8) * stress + state.velocity.x * -0.003;
+    mothership.root.rotation.x =
+      Math.cos(state.elapsedSeconds * 1.4) * stress + state.velocity.z * 0.002;
 
     const distanceToSilo = horizontalDistance(mothership.root.position);
-    arena.warningRing.scaling.setAll(1 + Math.sin(state.elapsedSeconds * 2.2) * 0.01);
-    arena.criticalRing.scaling.setAll(1 + Math.sin(state.elapsedSeconds * 3.3) * 0.025);
-    arena.siloCore.scaling.y = 1 + Math.max(0, 1 - distanceToSilo / SILO_WARNING_RADIUS) * 0.45;
+    arena.warningRing.scaling.setAll(
+      1 + Math.sin(state.elapsedSeconds * 2.2) * 0.01,
+    );
+    arena.criticalRing.scaling.setAll(
+      1 + Math.sin(state.elapsedSeconds * 3.3) * 0.025,
+    );
+    arena.siloCore.scaling.y =
+      1 + Math.max(0, 1 - distanceToSilo / SILO_WARNING_RADIUS) * 0.45;
 
     updateCamera(camera, state, mothership.root, deltaSeconds);
     scene.render();
@@ -651,10 +759,18 @@ async function main(): Promise<void> {
     { once: true },
   );
 
-  (window as unknown as { __defendMothershipNavigation?: unknown }).__defendMothershipNavigation = {
+  (
+    window as unknown as { __defendMothershipNavigation?: unknown }
+  ).__defendMothershipNavigation = {
     state,
     setSector: (x: number, z: number) =>
-      setTargetSector(state, mothership.root, raidMarker, desiredMarker, new Vector3(x, 0, z)),
+      setTargetSector(
+        state,
+        mothership.root,
+        raidMarker,
+        desiredMarker,
+        new Vector3(x, 0, z),
+      ),
   };
 }
 

--- a/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipNavigationPrototype.ts
@@ -3,7 +3,7 @@ import {
   Color3,
   Engine,
   HemisphericLight,
-  Mesh,
+  type Mesh,
   MeshBuilder,
   PointLight,
   RegisterStandardEngineExtensions,

--- a/experiments/hybrid-engine/src/mothershipPrototype.ts
+++ b/experiments/hybrid-engine/src/mothershipPrototype.ts
@@ -17,7 +17,12 @@ import {
 // what this prototype uses explicitly, or the failure only appears in a browser.
 RegisterStandardEngineExtensions();
 
-type MothershipPhase = "stable" | "low-reserve" | "critical" | "falling" | "hulk";
+type MothershipPhase =
+  | "stable"
+  | "low-reserve"
+  | "critical"
+  | "falling"
+  | "hulk";
 type CameraMode = "raider" | "defender";
 
 const START_RESERVE = 1;
@@ -202,7 +207,8 @@ function createMothership(scene: Scene) {
     );
     node.parent = root;
     node.position.copyFrom(position);
-    node.material = index % 3 === 0 ? activeStructureMaterial : structureMaterial;
+    node.material =
+      index % 3 === 0 ? activeStructureMaterial : structureMaterial;
     return node;
   });
 
@@ -315,7 +321,11 @@ function createArena(scene: Scene) {
   });
 }
 
-function setCameraMode(camera: ArcRotateCamera, mode: CameraMode, target: Vector3): void {
+function setCameraMode(
+  camera: ArcRotateCamera,
+  mode: CameraMode,
+  target: Vector3,
+): void {
   if (mode === "raider") {
     camera.alpha = -Math.PI / 2.2;
     camera.beta = 0.9;
@@ -351,7 +361,14 @@ async function main(): Promise<void> {
   const fastButton = document.querySelector<HTMLButtonElement>("#fast");
   const cameraButton = document.querySelector<HTMLButtonElement>("#camera");
 
-  if (!canvas || !metrics || !resetButton || !pauseButton || !fastButton || !cameraButton) {
+  if (
+    !canvas ||
+    !metrics ||
+    !resetButton ||
+    !pauseButton ||
+    !fastButton ||
+    !cameraButton
+  ) {
     throw new Error("Mothership lab DOM is incomplete");
   }
 
@@ -383,7 +400,11 @@ async function main(): Promise<void> {
   );
   ambient.intensity = 0.72;
 
-  const coreLight = new PointLight("core-light", new Vector3(0, START_ALTITUDE, 0), scene);
+  const coreLight = new PointLight(
+    "core-light",
+    new Vector3(0, START_ALTITUDE, 0),
+    scene,
+  );
   coreLight.diffuse = new Color3(0.12, 0.9, 0.88);
   coreLight.intensity = 0.65;
   coreLight.range = 62;
@@ -412,9 +433,14 @@ async function main(): Promise<void> {
   }
 
   const updateButtons = () => {
-    pauseButton.textContent = state.paused ? "Resume drain [Space]" : "Pause drain [Space]";
-    fastButton.textContent = state.fastDrain ? "Normal drain [F]" : "Fast drain [F]";
-    cameraButton.textContent = state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
+    pauseButton.textContent = state.paused
+      ? "Resume drain [Space]"
+      : "Pause drain [Space]";
+    fastButton.textContent = state.fastDrain
+      ? "Normal drain [F]"
+      : "Fast drain [F]";
+    cameraButton.textContent =
+      state.cameraMode === "raider" ? "Defender view [C]" : "Raider view [C]";
   };
 
   const doReset = () => {
@@ -468,7 +494,9 @@ async function main(): Promise<void> {
     if (!state.paused && state.phase !== "hulk") {
       const drainMultiplier = state.fastDrain ? FAST_DRAIN_MULTIPLIER : 1;
       const drainRate =
-        state.phase === "falling" ? FALL_DRAIN_PER_SECOND : HOVER_DRAIN_PER_SECOND;
+        state.phase === "falling"
+          ? FALL_DRAIN_PER_SECOND
+          : HOVER_DRAIN_PER_SECOND;
       state.reserve = Math.max(
         0,
         state.reserve - drainRate * drainMultiplier * deltaSeconds,
@@ -505,7 +533,10 @@ async function main(): Promise<void> {
     } else if (state.phase !== "hulk") {
       const liftFraction = Math.max(
         0,
-        Math.min(1, (state.reserve - FALL_RESERVE) / (START_RESERVE - FALL_RESERVE)),
+        Math.min(
+          1,
+          (state.reserve - FALL_RESERVE) / (START_RESERVE - FALL_RESERVE),
+        ),
       );
       const depletion = 1 - liftFraction;
       const targetAltitude = START_ALTITUDE - depletion * 12;
@@ -513,7 +544,8 @@ async function main(): Promise<void> {
       const damping = 1.1 + liftFraction * 3.1;
       const wobbleAmplitude = 0.08 + depletion * depletion * 1.5;
       const wobble =
-        Math.sin(state.elapsedSeconds * (1.2 + depletion * 1.8)) * wobbleAmplitude;
+        Math.sin(state.elapsedSeconds * (1.2 + depletion * 1.8)) *
+        wobbleAmplitude;
       const acceleration =
         (targetAltitude - mothership.root.position.y) * stiffness -
         state.verticalVelocity * damping +
@@ -523,8 +555,10 @@ async function main(): Promise<void> {
       mothership.root.position.y += state.verticalVelocity * deltaSeconds;
 
       const orientationAmplitude = depletion * depletion * 0.14;
-      const targetPitch = Math.sin(state.elapsedSeconds * 0.72) * orientationAmplitude;
-      const targetRoll = Math.cos(state.elapsedSeconds * 0.58) * orientationAmplitude;
+      const targetPitch =
+        Math.sin(state.elapsedSeconds * 0.72) * orientationAmplitude;
+      const targetRoll =
+        Math.cos(state.elapsedSeconds * 0.58) * orientationAmplitude;
       const correction = Math.max(0.35, 2.6 * liftFraction) * deltaSeconds;
       mothership.root.rotation.x +=
         (targetPitch - mothership.root.rotation.x) * correction;
@@ -538,7 +572,8 @@ async function main(): Promise<void> {
       state.angularVelocity.set(0.22, 0.08, -0.16);
     }
 
-    const visibleReserve = state.phase === "hulk" ? Math.min(state.reserve, 0.025) : state.reserve;
+    const visibleReserve =
+      state.phase === "hulk" ? Math.min(state.reserve, 0.025) : state.reserve;
     const coreScale = 0.26 + Math.cbrt(Math.max(0, visibleReserve)) * 0.74;
     mothership.core.scaling.set(coreScale, coreScale, coreScale);
 
@@ -553,7 +588,8 @@ async function main(): Promise<void> {
       0.17 + visibleReserve * 0.41,
     );
 
-    const structureEnergy = state.phase === "hulk" ? 0.02 : Math.max(0.03, state.reserve);
+    const structureEnergy =
+      state.phase === "hulk" ? 0.02 : Math.max(0.03, state.reserve);
     mothership.activeStructureMaterial.emissiveColor.set(
       0.01,
       0.04 + structureEnergy * 0.15,
@@ -566,7 +602,8 @@ async function main(): Promise<void> {
     );
 
     coreLight.position.copyFrom(mothership.root.position);
-    coreLight.intensity = state.phase === "hulk" ? 0.05 : 0.12 + state.reserve * 0.72;
+    coreLight.intensity =
+      state.phase === "hulk" ? 0.05 : 0.12 + state.reserve * 0.72;
 
     if (state.cameraMode === "raider") {
       const target = mothership.root.position.clone();

--- a/experiments/hybrid-engine/src/raidPlanPrototype.ts
+++ b/experiments/hybrid-engine/src/raidPlanPrototype.ts
@@ -148,7 +148,11 @@ panel.id = "raid-plan-lab";
 panel.setAttribute("aria-label", "Three-set raid planning prototype");
 document.body.appendChild(panel);
 
-function tierControls(planIndex: number, tier: RaiderTier, value: number): string {
+function tierControls(
+  planIndex: number,
+  tier: RaiderTier,
+  value: number,
+): string {
   return `
     <div class="tier-row">
       <span>R${tier}</span>
@@ -164,7 +168,10 @@ function render(): void {
   const currentSector = api
     ? `${api.state.raidSector.x.toFixed(1)}, ${api.state.raidSector.z.toFixed(1)}`
     : "navigation initializing";
-  const totalCommitment = plans.reduce((sum, plan) => sum + commitment(plan), 0);
+  const totalCommitment = plans.reduce(
+    (sum, plan) => sum + commitment(plan),
+    0,
+  );
 
   panel.innerHTML = `
     <header>
@@ -200,7 +207,7 @@ function render(): void {
   `;
 }
 
-panel.addEventListener("click", event => {
+panel.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLButtonElement)) return;
   const action = target.dataset.action;
@@ -235,7 +242,9 @@ function refreshCurrentSector(): void {
 render();
 requestAnimationFrame(refreshCurrentSector);
 
-(window as unknown as { __defendRaidPlanPrototype?: unknown }).__defendRaidPlanPrototype = {
+(
+  window as unknown as { __defendRaidPlanPrototype?: unknown }
+).__defendRaidPlanPrototype = {
   plans,
   advanceQueue,
   useCurrentSector,

--- a/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
+++ b/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
@@ -98,11 +98,7 @@ function createObstacle(
   health: number,
   breakable: boolean,
 ): Obstacle {
-  const mesh = MeshBuilder.CreateBox(
-    id,
-    { width, depth, height },
-    scene,
-  );
+  const mesh = MeshBuilder.CreateBox(id, { width, depth, height }, scene);
   mesh.position.set(x, height / 2 + terrainHeight(z), z);
   mesh.material = obstacleMaterial;
   return {
@@ -220,7 +216,11 @@ function createArena(scene: Scene) {
     { width: 125, depth: 10, height: 0.15 },
     scene,
   );
-  valley.position.set(0, terrainHeight(TERRAIN_VALLEY_Z) - 0.15, TERRAIN_VALLEY_Z);
+  valley.position.set(
+    0,
+    terrainHeight(TERRAIN_VALLEY_Z) - 0.15,
+    TERRAIN_VALLEY_Z,
+  );
   valley.material = valleyMaterial;
 
   const siloMaterial = material(
@@ -269,23 +269,103 @@ function createFortress(scene: Scene) {
   );
 
   const obstacles: Obstacle[] = [
-    createObstacle(scene, "wall-south", WALL_X, -43, 6, 18, 8, wallMaterial, 9999, false),
-    createObstacle(scene, "wall-mid", WALL_X, -12, 6, 28, 8, wallMaterial, 9999, false),
-    createObstacle(scene, "wall-north", WALL_X, 37, 6, 30, 8, wallMaterial, 9999, false),
-    createObstacle(scene, "broad-gate", WALL_X, BROAD_GATE_Z, 6, 20, 8, gateMaterial, 900, true),
+    createObstacle(
+      scene,
+      "wall-south",
+      WALL_X,
+      -43,
+      6,
+      18,
+      8,
+      wallMaterial,
+      9999,
+      false,
+    ),
+    createObstacle(
+      scene,
+      "wall-mid",
+      WALL_X,
+      -12,
+      6,
+      28,
+      8,
+      wallMaterial,
+      9999,
+      false,
+    ),
+    createObstacle(
+      scene,
+      "wall-north",
+      WALL_X,
+      37,
+      6,
+      30,
+      8,
+      wallMaterial,
+      9999,
+      false,
+    ),
+    createObstacle(
+      scene,
+      "broad-gate",
+      WALL_X,
+      BROAD_GATE_Z,
+      6,
+      20,
+      8,
+      gateMaterial,
+      900,
+      true,
+    ),
   ];
 
   const sideWalls = [
-    createObstacle(scene, "north-return", 38, 52, 46, 5, 7, wallMaterial, 9999, false),
-    createObstacle(scene, "south-return", 38, -52, 46, 5, 7, wallMaterial, 9999, false),
-    createObstacle(scene, "east-return", 61, 0, 5, 104, 7, wallMaterial, 9999, false),
+    createObstacle(
+      scene,
+      "north-return",
+      38,
+      52,
+      46,
+      5,
+      7,
+      wallMaterial,
+      9999,
+      false,
+    ),
+    createObstacle(
+      scene,
+      "south-return",
+      38,
+      -52,
+      46,
+      5,
+      7,
+      wallMaterial,
+      9999,
+      false,
+    ),
+    createObstacle(
+      scene,
+      "east-return",
+      61,
+      0,
+      5,
+      104,
+      7,
+      wallMaterial,
+      9999,
+      false,
+    ),
   ];
   obstacles.push(...sideWalls);
 
   return obstacles;
 }
 
-function createRaiderMaterial(scene: Scene, tier: RaiderTier): StandardMaterial {
+function createRaiderMaterial(
+  scene: Scene,
+  tier: RaiderTier,
+): StandardMaterial {
   const diffuse = [
     new Color3(0.22, 0.05, 0.34),
     new Color3(0.27, 0.055, 0.4),
@@ -327,10 +407,21 @@ function spawnRaiders(scene: Scene): RaiderBody[] {
 }
 
 function raiderDecision(body: RaiderBody, obstacles: Obstacle[]): Vector3 {
-  const direct = normalize2(SILO.x - body.mesh.position.x, SILO.z - body.mesh.position.z);
+  const direct = normalize2(
+    SILO.x - body.mesh.position.x,
+    SILO.z - body.mesh.position.z,
+  );
 
   if (body.tier === 1) {
-    return bestOpenDirection(body.mesh.position, body.radius + 0.25, SILO, obstacles, 4.4) ?? direct;
+    return (
+      bestOpenDirection(
+        body.mesh.position,
+        body.radius + 0.25,
+        SILO,
+        obstacles,
+        4.4,
+      ) ?? direct
+    );
   }
 
   if (body.tier === 2) {
@@ -341,11 +432,25 @@ function raiderDecision(body: RaiderBody, obstacles: Obstacle[]): Vector3 {
       obstacles,
     );
     if (blocker?.breakable) return direct;
-    return bestOpenDirection(body.mesh.position, body.radius + 0.35, SILO, obstacles, 5.2) ?? direct;
+    return (
+      bestOpenDirection(
+        body.mesh.position,
+        body.radius + 0.35,
+        SILO,
+        obstacles,
+        5.2,
+      ) ?? direct
+    );
   }
 
-  const downhillBias = normalize2(0, (TERRAIN_VALLEY_Z - body.mesh.position.z) * 0.28);
-  return normalize2(direct.x + downhillBias.x * 0.3, direct.z + downhillBias.z * 0.3);
+  const downhillBias = normalize2(
+    0,
+    (TERRAIN_VALLEY_Z - body.mesh.position.z) * 0.28,
+  );
+  return normalize2(
+    direct.x + downhillBias.x * 0.3,
+    direct.z + downhillBias.z * 0.3,
+  );
 }
 
 function applyObstacleImpact(body: RaiderBody, obstacle: Obstacle): void {
@@ -353,7 +458,10 @@ function applyObstacleImpact(body: RaiderBody, obstacle: Obstacle): void {
   if (obstacle.breakable) {
     const speed = Math.hypot(body.velocity.x, body.velocity.z);
     const tierImpulse = body.tier === 1 ? 6 : body.tier === 2 ? 26 : 68;
-    obstacle.health = Math.max(0, obstacle.health - tierImpulse * Math.max(0.5, speed));
+    obstacle.health = Math.max(
+      0,
+      obstacle.health - tierImpulse * Math.max(0.5, speed),
+    );
     const remaining = obstacle.health / obstacle.maxHealth;
     obstacle.mesh.scaling.y = Math.max(0.15, remaining);
     obstacle.mesh.position.y =
@@ -369,7 +477,11 @@ function applyObstacleImpact(body: RaiderBody, obstacle: Obstacle): void {
   body.state = "blocked";
 }
 
-function updateRaider(body: RaiderBody, obstacles: Obstacle[], deltaSeconds: number): void {
+function updateRaider(
+  body: RaiderBody,
+  obstacles: Obstacle[],
+  deltaSeconds: number,
+): void {
   if (body.state === "reached") return;
 
   const cadence = body.tier === 1 ? 0.16 : body.tier === 2 ? 0.42 : 0.9;
@@ -384,7 +496,10 @@ function updateRaider(body: RaiderBody, obstacles: Obstacle[], deltaSeconds: num
   body.velocity.x += body.desired.x * acceleration * deltaSeconds;
   body.velocity.z += body.desired.z * acceleration * deltaSeconds;
 
-  const damping = Math.max(0, 1 - (body.tier === 1 ? 1.8 : body.tier === 2 ? 0.9 : 0.35) * deltaSeconds);
+  const damping = Math.max(
+    0,
+    1 - (body.tier === 1 ? 1.8 : body.tier === 2 ? 0.9 : 0.35) * deltaSeconds,
+  );
   body.velocity.scaleInPlace(damping);
   const speed = Math.hypot(body.velocity.x, body.velocity.z);
   if (speed > maxSpeed) {
@@ -430,7 +545,11 @@ function createEnergyMaterial(scene: Scene): StandardMaterial {
   return result;
 }
 
-function spawnEnergy(scene: Scene, packets: EnergyPacket[], energyMaterial: StandardMaterial): void {
+function spawnEnergy(
+  scene: Scene,
+  packets: EnergyPacket[],
+  energyMaterial: StandardMaterial,
+): void {
   const offsets = [-4, -2, 0, 2, 4];
   offsets.forEach((offset, index) => {
     const mesh = MeshBuilder.CreateSphere(
@@ -455,8 +574,14 @@ function spawnEnergy(scene: Scene, packets: EnergyPacket[], energyMaterial: Stan
   });
 }
 
-function energyDirection(packet: EnergyPacket, obstacles: Obstacle[]): Vector3 | undefined {
-  const direct = normalize2(SILO.x - packet.mesh.position.x, SILO.z - packet.mesh.position.z);
+function energyDirection(
+  packet: EnergyPacket,
+  obstacles: Obstacle[],
+): Vector3 | undefined {
+  const direct = normalize2(
+    SILO.x - packet.mesh.position.x,
+    SILO.z - packet.mesh.position.z,
+  );
   const candidates = candidateDirections(direct)
     .filter((candidate) => {
       const x = packet.mesh.position.x + candidate.x * 3.2;
@@ -471,7 +596,11 @@ function energyDirection(packet: EnergyPacket, obstacles: Obstacle[]): Vector3 |
   return candidates[0];
 }
 
-function updateEnergy(packet: EnergyPacket, obstacles: Obstacle[], deltaSeconds: number): void {
+function updateEnergy(
+  packet: EnergyPacket,
+  obstacles: Obstacle[],
+  deltaSeconds: number,
+): void {
   if (packet.state === "collected") return;
 
   const distance = Math.hypot(
@@ -526,7 +655,10 @@ async function main(): Promise<void> {
     throw new Error("Surface routing lab DOM is incomplete");
   }
 
-  const engine = new Engine(canvas, true, { adaptToDeviceRatio: true, antialias: true });
+  const engine = new Engine(canvas, true, {
+    adaptToDeviceRatio: true,
+    antialias: true,
+  });
   const scene = new Scene(engine);
   scene.clearColor.set(0.02, 0.012, 0.034, 1);
   const camera = new ArcRotateCamera(
@@ -541,7 +673,11 @@ async function main(): Promise<void> {
   camera.lowerRadiusLimit = 70;
   camera.upperRadiusLimit = 190;
 
-  const light = new HemisphericLight("routing-light", new Vector3(0.2, 1, 0.1), scene);
+  const light = new HemisphericLight(
+    "routing-light",
+    new Vector3(0.2, 1, 0.1),
+    scene,
+  );
   light.intensity = 0.82;
 
   createArena(scene);
@@ -568,11 +704,14 @@ async function main(): Promise<void> {
   };
 
   resetButton.addEventListener("click", reset);
-  energyButton.addEventListener("click", () => spawnEnergy(scene, energyPackets, energyMaterial));
+  energyButton.addEventListener("click", () =>
+    spawnEnergy(scene, energyPackets, energyMaterial),
+  );
   gateButton.addEventListener("click", () => openBroadGate(obstacles));
   window.addEventListener("keydown", (event) => {
     if (event.key.toLowerCase() === "r") reset();
-    if (event.key.toLowerCase() === "e") spawnEnergy(scene, energyPackets, energyMaterial);
+    if (event.key.toLowerCase() === "e")
+      spawnEnergy(scene, energyPackets, energyMaterial);
     if (event.key.toLowerCase() === "g") openBroadGate(obstacles);
   });
 
@@ -587,7 +726,9 @@ async function main(): Promise<void> {
 
     const gate = obstacles.find((obstacle) => obstacle.id === "broad-gate");
     const pooled = energyPackets.filter((packet) => packet.state === "pooling");
-    const collected = energyPackets.filter((packet) => packet.state === "collected");
+    const collected = energyPackets.filter(
+      (packet) => packet.state === "collected",
+    );
     metrics.textContent = [
       "Shared surface topology proof of concept",
       `R1 navigator: ${raiders[0].state} | collisions ${raiders[0].collisions} | path ${raiders[0].distanceTravelled.toFixed(1)}`,

--- a/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
+++ b/experiments/hybrid-engine/src/surfaceRoutingPrototype.ts
@@ -3,7 +3,7 @@ import {
   Color3,
   Engine,
   HemisphericLight,
-  Mesh,
+  type Mesh,
   MeshBuilder,
   RegisterStandardEngineExtensions,
   Scene,
@@ -552,9 +552,15 @@ async function main(): Promise<void> {
   spawnEnergy(scene, energyPackets, energyMaterial);
 
   const reset = () => {
-    obstacles.forEach((obstacle) => obstacle.mesh.dispose());
-    raiders.forEach((raider) => raider.mesh.dispose());
-    energyPackets.forEach((packet) => packet.mesh.dispose());
+    obstacles.forEach((obstacle) => {
+      obstacle.mesh.dispose();
+    });
+    raiders.forEach((raider) => {
+      raider.mesh.dispose();
+    });
+    energyPackets.forEach((packet) => {
+      packet.mesh.dispose();
+    });
     obstacles = createFortress(scene);
     raiders = spawnRaiders(scene);
     energyPackets = [];
@@ -572,8 +578,12 @@ async function main(): Promise<void> {
 
   engine.runRenderLoop(() => {
     const deltaSeconds = Math.min(MAX_DT, engine.getDeltaTime() / 1000);
-    raiders.forEach((raider) => updateRaider(raider, obstacles, deltaSeconds));
-    energyPackets.forEach((packet) => updateEnergy(packet, obstacles, deltaSeconds));
+    raiders.forEach((raider) => {
+      updateRaider(raider, obstacles, deltaSeconds);
+    });
+    energyPackets.forEach((packet) => {
+      updateEnergy(packet, obstacles, deltaSeconds);
+    });
 
     const gate = obstacles.find((obstacle) => obstacle.id === "broad-gate");
     const pooled = energyPackets.filter((packet) => packet.state === "pooling");

--- a/experiments/hybrid-engine/src/towerTerrainPrototype.ts
+++ b/experiments/hybrid-engine/src/towerTerrainPrototype.ts
@@ -26,7 +26,15 @@ import {
 // what this prototype uses explicitly, or the failure only appears in a browser.
 RegisterStandardEngineExtensions();
 
-type TowerPhase = "foundation" | "base" | "drilling" | "assembly" | "calibrating" | "ready" | "dry" | "renovating";
+type TowerPhase =
+  | "foundation"
+  | "base"
+  | "drilling"
+  | "assembly"
+  | "calibrating"
+  | "ready"
+  | "dry"
+  | "renovating";
 
 interface MagmaSource {
   id: string;
@@ -119,11 +127,24 @@ async function main(): Promise<void> {
   const miss3Button = document.querySelector<HTMLButtonElement>("#miss3");
   const dropButton = document.querySelector<HTMLButtonElement>("#drop");
   const bulgeButton = document.querySelector<HTMLButtonElement>("#bulge");
-  if (!canvas || !metrics || !resetButton || !maintainButton || !migrateButton || !miss2Button || !miss3Button || !dropButton || !bulgeButton) {
+  if (
+    !canvas ||
+    !metrics ||
+    !resetButton ||
+    !maintainButton ||
+    !migrateButton ||
+    !miss2Button ||
+    !miss3Button ||
+    !dropButton ||
+    !bulgeButton
+  ) {
     throw new Error("Tower terrain lab DOM is incomplete");
   }
 
-  const engine = new Engine(canvas, true, { antialias: true, adaptToDeviceRatio: true });
+  const engine = new Engine(canvas, true, {
+    antialias: true,
+    adaptToDeviceRatio: true,
+  });
   const scene = new Scene(engine);
   scene.clearColor.set(0.018, 0.012, 0.027, 1);
 
@@ -141,7 +162,11 @@ async function main(): Promise<void> {
   camera.lowerBetaLimit = 0.45;
   camera.upperBetaLimit = 1.42;
 
-  const light = new HemisphericLight("ambient", new Vector3(0.2, 1, -0.15), scene);
+  const light = new HemisphericLight(
+    "ambient",
+    new Vector3(0.2, 1, -0.15),
+    scene,
+  );
   light.intensity = 0.9;
 
   const groundMaterial = createMaterial(
@@ -193,12 +218,19 @@ async function main(): Promise<void> {
 
   const ground = MeshBuilder.CreateGround(
     "deformable-terrain",
-    { width: TERRAIN_SIZE, height: TERRAIN_SIZE, subdivisions: TERRAIN_SUBDIVISIONS, updatable: true },
+    {
+      width: TERRAIN_SIZE,
+      height: TERRAIN_SIZE,
+      subdivisions: TERRAIN_SUBDIVISIONS,
+      updatable: true,
+    },
     scene,
   );
   ground.material = groundMaterial;
 
-  const positions = Array.from(ground.getVerticesData(VertexBuffer.PositionKind) ?? []);
+  const positions = Array.from(
+    ground.getVerticesData(VertexBuffer.PositionKind) ?? [],
+  );
   const indices = Array.from(ground.getIndices() ?? []);
   const baselineHeights = new Array<number>(positions.length / 3);
   const depressionDepths = new Array<number>(positions.length / 3).fill(0);
@@ -207,7 +239,10 @@ async function main(): Promise<void> {
   for (let index = 0; index < positions.length; index += 3) {
     const x = positions[index];
     const z = positions[index + 2];
-    const y = 0.65 * Math.sin(x * 0.075) + 0.38 * Math.cos(z * 0.095) + 0.22 * Math.sin((x + z) * 0.13);
+    const y =
+      0.65 * Math.sin(x * 0.075) +
+      0.38 * Math.cos(z * 0.095) +
+      0.22 * Math.sin((x + z) * 0.13);
     positions[index + 1] = y;
     baselineHeights[index / 3] = y;
   }
@@ -215,7 +250,10 @@ async function main(): Promise<void> {
   const updateTerrainMesh = () => {
     const normals = new Array<number>(positions.length).fill(0);
     for (let vertex = 0; vertex < baselineHeights.length; vertex += 1) {
-      positions[vertex * 3 + 1] = baselineHeights[vertex] + upliftHeights[vertex] - depressionDepths[vertex];
+      positions[vertex * 3 + 1] =
+        baselineHeights[vertex] +
+        upliftHeights[vertex] -
+        depressionDepths[vertex];
     }
     VertexData.ComputeNormals(positions, indices, normals);
     ground.updateVerticesData(VertexBuffer.PositionKind, positions, true);
@@ -236,10 +274,18 @@ async function main(): Promise<void> {
         nearest = vertex;
       }
     }
-    return baselineHeights[nearest] + upliftHeights[nearest] - depressionDepths[nearest];
+    return (
+      baselineHeights[nearest] +
+      upliftHeights[nearest] -
+      depressionDepths[nearest]
+    );
   };
 
-  const stabilizationAt = (x: number, z: number, towerPositions: Vector3[]): number => {
+  const stabilizationAt = (
+    x: number,
+    z: number,
+    towerPositions: Vector3[],
+  ): number => {
     let value = 0;
     for (const towerPosition of towerPositions) {
       value = Math.max(
@@ -263,7 +309,10 @@ async function main(): Promise<void> {
       const distance = Math.hypot(x - center.x, z - center.z);
       if (distance <= radius) {
         affected.push(vertex);
-        average += baselineHeights[vertex] + upliftHeights[vertex] - depressionDepths[vertex];
+        average +=
+          baselineHeights[vertex] +
+          upliftHeights[vertex] -
+          depressionDepths[vertex];
       }
     }
     if (affected.length === 0) return;
@@ -273,7 +322,10 @@ async function main(): Promise<void> {
       const z = positions[vertex * 3 + 2];
       const distance = Math.hypot(x - center.x, z - center.z);
       const influence = smoothstep(1 - distance / radius) * 0.48;
-      const current = baselineHeights[vertex] + upliftHeights[vertex] - depressionDepths[vertex];
+      const current =
+        baselineHeights[vertex] +
+        upliftHeights[vertex] -
+        depressionDepths[vertex];
       baselineHeights[vertex] += (average - current) * influence;
     }
     updateTerrainMesh();
@@ -315,7 +367,12 @@ async function main(): Promise<void> {
     updateTerrainMesh();
   };
 
-  const applyBulge = (x: number, z: number, radius: number, height: number): void => {
+  const applyBulge = (
+    x: number,
+    z: number,
+    radius: number,
+    height: number,
+  ): void => {
     for (let vertex = 0; vertex < upliftHeights.length; vertex += 1) {
       const dx = positions[vertex * 3] - x;
       const dz = positions[vertex * 3 + 2] - z;
@@ -327,10 +384,18 @@ async function main(): Promise<void> {
     updateTerrainMesh();
   };
 
-  const silo = MeshBuilder.CreateBox("silo", { width: 20, depth: 20, height: 3 }, scene);
+  const silo = MeshBuilder.CreateBox(
+    "silo",
+    { width: 20, depth: 20, height: 3 },
+    scene,
+  );
   silo.position.set(0, sampleHeight(0, 0) + 1.5, 0);
   silo.material = towerMaterial;
-  const siloCore = MeshBuilder.CreateBox("silo-core", { width: 13, depth: 13, height: 1 }, scene);
+  const siloCore = MeshBuilder.CreateBox(
+    "silo-core",
+    { width: 13, depth: 13, height: 1 },
+    scene,
+  );
   siloCore.position.set(0, silo.position.y + 2, 0);
   siloCore.material = tealMaterial;
 
@@ -340,13 +405,21 @@ async function main(): Promise<void> {
     { id: "east", position: new Vector3(55, -7, -28) },
   ];
   const sources: MagmaSource[] = sourceData.map(({ id, position }) => {
-    const mesh = MeshBuilder.CreateSphere(`magma-${id}`, { diameter: 5.5, segments: 7 }, scene);
+    const mesh = MeshBuilder.CreateSphere(
+      `magma-${id}`,
+      { diameter: 5.5, segments: 7 },
+      scene,
+    );
     mesh.position.copyFrom(position);
     mesh.material = tealMaterial;
     return { id, position: mesh.position, mesh };
   });
 
-  const target = MeshBuilder.CreateSphere("moving-raider-target", { diameter: 7, segments: 6 }, scene);
+  const target = MeshBuilder.CreateSphere(
+    "moving-raider-target",
+    { diameter: 7, segments: 6 },
+    scene,
+  );
   target.material = targetMaterial;
 
   const towers: TowerModel[] = [];
@@ -362,7 +435,11 @@ async function main(): Promise<void> {
     const groundY = sampleHeight(x, z);
     root.position.set(x, groundY, z);
 
-    const base = MeshBuilder.CreateBox(`tower-${level}-base`, { width: 10, depth: 10, height: 3 }, scene);
+    const base = MeshBuilder.CreateBox(
+      `tower-${level}-base`,
+      { width: 10, depth: 10, height: 3 },
+      scene,
+    );
     base.parent = root;
     base.position.y = 1.5;
     base.material = towerMaterial;
@@ -374,7 +451,11 @@ async function main(): Promise<void> {
     if (level > 1) {
       pillar = MeshBuilder.CreateBox(
         `tower-${level}-pillar`,
-        { width: level === 2 ? 1.5 : 2.2, depth: level === 2 ? 1.5 : 2.2, height: level === 2 ? 6 : 9 },
+        {
+          width: level === 2 ? 1.5 : 2.2,
+          depth: level === 2 ? 1.5 : 2.2,
+          height: level === 2 ? 6 : 9,
+        },
         scene,
       );
       pillar.parent = root;
@@ -392,7 +473,11 @@ async function main(): Promise<void> {
       turret.material = dryMaterial;
       turret.scaling.set(0.04, 0.04, 0.04);
 
-      drill = MeshBuilder.CreateCylinder(`tower-${level}-drill`, { height: 12, diameter: 0.45, tessellation: 7 }, scene);
+      drill = MeshBuilder.CreateCylinder(
+        `tower-${level}-drill`,
+        { height: 12, diameter: 0.45, tessellation: 7 },
+        scene,
+      );
       drill.parent = root;
       drill.position.y = -6;
       drill.material = dryMaterial;
@@ -431,7 +516,11 @@ async function main(): Promise<void> {
     midpoint.y -= 4.5;
     tower.conduit = MeshBuilder.CreateTube(
       `tower-${tower.level}-conduit`,
-      { path: [start, midpoint, end], radius: tower.level === 3 ? 0.42 : 0.3, tessellation: 7 },
+      {
+        path: [start, midpoint, end],
+        radius: tower.level === 3 ? 0.42 : 0.3,
+        tessellation: 7,
+      },
       scene,
     );
     tower.conduit.material = tealMaterial;
@@ -476,14 +565,21 @@ async function main(): Promise<void> {
   };
   buildAll();
 
-  const deploymentCompleteAt = (level: number): number => (level === 1 ? 1.8 : level === 2 ? 4.1 : 5.4);
+  const deploymentCompleteAt = (level: number): number =>
+    level === 1 ? 1.8 : level === 2 ? 4.1 : 5.4;
 
   const updateTowerDeployment = (tower: TowerModel, dt: number): void => {
     tower.elapsed += dt;
     const baseStart = 0.25;
     const baseEnd = tower.level === 1 ? 1.55 : 1.5;
-    const baseT = smoothstep((tower.elapsed - baseStart) / (baseEnd - baseStart));
-    tower.base.scaling.set(0.05 + baseT * 0.95, 0.05 + baseT * 0.95, 0.05 + baseT * 0.95);
+    const baseT = smoothstep(
+      (tower.elapsed - baseStart) / (baseEnd - baseStart),
+    );
+    tower.base.scaling.set(
+      0.05 + baseT * 0.95,
+      0.05 + baseT * 0.95,
+      0.05 + baseT * 0.95,
+    );
 
     if (tower.level === 1) {
       tower.phase = tower.elapsed < baseEnd ? "base" : "ready";
@@ -492,47 +588,73 @@ async function main(): Promise<void> {
 
     const drillStart = 1.0;
     const drillEnd = tower.level === 2 ? 2.35 : 2.8;
-    const drillT = smoothstep((tower.elapsed - drillStart) / (drillEnd - drillStart));
+    const drillT = smoothstep(
+      (tower.elapsed - drillStart) / (drillEnd - drillStart),
+    );
     if (tower.drill) tower.drill.scaling.y = Math.max(0.01, drillT);
 
     const pillarStart = tower.level === 2 ? 1.65 : 2.0;
     const pillarEnd = tower.level === 2 ? 2.9 : 3.65;
-    const pillarT = smoothstep((tower.elapsed - pillarStart) / (pillarEnd - pillarStart));
+    const pillarT = smoothstep(
+      (tower.elapsed - pillarStart) / (pillarEnd - pillarStart),
+    );
     if (tower.pillar) tower.pillar.scaling.y = Math.max(0.01, pillarT);
 
     const turretStart = tower.level === 2 ? 2.45 : 3.15;
     const turretEnd = tower.level === 2 ? 3.55 : 4.65;
-    const turretT = smoothstep((tower.elapsed - turretStart) / (turretEnd - turretStart));
-    if (tower.turret) tower.turret.scaling.set(Math.max(0.04, turretT), Math.max(0.04, turretT), Math.max(0.04, turretT));
+    const turretT = smoothstep(
+      (tower.elapsed - turretStart) / (turretEnd - turretStart),
+    );
+    if (tower.turret)
+      tower.turret.scaling.set(
+        Math.max(0.04, turretT),
+        Math.max(0.04, turretT),
+        Math.max(0.04, turretT),
+      );
 
     if (tower.elapsed < drillStart) tower.phase = "base";
     else if (tower.elapsed < pillarStart) tower.phase = "drilling";
     else if (tower.elapsed < turretEnd) tower.phase = "assembly";
-    else if (tower.elapsed < deploymentCompleteAt(tower.level)) tower.phase = "calibrating";
+    else if (tower.elapsed < deploymentCompleteAt(tower.level))
+      tower.phase = "calibrating";
     else if (tower.powered) tower.phase = "ready";
     else tower.phase = "dry";
 
-    if (!tower.searchAttempted && tower.elapsed >= drillEnd) searchForMagma(tower);
+    if (!tower.searchAttempted && tower.elapsed >= drillEnd)
+      searchForMagma(tower);
   };
 
   const updateTurret = (tower: TowerModel, dt: number): void => {
-    if (!tower.turret || tower.elapsed < (tower.level === 2 ? 3.55 : 4.65)) return;
+    if (!tower.turret || tower.elapsed < (tower.level === 2 ? 3.55 : 4.65))
+      return;
     const dx = target.position.x - tower.root.position.x;
     const dz = target.position.z - tower.root.position.z;
     const desiredYaw = Math.atan2(dx, dz);
     const error = normalizeAngle(desiredYaw - tower.turret.rotation.y);
     const maxSpeed = tower.level === 2 ? 2.45 : 1.15;
     const acceleration = tower.level === 2 ? 6.8 : 2.2;
-    const brakingDistance = (tower.angularVelocity * tower.angularVelocity) / (2 * Math.max(0.001, acceleration));
+    const brakingDistance =
+      (tower.angularVelocity * tower.angularVelocity) /
+      (2 * Math.max(0.001, acceleration));
     const desiredSign = Math.sign(error);
     const shouldBrake = Math.abs(error) <= brakingDistance + 0.025;
     const desiredVelocity = shouldBrake ? 0 : desiredSign * maxSpeed;
     const velocityDelta = desiredVelocity - tower.angularVelocity;
     const maxVelocityChange = acceleration * dt;
-    tower.angularVelocity += Math.max(-maxVelocityChange, Math.min(maxVelocityChange, velocityDelta));
-    tower.turret.rotation.y = normalizeAngle(tower.turret.rotation.y + tower.angularVelocity * dt);
-    tower.aimError = Math.abs(normalizeAngle(desiredYaw - tower.turret.rotation.y));
-    tower.readyToFire = tower.powered && tower.phase === "ready" && tower.aimError < (tower.level === 2 ? 0.09 : 0.055);
+    tower.angularVelocity += Math.max(
+      -maxVelocityChange,
+      Math.min(maxVelocityChange, velocityDelta),
+    );
+    tower.turret.rotation.y = normalizeAngle(
+      tower.turret.rotation.y + tower.angularVelocity * dt,
+    );
+    tower.aimError = Math.abs(
+      normalizeAngle(desiredYaw - tower.turret.rotation.y),
+    );
+    tower.readyToFire =
+      tower.powered &&
+      tower.phase === "ready" &&
+      tower.aimError < (tower.level === 2 ? 0.09 : 0.055);
   };
 
   const spawnMiss = (tower: TowerModel): void => {
@@ -542,11 +664,17 @@ async function main(): Promise<void> {
       { diameter: tower.level === 2 ? 1.0 : 1.55, segments: 5 },
       scene,
     );
-    projectile.position.copyFrom(tower.root.position.add(tower.turret.position));
+    projectile.position.copyFrom(
+      tower.root.position.add(tower.turret.position),
+    );
     projectile.material = projectileMaterial;
     const yaw = tower.turret.rotation.y + (tower.level === 2 ? 0.24 : -0.18);
     const speed = tower.level === 2 ? 34 : 42;
-    const velocity = new Vector3(Math.sin(yaw) * speed, -6.5, Math.cos(yaw) * speed);
+    const velocity = new Vector3(
+      Math.sin(yaw) * speed,
+      -6.5,
+      Math.cos(yaw) * speed,
+    );
     projectiles.push({
       mesh: projectile,
       velocity,
@@ -560,7 +688,10 @@ async function main(): Promise<void> {
       const projectile = projectiles[index];
       projectile.velocity.y -= 12 * dt;
       projectile.mesh.position.addInPlace(projectile.velocity.scale(dt));
-      const groundY = sampleHeight(projectile.mesh.position.x, projectile.mesh.position.z);
+      const groundY = sampleHeight(
+        projectile.mesh.position.x,
+        projectile.mesh.position.z,
+      );
       if (projectile.mesh.position.y <= groundY + projectile.bodyRadius * 0.2) {
         applyImpact(
           projectile.mesh.position.x,
@@ -571,7 +702,10 @@ async function main(): Promise<void> {
         );
         projectile.mesh.dispose();
         projectiles.splice(index, 1);
-      } else if (Math.abs(projectile.mesh.position.x) > 75 || Math.abs(projectile.mesh.position.z) > 75) {
+      } else if (
+        Math.abs(projectile.mesh.position.x) > 75 ||
+        Math.abs(projectile.mesh.position.z) > 75
+      ) {
         projectile.mesh.dispose();
         projectiles.splice(index, 1);
       }
@@ -620,7 +754,9 @@ async function main(): Promise<void> {
     const tower = towers.find((candidate) => candidate.level === 3);
     if (tower) spawnMiss(tower);
   });
-  dropButton.addEventListener("click", () => applyImpact(-11, 24, 48_600, 8.5, 7));
+  dropButton.addEventListener("click", () =>
+    applyImpact(-11, 24, 48_600, 8.5, 7),
+  );
   bulgeButton.addEventListener("click", () => applyBulge(18, 20, 14, 2.2));
 
   window.addEventListener("keydown", (event) => {
@@ -657,8 +793,15 @@ async function main(): Promise<void> {
     updateProjectiles(dt);
 
     const towerLines = towers.map((tower) => {
-      const power = tower.level === 1 ? "passive" : tower.powered ? `source:${tower.connectedSourceId}` : "DRY";
-      const slew = tower.turret ? ` err:${(tower.aimError * 180 / Math.PI).toFixed(1)}° ω:${tower.angularVelocity.toFixed(2)}` : "";
+      const power =
+        tower.level === 1
+          ? "passive"
+          : tower.powered
+            ? `source:${tower.connectedSourceId}`
+            : "DRY";
+      const slew = tower.turret
+        ? ` err:${((tower.aimError * 180) / Math.PI).toFixed(1)}° ω:${tower.angularVelocity.toFixed(2)}`
+        : "";
       return `T${tower.level} ${tower.phase.padEnd(11)} ${power.padEnd(13)}${slew}${tower.readyToFire ? " READY" : ""}`;
     });
     metrics.textContent = [

--- a/experiments/hybrid-engine/src/towerTerrainPrototype.ts
+++ b/experiments/hybrid-engine/src/towerTerrainPrototype.ts
@@ -3,7 +3,7 @@ import {
   Color3,
   Engine,
   HemisphericLight,
-  Mesh,
+  type Mesh,
   MeshBuilder,
   RegisterStandardEngineExtensions,
   Scene,
@@ -17,8 +17,8 @@ import {
   accumulateDepression,
   radialDeformationDepth,
   structuralStabilization,
-  terrainImpactProfile,
   type TerrainDeformationCalibration,
+  terrainImpactProfile,
 } from "../../../src/js/gameplay/terrainDeformation";
 
 // "@babylonjs/core/pure" is the side-effect-free barrel: it exports classes but
@@ -467,7 +467,9 @@ async function main(): Promise<void> {
 
   const buildAll = (): void => {
     for (const tower of towers.splice(0)) disposeTower(tower);
-    towerPositions.forEach((position) => stabilizeFoundation(position));
+    towerPositions.forEach((position) => {
+      stabilizeFoundation(position);
+    });
     createTower(1, towerPositions[0].x, towerPositions[0].z);
     createTower(2, towerPositions[1].x, towerPositions[1].z);
     createTower(3, towerPositions[2].x, towerPositions[2].z);


### PR DESCRIPTION
## Scope

Linked issue: closes #174

Ownership boundary: `experiments/hybrid-engine/biome.json`, `mothership.html`, and the lab's `src/*.ts`. No dependency, build-config, or gameplay changes.

**Stacked on #179** (which is stacked on #178), because #179 edits the import blocks in the same six source files and `organizeImports` here would conflict head-on otherwise. The diff against that parent is only this PR's three commits.

Three commits, deliberately separable:

| Commit | What |
| --- | --- |
| `5703b81` | `biome.json` — stop checking Rust build artifacts, drop a deprecated field |
| `09f7714` | the 12 real lint/assist errors |
| `607ecb0` | the formatting sweep, mechanical |

## Change

### 1. `pnpm check` was not reproducible

| State | Files checked | Result |
| --- | --- | --- |
| clean checkout | 13 | 20 errors |
| after any Rust build | 288 | 289 errors |

The extra 269 were `rust/target/**/*.json` fingerprints. Since `pnpm build` runs `pnpm wasm` first, the gate effectively never saw the clean-tree answer.

`biome.json` excluded `pkg`, `dist` and `node_modules` by hand but not `rust/target`. Rather than adding a fourth entry to a list that has already drifted once, this enables `vcs.useIgnoreFile`: the package's `.gitignore` already lists all four, so there is now one source of truth instead of two that must be kept in sync. Verified with `rust/target` present on disk: 19 files checked, result identical to the clean tree.

Also migrates `linter.rules.recommended` to the `preset` field it was deprecated in favour of, after confirming the enabled rule set is unchanged.

### 2. The 12 real errors

**`useIterableCallbackReturn` (8).** Every site is `array.forEach((x) => sideEffect(x))`, where the concise arrow body implicitly returns the callee's value into a `forEach` that discards it. As the issue asked, each was inspected rather than blanket-autofixed — all eight callees return `void` (`Mesh.dispose`, `updateRaider`, `updateEnergy`, `stabilizeFoundation`), so none was a `forEach` that should have been a `map`. Block bodies, behaviour-preserving.

**`useAriaPropsSupportedByRole` (1).** `<div id="controls">` carried an `aria-label` with no role to support it. `role="toolbar"` is the accurate role for a row of control buttons and does support a label, so the author's intent is kept rather than dropping the label. `role="group"` was tried first and traded the error for `useSemanticElements`, which wants `<fieldset>` — the wrong element for a toolbar containing no form controls.

**`organizeImports` (3)** and **`useImportType` (3 warnings)** applied via biome's safe autofixes; three `Mesh` imports are used only as types.

**Deliberately not applied:** `useOptionalChain` at `geothermalPrototype.ts:703`. Biome marks that fix unsafe, and rewriting `!source || source.phase !== "active"` as an optional chain is a readability judgement on a guard clause, not a defect. It is a warning, does not fail the gate, and is left for whoever owns that prototype.

### 3. The formatting sweep

`biome check` includes formatting and 8 of 13 files had never been run through it, so the gate could not pass on formatting alone. This is the large commit — 825 insertions — and it is entirely mechanical.

I considered raising `formatter.lineWidth` to shrink the diff and rejected it: the sources are not written to any consistent width (p50 28, p90 70, p99 106, **max 272** columns), so there is no author intent to preserve, and `biome.json` already accepted every formatter default except `indentStyle`.

## Gameplay impact

- [x] No intended gameplay/balance change

No #29 invariant is touched. The eight `forEach` conversions were each verified against a `void`-returning callee, and all six lab pages were re-run in a browser afterwards.

## Validation

macOS 26.5.2 aarch64, Node 24.20.0, biome 2.5.11, Chromium 151.0.7922.34.

- `biome check .` → **exit 0**, 0 errors (was 20), 1 intentional warning;
- result is now identical with and without `rust/target` on disk;
- `tsc --noEmit` → clean;
- `vitest run` → 5 passed;
- `pnpm build` → green;
- six-page headless smoke, zero console errors and a progressing render loop on every page, `index.html` at 31.8 fps — run after the lint commit **and** again after the formatting commit.

Not validated online / requires local Codex:

- [x] build/install — done locally
- [x] browser interaction — done locally, all six pages
- [ ] physics behavior
- [ ] performance/profile
- [ ] touch/input
- [ ] audio
- [ ] PWA/offline

## Concurrency

Known overlapping PRs/issues: #178 and #179 (this stack), #163 (its `pnpm check` gate fails until this lands).

Integration notes for other executors:

- **Conflict exposure is low but time-sensitive.** I checked every open PR: only #179, this PR's own parent, touches `experiments/hybrid-engine/src/`. The formatting commit will conflict with anything new that lands in those files, so landing it sooner is cheaper than later. It is isolated in its own commit if it needs to be dropped or re-run.
- No lockfile is committed. Verification used a package-local `pnpm install`; the generated lockfile was left untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
