### PR TITLE
Target Dependabot at the modern pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /experiments
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 8
+    versioning-strategy: increase
+    groups:
+      babylon:
+        applies-to: version-updates
+        patterns:
+          - "@babylonjs/*"
+      storybook:
+        applies-to: version-updates
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      vite-vitest-browser-tooling:
+        applies-to: version-updates
+        patterns:
+          - "vite"
+          - "vitest"
+          - "@vitest/*"
+          - "playwright"
+        update-types:
+          - patch
+          - minor
+      type-and-lint-tooling:
+        applies-to: version-updates
+        patterns:
+          - "typescript"
+          - "@types/*"
+          - "@biomejs/biome"
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
## Summary
Add Dependabot configuration to manage updates for the modern pnpm workspace in `/experiments`.

## Configuration
- **Directory**: `/experiments` (workspace root with shared lockfile)
- **Schedule**: Weekly
- **Limit**: 8 open PRs
- **Versioning**: Increase strategy (uses current version constraint)

## Update Groups
Organized by domain for clearer PRs and review:

| Group | Packages | Update Policy |
|---|---|---|
| babylon | `@babylonjs/*` | All versions |
| storybook | `storybook`, `@storybook/*` | All versions |
| vite-vitest-browser-tooling | `vite`, `vitest`, `@vitest/*`, `playwright` | Patch + minor only |
| type-and-lint-tooling | `typescript`, `@types/*`, `@biomejs/biome` | Patch + minor only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)